### PR TITLE
[feat] 퍼미션 재시도 로직 추가

### DIFF
--- a/app/api/drive/_lib/publishPermissionWithRetry.ts
+++ b/app/api/drive/_lib/publishPermissionWithRetry.ts
@@ -1,0 +1,117 @@
+import 'server-only';
+
+import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+
+export type PublishPermissionRetryResult =
+  | { ok: true; attempt: number; ignored?: 'already_public' }
+  | {
+      ok: false;
+      attempt: number;
+      status?: number;
+      details?: unknown;
+      immediateFail?: boolean;
+      error?: string;
+    };
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 300;
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+const IMMEDIATE_FAIL_STATUS = new Set([400, 401, 403, 404]);
+
+const permissionCreateUrl = (folderId: string) =>
+  `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
+    folderId
+  )}/permissions?supportsAllDrives=true&sendNotificationEmail=false&fields=id`;
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+function retryDelayMs(attempt: number, baseDelayMs: number): number {
+  const exponential = baseDelayMs * 2 ** (attempt - 1);
+  const jitter = Math.floor(Math.random() * 120);
+  return exponential + jitter;
+}
+
+/**
+ * 초대장 폴더를 공개(`anyone:reader`) 상태로 게시합니다. (재시도 횟수 제한 있음)
+ *
+ * 동작 방식:
+ * - `409` 응답은 이미 공개 상태이므로 성공으로 간주합니다.
+ * - 일시적인 오류(`429`, `5xx`) 및 요청 중 발생한 예외는 재시도합니다.
+ * - 클라이언트/인증 오류(`400`, `401`, `403`, `404`)는 즉시 실패 처리합니다.
+ *
+ * @param invitationFolderId 대상 Drive 초대장 폴더 ID
+ * @param options 재시도 관련 옵션 (기본값: 최대 3회 시도, 기본 지연 300ms)
+ * @returns 시도 횟수 및 실패 메타데이터를 포함한 결과 객체
+ */
+export async function publishPermissionWithRetry(
+  invitationFolderId: string,
+  options?: { maxAttempts?: number; baseDelayMs?: number }
+): Promise<PublishPermissionRetryResult> {
+  const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let res: Response;
+    try {
+      res = await googleFetch(permissionCreateUrl(invitationFolderId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'anyone',
+          role: 'reader',
+          allowFileDiscovery: false,
+        }),
+        cache: 'no-store',
+      });
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        return {
+          ok: false,
+          attempt,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+
+      await sleep(retryDelayMs(attempt, baseDelayMs));
+      continue;
+    }
+
+    if (res.status === 409) {
+      return { ok: true, attempt, ignored: 'already_public' };
+    }
+
+    if (res.ok) {
+      return { ok: true, attempt };
+    }
+
+    const details = await res.json().catch(() => undefined);
+
+    if (IMMEDIATE_FAIL_STATUS.has(res.status)) {
+      return {
+        ok: false,
+        attempt,
+        status: res.status,
+        details,
+        immediateFail: true,
+      };
+    }
+
+    const retryable = RETRYABLE_STATUS.has(res.status);
+    if (!retryable || attempt === maxAttempts) {
+      return {
+        ok: false,
+        attempt,
+        status: res.status,
+        details,
+      };
+    }
+
+    await sleep(retryDelayMs(attempt, baseDelayMs));
+  }
+
+  return { ok: false, attempt: maxAttempts };
+}

--- a/app/api/drive/publishInvitation/route.ts
+++ b/app/api/drive/publishInvitation/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 
 import { ensureDataJsonFile } from '@/app/api/drive/_lib/ensureDataJsonFile';
-import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+import { publishPermissionWithRetry } from '@/app/api/drive/_lib/publishPermissionWithRetry';
 
 // publish API 요청 본문
 type Body = { invitationFolderId: string };
@@ -32,11 +32,6 @@ type ReadinessResult =
 
 const VERIFY_MAX_ATTEMPTS = 3;
 const VERIFY_DELAY_MS = 350;
-
-const permissionCreateUrl = (folderId: string) =>
-  `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
-    folderId
-  )}/permissions?supportsAllDrives=true&sendNotificationEmail=false&fields=id`;
 
 const guestPath = (dataJsonFileId: string) => `/guest/${dataJsonFileId}`;
 
@@ -194,20 +189,10 @@ export async function POST(req: Request) {
   const { dataJsonFileId } = await ensureDataJsonFile(invitationFolderId);
   const guestUrl = guestPath(dataJsonFileId);
 
-  const res = await googleFetch(permissionCreateUrl(invitationFolderId), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      type: 'anyone',
-      role: 'reader',
-      allowFileDiscovery: false,
-    }),
-    cache: 'no-store',
-  });
+  const permissionResult = await publishPermissionWithRetry(invitationFolderId);
 
-  if (res.status === 409) {
-    // 409는 "이미 공개 상태"를 의미한다.
-    // 캐시 갱신 및 준비 상태 확인을 계속 진행한다.
+  if (permissionResult.ok && permissionResult.ignored === 'already_public') {
+    // 409는 "이미 공개 상태"이므로 발행 성공 흐름을 유지한다.
     return buildPublishSuccessResponse({
       guestUrl,
       dataJsonFileId,
@@ -215,18 +200,25 @@ export async function POST(req: Request) {
     });
   }
 
-  if (!res.ok) {
-    const details = await res.json().catch(() => undefined);
+  if (!permissionResult.ok) {
+    const responseStatus =
+      permissionResult.status && permissionResult.status >= 400
+        ? permissionResult.status
+        : 502;
+
     return NextResponse.json(
       {
         ok: false,
         guestUrl,
         dataJsonFileId,
-        error: 'publish_failed',
-        status: res.status,
-        details,
+        error: 'publish_permission_failed',
+        status: responseStatus,
+        attempts: permissionResult.attempt,
+        immediateFail: Boolean(permissionResult.immediateFail),
+        details: permissionResult.details,
+        ...(permissionResult.error ? { cause: permissionResult.error } : {}),
       },
-      { status: 502 }
+      { status: responseStatus }
     );
   }
 


### PR DESCRIPTION
## 작업 개요

- 초대장 발행 단계에서 구글 드라이브 권한을 변경하는데 기존에는 실패해도 성공으로 간주하게끔 만들었는데
- 이제는 재시도 요청과 에러 반환까지 다시 수정했습니다. 

## 작업 내용

- [x] publishInvitation/route.ts 파일 수정

## 관련 이슈

Closes #null

## 테스트 결과 보고

<!-- 테스트 결과나 내용 텍스트 또는 사진 등 기입 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * Google Drive 폴더 공유 권한 설정 시 자동 재시도 기능 추가 (최대 3회, 지수 백오프 적용)
  * 향상된 오류 처리로 권한 설정 실패 시 더 상세한 진단 정보 제공

* **리팩터**
  * 권한 설정 로직을 별도 모듈로 분리하여 재사용성 및 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->