### PR TITLE
[feat] 신랑/신부 소개 디바이더 추가 및 스타일 수정

### DIFF
--- a/components/organisms/couple-introduction/CoupleIntroduction.schema.ts
+++ b/components/organisms/couple-introduction/CoupleIntroduction.schema.ts
@@ -36,7 +36,7 @@ export const coupleIntroductionSchema = {
       required: false,
     },
     showProfileImage: {
-      default: false,
+      default: true,
       required: false,
     },
     showTitle: {

--- a/components/organisms/couple-introduction/CoupleIntroduction.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroduction.tsx
@@ -29,7 +29,6 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
     brideImage = [],
     title = '',
     messageJson = null,
-    showProfileImage = false,
     showTitle = false,
     showContent = false,
     brideFirst = false,
@@ -143,19 +142,25 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
     <LeftEditorWrapper className="items-start" ariaLabel="신랑 신부 소개">
       <NavigationBar>신랑・신부 소개</NavigationBar>
 
-      {profileFields.map(profile => (
+      {profileFields.map((profile, index) => (
         <Fragment key={profile.key}>
-          <TextField
-            label={profile.label}
-            inputProps={{
-              placeholder: '성함',
-              value: profile.value,
-              onChange: profile.onChange,
-            }}
-            className="text-center py-1.5"
-          />
+          <div className="flex flex-col gap-2 w-full">
+            {index !== 0 && (
+              <div className="flex flex-col items-center gap-1">
+                <div className="w-0.5 h-1 rounded-sm bg-text-secondary" />
+                <div className="w-0.5 h-1 rounded-sm bg-text-secondary" />
+              </div>
+            )}
+            <TextField
+              label={profile.label}
+              inputProps={{
+                placeholder: '성함',
+                value: profile.value,
+                onChange: profile.onChange,
+              }}
+              className="w-full text-center py-1.5"
+            />
 
-          {showProfileImage && (
             <Picture
               key={`${profile.key}-${brideFirst ? 'first' : 'last'}`}
               label="사진"
@@ -164,7 +169,7 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
               onDelete={profile.onDelete}
               className="text-center"
             />
-          )}
+          </div>
         </Fragment>
       ))}
 
@@ -177,7 +182,7 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
             value: title,
             onChange: handleTitleChange,
           }}
-          className="text-center py-1.5"
+          className="w-full text-center py-1.5"
         />
       )}
 
@@ -202,23 +207,12 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
           <div className="flex gap-2">
             <Checkbox
               className="gap-1 pl-1 font-medium text-text-secondary"
-              checked={showProfileImage}
-              onChange={e =>
-                updateBlock(id, { showProfileImage: e.target.checked })
-              }
-            >
-              프로필 사진 추가
-            </Checkbox>
-
-            <Checkbox
-              className="gap-1 pl-1 font-medium text-text-secondary"
               checked={showTitle}
               onChange={e => updateBlock(id, { showTitle: e.target.checked })}
             >
               제목 추가
             </Checkbox>
-          </div>
-          <div className="flex gap-2">
+            
             <Checkbox
               className="gap-1 pl-1 font-medium text-text-secondary"
               checked={showContent}
@@ -226,7 +220,8 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
             >
               내용 추가
             </Checkbox>
-
+          </div>
+          <div className="flex gap-2">
             <Checkbox
               className="gap-1 pl-1 font-medium text-text-secondary"
               checked={brideFirst}

--- a/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
@@ -36,7 +36,6 @@ function CoupleIntroductionPreview({
     title = '',
     messageJson = null,
     messageHtml = null,
-    showProfileImage = false,
     showTitle = false,
     showContent = false,
     brideFirst = false,
@@ -112,21 +111,20 @@ function CoupleIntroductionPreview({
             key={profile.key}
             className="w-40 flex flex-col justify-center items-center gap-4"
           >
-            {showProfileImage &&
-              (profile.imageSrc ? (
-                <div className="relative size-40 rounded-3xl overflow-hidden">
-                  <Image
-                    src={profile.imageSrc}
-                    alt={`${profile.label} 사진`}
-                    fill
-                    className="object-cover"
-                  />
-                </div>
-              ) : (
-                <div className="size-40 rounded-3xl bg-border-neutral flex justify-center items-center">
-                  <p>사진을 추가해 주세요.</p>
-                </div>
-              ))}
+            {profile.imageSrc ? (
+              <div className="relative size-40 rounded-3xl overflow-hidden">
+                <Image
+                  src={profile.imageSrc}
+                  alt={`${profile.label} 사진`}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+            ) : (
+              <div className="size-40 rounded-3xl bg-border-neutral flex justify-center items-center">
+                <p>사진을 추가해 주세요.</p>
+              </div>
+            )}
             <p className="text-[16px] font-semibold">
               {profile.name || '성함'}
             </p>


### PR DESCRIPTION
## 작업 개요

- CoupleIntroduction 컴포넌트 UI를 정리했습니다.

## 작업 내용

- [x] 신랑/신부 사이에 디바이더 추가
- [x] 프로필 사진 영역을 항상 노출되도록 변경
- [x] 제목 입력창 너비를 이름 입력창과 동일하게 조정

## 관련 이슈

Closes #null

## 테스트 결과 보고

에디터 기준으로 신랑/신부 사이 디바이더 노출, 프로필 사진 영역 상시 노출, 제목 추가 시 입력창 너비가 정상적으로 적용되는지 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 커플 소개 섹션에서 프로필 사진이 이제 항상 표시됩니다(사진이 있는 경우).
  * 프로필 사진 표시 토글 옵션이 제거되었습니다.
  * 프로필 정보 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->