### PR TITLE
[fix] 게스트 페이지 404 에러 픽스

### DIFF
--- a/app/api/drive/_lib/ensureDataJsonFile.ts
+++ b/app/api/drive/_lib/ensureDataJsonFile.ts
@@ -1,4 +1,4 @@
-import 'server-only';
+﻿import 'server-only';
 
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
@@ -18,29 +18,31 @@ export type EnsureDataJsonFileResult = {
 };
 
 const APP_IDENTIFIER = 'Bread-Barbershop';
-
 const DATA_JSON_NAME = 'data.json';
 const DATA_JSON_KIND = 'invitation_data_json';
 
-/**
- * invitationFolderId 하위에 data.json 파일을 보장한다.
- * - 있으면 재사용
- * - 없으면 생성
- *
- * 주의:
- * - Drive는 같은 이름 파일이 여러 개 있을 수 있어 appProperties.kind로 식별한다.
- * - 그래도 혹시 중복이 생기면 createdTime 오래된 것을 정본으로 취급한다(폴더 정책과 동일).
- */
+const DEFAULT_DATA_JSON_PAYLOAD = {
+  blocks: [],
+  bgm: {
+    selectedBgmId: null,
+    isLoop: false,
+    volume: 0.2,
+    userBgmTitle: null,
+    userBgmDuration: null,
+    userBgmFileId: null,
+  },
+};
+
+// "invitation 폴더 내에 단일 data.json 초대 파일이 존재하는지 확인합니다. 파일이 없는 경우, 파일을 생성하고 유효한 기본 페이로드(payload)로 초기화합니다."
 export async function ensureDataJsonFile(
   invitationFolderId: string
 ): Promise<EnsureDataJsonFileResult> {
   if (!invitationFolderId) {
-    throw new DriveHttpError('invitationFolderId가 필요합니다.', 400, {
+    throw new DriveHttpError('invitationFolderId is required', 400, {
       invitationFolderId,
     });
   }
 
-  // 1) appProperties.kind 기반으로 검색 (이름은 보조 조건)
   const q = [
     `'${escapeDriveQueryValue(invitationFolderId)}' in parents`,
     `trashed=false`,
@@ -55,7 +57,7 @@ export async function ensureDataJsonFile(
     q,
     spaces: 'drive',
     fields: 'files(id,name,createdTime,appProperties)',
-    orderBy: 'createdTime', // 가장 오래된 것을 정본으로 정함(중복 방어)
+    orderBy: 'createdTime',
     pageSize: '10',
   });
 
@@ -70,7 +72,7 @@ export async function ensureDataJsonFile(
 
   if (!searchRes.ok) {
     throw new DriveHttpError(
-      'data.json 검색 실패',
+      'data.json search failed',
       searchRes.status,
       searchData
     );
@@ -81,7 +83,6 @@ export async function ensureDataJsonFile(
     return { dataJsonFileId: found[0].id, reused: true };
   }
 
-  // 2) 없으면 생성 (빈 JSON으로 시작)
   const createRes = await googleFetch(
     'https://www.googleapis.com/drive/v3/files',
     {
@@ -105,7 +106,31 @@ export async function ensureDataJsonFile(
   };
 
   if (!createRes.ok || !created.id) {
-    throw new DriveHttpError('data.json 생성 실패', createRes.status, created);
+    throw new DriveHttpError(
+      'data.json create failed',
+      createRes.status,
+      created
+    );
+  }
+
+  const initRes = await googleFetch(
+    `https://www.googleapis.com/upload/drive/v3/files/${encodeURIComponent(
+      created.id
+    )}?uploadType=media&supportsAllDrives=true`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+      body: JSON.stringify(DEFAULT_DATA_JSON_PAYLOAD),
+    }
+  );
+
+  if (!initRes.ok) {
+    const initDetails = await initRes.json().catch(() => undefined);
+    throw new DriveHttpError(
+      'data.json default payload init failed',
+      initRes.status,
+      initDetails
+    );
   }
 
   return { dataJsonFileId: created.id, reused: false };

--- a/app/api/drive/publishInvitation/route.ts
+++ b/app/api/drive/publishInvitation/route.ts
@@ -1,18 +1,189 @@
-import 'server-only';
+﻿import 'server-only';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 
 import { ensureDataJsonFile } from '@/app/api/drive/_lib/ensureDataJsonFile';
 import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
 
+// publish API 요청 본문
 type Body = { invitationFolderId: string };
+
+// 단일 probe 실패 사유
+type ProbeFailureReason =
+  | 'http_not_ok'
+  | 'json_parse_failed'
+  | 'invalid_schema';
+
+// 단일 probe 결과
+type ProbeResult =
+  | { ok: true; status: number }
+  | {
+      ok: false;
+      status: number;
+      reason: ProbeFailureReason;
+      error?: string;
+      rawPreview?: string;
+    };
+
+// 재시도 전체 결과
+type ReadinessResult =
+  | { ok: true; attempt: number }
+  | { ok: false; attempts: number; lastProbe: ProbeResult | null };
+
+const VERIFY_MAX_ATTEMPTS = 3;
+const VERIFY_DELAY_MS = 350;
 
 const permissionCreateUrl = (folderId: string) =>
   `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
     folderId
   )}/permissions?supportsAllDrives=true&sendNotificationEmail=false&fields=id`;
 
+const guestPath = (dataJsonFileId: string) => `/guest/${dataJsonFileId}`;
+
+const guestDataUrl = (dataJsonFileId: string) =>
+  `https://drive.google.com/uc?export=download&id=${encodeURIComponent(
+    dataJsonFileId
+  )}`;
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+// 게스트 페이지/태그 캐시를 함께 무효화
+function revalidateGuestCaches(dataJsonFileId: string) {
+  // 데이터 태그 캐시와 페이지 캐시에 남아 있을 수 있는
+  // 오래된 정적 출력 결과를 모두 제거한다.
+  revalidateTag(`invitation:${dataJsonFileId}`, 'max');
+  revalidatePath(guestPath(dataJsonFileId));
+}
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+
+function isNullableString(x: unknown): x is string | null {
+  return x === null || typeof x === 'string';
+}
+
+// guest 페이지에서 요구하는 최소 JSON 형태 검사
+function isGuestPayloadShape(x: unknown): boolean {
+  if (!isRecord(x)) return false;
+  if (!Array.isArray(x.blocks)) return false;
+  if (!isRecord(x.bgm)) return false;
+
+  const bgm = x.bgm;
+  return (
+    isNullableString(bgm.selectedBgmId) &&
+    typeof bgm.isLoop === 'boolean' &&
+    typeof bgm.volume === 'number' &&
+    isNullableString(bgm.userBgmTitle) &&
+    isNullableString(bgm.userBgmDuration) &&
+    isNullableString(bgm.userBgmFileId)
+  );
+}
+
+// 공개 data.json URL을 1회 조회하고 파싱/스키마까지 검증
+async function probeGuestData(dataJsonFileId: string): Promise<ProbeResult> {
+  const res = await fetch(guestDataUrl(dataJsonFileId), { cache: 'no-store' });
+
+  if (!res.ok) {
+    return { ok: false, status: res.status, reason: 'http_not_ok' };
+  }
+
+  const raw = await res.text();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      status: res.status,
+      reason: 'json_parse_failed',
+      rawPreview: raw.slice(0, 200),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!isGuestPayloadShape(parsed)) {
+    return { ok: false, status: res.status, reason: 'invalid_schema' };
+  }
+
+  return { ok: true, status: res.status };
+}
+
+// guest 데이터가 준비될 때까지 짧게 재시도
+async function waitUntilGuestReady(
+  dataJsonFileId: string
+): Promise<ReadinessResult> {
+  let lastProbe: ProbeResult | null = null;
+
+  for (let attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt += 1) {
+    const probe = await probeGuestData(dataJsonFileId);
+    if (probe.ok) {
+      return { ok: true, attempt };
+    }
+
+    lastProbe = probe;
+
+    if (attempt < VERIFY_MAX_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  return { ok: false, attempts: VERIFY_MAX_ATTEMPTS, lastProbe };
+}
+
+// "게스트 미준비" 공통 실패 응답
+function notReadyResponse(params: {
+  guestUrl: string;
+  dataJsonFileId: string;
+  verification: ReadinessResult;
+}) {
+  const { guestUrl, dataJsonFileId, verification } = params;
+
+  return NextResponse.json(
+    {
+      ok: false,
+      guestUrl,
+      dataJsonFileId,
+      error: 'guest_not_ready_after_publish',
+      status: 502,
+      details: verification,
+    },
+    { status: 502 }
+  );
+}
+
+// 퍼블리시 성공 후 공통 처리(캐시 무효화 + 준비 확인 + 성공 응답)
+async function buildPublishSuccessResponse(params: {
+  guestUrl: string;
+  dataJsonFileId: string;
+  ignored?: string;
+}) {
+  const { guestUrl, dataJsonFileId, ignored } = params;
+
+  revalidateGuestCaches(dataJsonFileId);
+
+  // 공개된 JSON 엔드포인트가 안정적으로 읽히는 것이 확인된 이후에만
+  // 게스트 URL을 외부에 노출한다.
+  const verification = await waitUntilGuestReady(dataJsonFileId);
+  if (!verification.ok) {
+    return notReadyResponse({ guestUrl, dataJsonFileId, verification });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    guestUrl,
+    dataJsonFileId,
+    ...(ignored ? { ignored } : {}),
+  });
+}
+
 export async function POST(req: Request) {
   const { invitationFolderId } = (await req.json()) as Partial<Body>;
+
   if (!invitationFolderId) {
     return NextResponse.json(
       { ok: false, error: 'invitationFolderId required' },
@@ -21,7 +192,7 @@ export async function POST(req: Request) {
   }
 
   const { dataJsonFileId } = await ensureDataJsonFile(invitationFolderId);
-  const guestUrl = `/guest/${dataJsonFileId}`;
+  const guestUrl = guestPath(dataJsonFileId);
 
   const res = await googleFetch(permissionCreateUrl(invitationFolderId), {
     method: 'POST',
@@ -35,8 +206,9 @@ export async function POST(req: Request) {
   });
 
   if (res.status === 409) {
-    return NextResponse.json({
-      ok: true,
+    // 409는 "이미 공개 상태"를 의미한다.
+    // 캐시 갱신 및 준비 상태 확인을 계속 진행한다.
+    return buildPublishSuccessResponse({
       guestUrl,
       dataJsonFileId,
       ignored: 'already_public',
@@ -58,5 +230,5 @@ export async function POST(req: Request) {
     );
   }
 
-  return NextResponse.json({ ok: true, guestUrl, dataJsonFileId });
+  return buildPublishSuccessResponse({ guestUrl, dataJsonFileId });
 }

--- a/app/guest/[id]/page.tsx
+++ b/app/guest/[id]/page.tsx
@@ -25,13 +25,16 @@ export default async function GuestPage({
 
   if (!res.ok) notFound();
 
+  const raw = await res.text();
   let payload: unknown;
   try {
-    payload = await res.json();
+    payload = JSON.parse(raw);
   } catch {
     notFound();
   }
-  if (!isGuestPayload(payload)) notFound();
+  if (!isGuestPayload(payload)) {
+    notFound();
+  }
 
   return (
     <main className="min-h-screen bg-neutral-50">


### PR DESCRIPTION
## 작업 개요

- 기존 게스트 페이지에서 404에러가 발생해 원인을 찾고 에러를 수정했습니다.
- 게스트 페이지 로딩시 data.json을 구글 드라이브로부터 받아오는데 예상하는 페이로드 형식이 아니거나 새로 업로드 되는 data.json을 아직 읽지 못했을 경우 404로 리다이렉팅되게 끔 만들었는데 이게 정적으로 굳어져서 계속 404를 띄우던 현상이었습니다.
- 따라서 초기 data.json을 만들때 기본 페이로드를 만들도록 했습니다.
- 또한 퍼블리시 버튼을 클릭했을때 백그라운드에서 3차례 data.json이 유효한 data.json인지 확인하는 검사 과정이 추가되었습니다.
- 만약 그럼에도 404가 발생한다면 퍼블리시 버튼을 다시 클릭하면 캐시를 무효화하고 다시 받아올 수 있도록 갱신 로직을 추가했습니다.

## 작업 내용

- [x] data.json 초기 페이로드 작성
- [x] 퍼블리시 버튼 클릭시 캐시 무효화 추가
- [x] 퍼블리시 성공 반환전 백그라운드에서 유효한 data.json인지 3차례 확인하고 성공 반환 로직 추가.

## 관련 이슈

Closes #null

## 테스트 결과 보고

- 제가 테스트 했을때는 문제가 없었으나 또 문제 발견시 연락주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* data.json 파일 자동 생성 및 기본 구조로 초기화 기능 추가
* 게스트 초대 발행 전 데이터 준비 상태 검증 추가
* 게스트 캐시 무효화 및 재검증 로직 강화
* 오류 메시지를 영어로 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->