### PR TITLE
[FEAT] 디자인 변수 설정 및 버튼, 인풋 라벨 컴포넌트에 적용  #14

### DIFF
--- a/app/styles/_variables.css
+++ b/app/styles/_variables.css
@@ -1,1 +1,33 @@
 /* 색상, 폰트, spacing 등 커스텀 변수 */
+@theme {
+  --color-primary: #1f72ef;
+  --color-primary-hover: #1f72ef08;
+  --color-primary-border: #1f72ef12;
+
+  /* Semantic */
+  --color-semantic-stroke: #000000;
+
+  /* Text */
+  --color-text-primary: #000000;
+  --color-text-secondary: #838383;
+  --color-text-tertiary: #787878;
+
+  /* Liner */
+  --color-liner-slider: #e5e5e8;
+  --color-liner-divider: #505050;
+  --color-liner-segment: #6fef1f;
+  --color-liner-button: #e5e5e8;
+
+  /* Button */
+  --color-button-disabled: #d1d5db;
+  --color-button-close: #ff0004;
+
+  /* Background */
+  --color-background-base: #ffffff;
+  --color-background-sub: #f5f8ff;
+  --color-background-draft: #00000040;
+
+  /* Neutral */
+  --color-neutral-border: #eaeaea;
+  --color-neutral-liner: #444444;
+}

--- a/components/atom/button/Button.style.ts
+++ b/components/atom/button/Button.style.ts
@@ -6,9 +6,9 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         solid:
-          'bg-white text-black border-[#EAEAEA] active:border-[#1F72EF] disabled:active:border-[#EAEAEA] h-8 py-2',
+          'bg-white text-text-primary border-neutral-border hover:bg-neutral-border active:border-primary disabled:active:text-button-disabled h-8 py-2',
         ghost:
-          'bg-transparent border-transparent text-[#1F72EF] px-2 hover:bg-[#1F72EF]/8 disabled:text-[#D1D5DB] disabled:bg-transparent',
+          'bg-transparent border-transparent text-primary px-2 hover:bg-primary-hover disabled:text-button-disabled disabled:bg-transparent',
       },
       size: {
         sm: 'w-[57px]',

--- a/components/atom/input/Input.style.ts
+++ b/components/atom/input/Input.style.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const inputVariants = cva(
-  'min-h-8 px-3 text-[13px] leading-4 text-center rounded-lg border border-transparent placeholder:text-[#838383] bg-[#EAEAEA] focus:outline-none focus:border-[#1F72EF] transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+  'min-h-8 px-3 text-[13px] leading-4 text-center rounded-lg border border-transparent placeholder:text-text-secondary bg-neutral-border focus:outline-none focus:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
   {
     variants: {
       size: {

--- a/components/atom/label/Label.tsx
+++ b/components/atom/label/Label.tsx
@@ -8,7 +8,7 @@ export const Label = ({ children, className, ...props }: LabelProps) => {
   return (
     <label
       className={cn(
-        'min-h-8 py-2 px-1 text-sm leading-4 text-black',
+        'min-h-8 py-2 px-1 text-sm leading-4 text-text-primary',
         className
       )}
       {...props}


### PR DESCRIPTION
## 작업 개요
- 피그마 디자인 변수 설정
- 구현된 공통 컴포넌트에 적용

## 작업 내용

- [x] _variables.css 색상 변수 추가
- [x] 버튼 인풋 라벨 적용 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 디자인 색상 정의 시스템 도입
  * 버튼 컴포넌트의 색상 스타일 업데이트 (기본, 고스트 변형)
  * 입력창 컴포넌트의 색상 및 포커스 상태 스타일 개선
  * 레이블 컴포넌트의 텍스트 색상 표준화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->