### PR TITLE
Feat/component/gallery

### DIFF
--- a/__tests__/Image.test.tsx
+++ b/__tests__/Image.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import * as ImageStories from '@/components/atoms/image/Image.stories';
+import { Image } from '@/components/atoms/image/Image';
+
+jest.mock('@/shared/assets/icons/loadingSpinner.svg', () => {
+  return {
+    __esModule: true,
+    default: (props: any) => <svg data-testid="loading-spinner" {...props} />,
+  };
+});
+
+describe('Image 컴포넌트 테스트', () => {
+  it('기본 이미지 렌더링 및 로딩 완료 후 상태 변경 테스트', async () => {
+    const { container } = render(<Image {...ImageStories.Default.args} />);
+
+    // 처음 렌더링 시에는 LoadingSpinner(animate-spin 클래스 포함)가 보여야 함
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+
+    // 넘겨준 alt 속성으로 이미지 엘리먼트 검색
+    const image = screen.getByAltText(ImageStories.Default.args!.alt as string);
+    expect(image).toBeInTheDocument();
+
+    // 이미지 로드 이벤트 발생
+    fireEvent.load(image);
+
+    // 로드가 완료되면 LoadingSpinner 엘리먼트가 사라져야 함
+    await waitFor(() => {
+      expect(container.querySelector('.animate-spin')).not.toBeInTheDocument();
+    });
+  });
+
+  it('이미지 로드 에러 시 스켈레톤 상태 테스트', async () => {
+    const { container } = render(<Image {...ImageStories.Skeleton.args} />);
+
+    // 처음에 로딩 표시
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+
+    const image = screen.getByAltText(
+      ImageStories.Skeleton.args!.alt as string
+    );
+
+    // 이미지 로드 에러 이벤트 발생
+    fireEvent.error(image);
+
+    // 에러 발생 시에도 무한 로딩을 피하기 위해 LoadingSpinner 엘리먼트가 사라져야 함
+    await waitFor(() => {
+      expect(container.querySelector('.animate-spin')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/organisms/gallery/Gallery.tsx
+++ b/components/organisms/gallery/Gallery.tsx
@@ -19,8 +19,9 @@ interface Props {
 }
 
 function Gallery({ blockInfo, id }: Props) {
-  const { updateBlock, updateImage } = useEditorStore(
+  const { block, updateBlock, updateImage } = useEditorStore(
     useShallow(state => ({
+      block: state.block,
       updateBlock: state.updateBlock,
       updateImage: state.updateImage,
     }))
@@ -31,8 +32,10 @@ function Gallery({ blockInfo, id }: Props) {
   };
 
   const handlePictureChange = (file: (File | string)[]) => {
-    updateBlock(id, { images: file });
-    updateImage(id, file);
+    const currentBlock = block as EditorBlock<'gallery'>[];
+    const image = currentBlock.find(b => b.id === id)?.props.images;
+    updateBlock(id, { images: [...(image ?? []), ...file] });
+    updateImage(id, [...(image ?? []), ...file]);
   };
 
   const handlePopViewChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -295,6 +295,7 @@ export default defineConfig([
     'build/**', // 일반 빌드 폴더
     'dist/**', // 배포용 빌드 폴더
     'node_modules/**', // 외부 패키지
+    'coverage/**', // 테스트 커버리지 결과
     'next-env.d.ts', // Next.js 타입 정의
     '*.config.js', // JS 설정 파일
     '*.config.ts', // TS 설정 파일


### PR DESCRIPTION
## 작업 개요

- 갤러리에 사진을 다시 추가하면 이전 사진들이 날라가는 이슈를 해결하였습니다.

## 작업 내용

- [x] spread 문법으로 이전 내역 복원
- [x] image 테스트 코드 작성 
- [x] lint에 coverage 제외 

## 관련 이슈

Closes #

## 테스트 결과 보고

<!-- 테스트 결과나 내용 텍스트 또는 사진 등 기입 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 갤러리에서 이미지 추가 시 기존 이미지를 대체하지 않고 병합하도록 수정했습니다.

* **Tests**
  * 이미지 컴포넌트의 로딩 및 오류 상태 처리에 대한 테스트 스위트를 추가했습니다.

* **Chores**
  * ESLint 설정을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->