### PR TITLE
[Feat] 포스터 : 숏컷 추가, 컨텍스트 메뉴 케이스별 처리, im/export 테스트

### DIFF
--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -48,6 +48,14 @@ export const MainPosterPreview = () => {
     setupEventListeners,
     copy,
     paste,
+    lock,
+    unLock,
+    moveUp,
+    moveDown,
+    moveTop,
+    moveBottom,
+    undo,
+    redo,
     startCrop,
     isCropping,
   } = useFabricContext();
@@ -215,28 +223,119 @@ export const MainPosterPreview = () => {
 
       const mod = e.ctrlKey || e.metaKey;
 
+      // 복사 ctrl + c
       if (mod && e.code === 'KeyC') {
         const activeObj = canvas.getActiveObject();
         const isEditingText =
-          activeObj && 'isEditing' in activeObj && (activeObj as any).isEditing;
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
         if (activeObj && !isEditingText) {
           e.preventDefault();
           copy();
         }
       }
 
+      // 붙여넣기 ctrl + v
       if (mod && e.code === 'KeyV') {
         const activeObj = canvas.getActiveObject();
         const isEditingText =
-          activeObj && 'isEditing' in activeObj && (activeObj as any).isEditing;
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
         if (!isEditingText) {
           e.preventDefault();
           paste();
         }
       }
 
+      // 잠그기 ctrl + l
+      if (mod && e.code === 'KeyL') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          lock(activeObj);
+        }
+      }
+
+      // 잠금 해제 ctrl + shift + l
+      if (mod && e.shiftKey && e.code === 'KeyL') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          unLock(activeObj);
+        }
+      }
+
+      // 맨 위로 보내기 ctrl + shift + [
+      if (mod && e.shiftKey && e.code === 'BracketLeft') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveTop(activeObj);
+        }
+      }
+
+      // 맨 아래로 보내기 ctrl + shift + ]
+      if (mod && e.shiftKey && e.code === 'BracketRight') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveBottom(activeObj);
+        }
+      }
+
+      // 위로 보내기 ctrl + [
+      if (mod && e.code === 'BracketLeft') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveUp(activeObj);
+        }
+      }
+
+      // 아래로 보내기 ctrl + ]
+      if (mod && e.code === 'BracketRight') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveDown(activeObj);
+        }
+      }
+
+      // 삭제 delete
       if (e.key === 'Delete') {
         handleDeleteShape(canvas, e);
+      }
+
+      // 되돌리기 ctrl + z
+      if (mod && e.code === 'KeyZ') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          undo();
+        }
+      }
+
+      // 다시하기 ctrl + shift + z
+      if (mod && e.shiftKey && e.code === 'KeyZ') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          redo();
+        }
       }
 
       if (e.key === 'Escape') {
@@ -247,7 +346,20 @@ export const MainPosterPreview = () => {
 
     window.addEventListener('keydown', handleKeyboard);
     return () => window.removeEventListener('keydown', handleKeyboard);
-  }, [canvas, copy, paste, handleDeleteShape]);
+  }, [
+    canvas,
+    copy,
+    paste,
+    handleDeleteShape,
+    moveUp,
+    moveDown,
+    moveTop,
+    moveBottom,
+    lock,
+    unLock,
+    undo,
+    redo,
+  ]);
 
   return (
     <>

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -47,10 +47,45 @@ export const MainPosterPreview = () => {
     setupEventListeners,
     startCrop,
     isCropping,
+    initialData,
   } = useFabricContext();
 
   useSetFabricControls();
   useKeyboardEvents(canvas, isMouseInCanvasRef);
+
+  useEffect(() => {
+    if (!canvas || !initialData) return;
+
+    const loadData = async () => {
+      try {
+        const jsonData =
+          typeof initialData === 'string'
+            ? JSON.parse(initialData)
+            : initialData;
+        await canvas.loadFromJSON(jsonData);
+
+        canvas.getObjects().forEach(obj => {
+          if ((obj as any).isLocked) {
+            obj.set({
+              lockMovementX: true,
+              lockMovementY: true,
+              lockScalingX: true,
+              lockScalingY: true,
+              lockRotation: true,
+              hasControls: false,
+              editable: false,
+            });
+          }
+        });
+
+        canvas.requestRenderAll();
+      } catch (error) {
+        console.error('Fabric load Error:', error);
+      }
+    };
+
+    loadData();
+  }, [canvas, initialData]);
 
   useEffect(() => {
     if (!canvasRef.current) return;

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -19,7 +19,7 @@ import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
-import { useInitFabricData } from '../hooks/useInitFabricData';
+import { useKeyboardEvents } from '../hooks/useKeyboardEvents';
 import { useSetFabricControls } from '../hooks/useSetFabricControls';
 import { initAligningGuidelines } from '../libs/aligning-guidelines';
 import { FabricObjectWithLock } from '../types/fabric';
@@ -43,25 +43,14 @@ export const MainPosterPreview = () => {
   const {
     canvas,
     setCanvas,
-    handleDeleteShape,
     handleDeleteEmptyShape,
     setupEventListeners,
-    copy,
-    paste,
-    lock,
-    unLock,
-    moveUp,
-    moveDown,
-    moveTop,
-    moveBottom,
-    undo,
-    redo,
     startCrop,
     isCropping,
   } = useFabricContext();
 
   useSetFabricControls();
-  useInitFabricData();
+  useKeyboardEvents(canvas, isMouseInCanvasRef);
 
   useEffect(() => {
     if (!canvasRef.current) return;
@@ -132,6 +121,7 @@ export const MainPosterPreview = () => {
       }
     };
 
+    // 마우스 드래그해 그룹으로 영역 선택시 잠금 객체 제외하고 선택될수있게
     const handleMouseDown = (options: TPointerEventInfo<TPointerEvent>) => {
       const e = options.e as MouseEvent;
       if (e.button === 2) return; // 우클릭(Right Click)은 무시
@@ -171,13 +161,13 @@ export const MainPosterPreview = () => {
   }, [
     canvas,
     handleDeleteEmptyShape,
-    handleDeleteShape,
     setActiveTab,
     setupEventListeners,
     startCrop,
     isCropping,
   ]);
 
+  // 마우스가 캔버스에 들어왔는지 나갔는지 확인
   useEffect(() => {
     if (!canvas) return;
     const el = canvas.upperCanvasEl;
@@ -193,6 +183,7 @@ export const MainPosterPreview = () => {
     };
   }, [canvas]);
 
+  // 외부클릭시 액티브 해제
   useEffect(() => {
     if (!canvas) return;
 
@@ -213,153 +204,6 @@ export const MainPosterPreview = () => {
     document.addEventListener('click', handleClickOutside);
     return () => document.removeEventListener('click', handleClickOutside);
   }, [canvas]);
-
-  useEffect(() => {
-    if (!canvas) return;
-
-    const handleKeyboard = (e: KeyboardEvent) => {
-      const hasActiveObj = canvas.getActiveObjects().length > 0;
-      if (!isMouseInCanvasRef.current && !hasActiveObj) return;
-
-      const mod = e.ctrlKey || e.metaKey;
-
-      // 복사 ctrl + c
-      if (mod && e.code === 'KeyC') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          copy();
-        }
-      }
-
-      // 붙여넣기 ctrl + v
-      if (mod && e.code === 'KeyV') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (!isEditingText) {
-          e.preventDefault();
-          paste();
-        }
-      }
-
-      // 잠그기 ctrl + l
-      if (mod && e.code === 'KeyL') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          lock(activeObj);
-        }
-      }
-
-      // 잠금 해제 ctrl + shift + l
-      if (mod && e.shiftKey && e.code === 'KeyL') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          unLock(activeObj);
-        }
-      }
-
-      // 맨 위로 보내기 ctrl + shift + [
-      if (mod && e.shiftKey && e.code === 'BracketLeft') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          moveTop(activeObj);
-        }
-      }
-
-      // 맨 아래로 보내기 ctrl + shift + ]
-      if (mod && e.shiftKey && e.code === 'BracketRight') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          moveBottom(activeObj);
-        }
-      }
-
-      // 위로 보내기 ctrl + [
-      if (mod && e.code === 'BracketLeft') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          moveUp(activeObj);
-        }
-      }
-
-      // 아래로 보내기 ctrl + ]
-      if (mod && e.code === 'BracketRight') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          moveDown(activeObj);
-        }
-      }
-
-      // 삭제 delete
-      if (e.key === 'Delete') {
-        handleDeleteShape(canvas, e);
-      }
-
-      // 되돌리기 ctrl + z
-      if (mod && e.code === 'KeyZ') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          undo();
-        }
-      }
-
-      // 다시하기 ctrl + shift + z
-      if (mod && e.shiftKey && e.code === 'KeyZ') {
-        const activeObj = canvas.getActiveObject();
-        const isEditingText =
-          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
-        if (activeObj && !isEditingText) {
-          e.preventDefault();
-          redo();
-        }
-      }
-
-      if (e.key === 'Escape') {
-        canvas.discardActiveObject();
-        canvas.renderAll();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyboard);
-    return () => window.removeEventListener('keydown', handleKeyboard);
-  }, [
-    canvas,
-    copy,
-    paste,
-    handleDeleteShape,
-    moveUp,
-    moveDown,
-    moveTop,
-    moveBottom,
-    lock,
-    unLock,
-    undo,
-    redo,
-  ]);
 
   return (
     <>

--- a/widgets/mainPoster/components/context-menu/ContextMenu.tsx
+++ b/widgets/mainPoster/components/context-menu/ContextMenu.tsx
@@ -6,6 +6,7 @@ import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 import ControlZindex from './ControlZindex';
 import CopyAndPaste from './CopyAndPaste';
 import { LockObject } from './LockObject';
+import { UndoRedo } from './UndoRedo';
 
 export function ContextMenu() {
   const { canvas, handleDeleteShape } = useFabricContext();
@@ -61,16 +62,16 @@ export function ContextMenu() {
   return (
     <div
       ref={menuRef}
-      className="fixed z-9999 flex flex-col gap-3 p-3 bg-white border border-gray-200 rounded-md shadow-lg"
+      className="fixed z-9999 w-55 flex flex-col gap-3 p-3 bg-white border border-gray-200 rounded-md shadow-lg"
       style={{ top: pos.y, left: pos.x }}
-      // onMouseDown={e => e.stopPropagation()}
       onContextMenu={e => e.preventDefault()}
     >
       <CopyAndPaste onClick={() => setOpen(false)} />
       <ControlZindex onClick={() => setOpen(false)} />
+      <UndoRedo onClick={() => setOpen(false)} />
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
           if (canvas) {
             handleDeleteShape(canvas, undefined, true);
@@ -78,7 +79,8 @@ export function ContextMenu() {
           setOpen(false);
         }}
       >
-        삭제하기
+        <p>삭제하기</p>
+        <p>Delete</p>
       </button>
       <LockObject onClick={() => setOpen(false)} />
     </div>

--- a/widgets/mainPoster/components/context-menu/ContextMenu.tsx
+++ b/widgets/mainPoster/components/context-menu/ContextMenu.tsx
@@ -86,7 +86,9 @@ export function ContextMenu() {
         }}
       >
         <p className={cn(!hasActiveObject && 'text-gray-400')}>삭제하기</p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>Delete</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
+          Delete
+        </p>
       </button>
       <LockObject onClick={() => setOpen(false)} />
     </div>

--- a/widgets/mainPoster/components/context-menu/ContextMenu.tsx
+++ b/widgets/mainPoster/components/context-menu/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import { TPointerEvent, TPointerEventInfo } from 'fabric';
 import { useEffect, useRef, useState } from 'react';
 
+import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 import ControlZindex from './ControlZindex';
@@ -9,7 +10,8 @@ import { LockObject } from './LockObject';
 import { UndoRedo } from './UndoRedo';
 
 export function ContextMenu() {
-  const { canvas, handleDeleteShape } = useFabricContext();
+  const { canvas, handleDeleteShape, activeInfo } = useFabricContext();
+  const hasActiveObject = activeInfo.type !== null;
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
 
@@ -71,16 +73,20 @@ export function ContextMenu() {
       <UndoRedo onClick={() => setOpen(false)} />
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          if (canvas) {
+          if (canvas && hasActiveObject) {
             handleDeleteShape(canvas, undefined, true);
           }
           setOpen(false);
         }}
       >
-        <p>삭제하기</p>
-        <p>Delete</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>삭제하기</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>Delete</p>
       </button>
       <LockObject onClick={() => setOpen(false)} />
     </div>

--- a/widgets/mainPoster/components/context-menu/ControlZindex.tsx
+++ b/widgets/mainPoster/components/context-menu/ControlZindex.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 import { FabricObjectWithLock } from '../../types/fabric';
@@ -7,54 +8,88 @@ interface Props {
 }
 
 function ControlZindex({ onClick }: Props) {
-  const { canvas, moveUp, moveDown, moveTop, moveBottom } = useFabricContext();
+  const { canvas, moveUp, moveDown, moveTop, moveBottom, activeInfo } =
+    useFabricContext();
+  const hasActiveObject = activeInfo.type !== null;
   const activeObject = canvas?.getActiveObject() as FabricObjectWithLock;
 
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          moveTop(activeObject);
-          onClick();
+          if (hasActiveObject && activeObject) {
+            moveTop(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>맨 위로 보내기</p>
-        <p>Ctrl + Shift + [</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+          맨 위로 보내기
+        </p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+          Ctrl + Shift + [
+        </p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          moveBottom(activeObject);
-          onClick();
+          if (hasActiveObject && activeObject) {
+            moveBottom(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>맨 아래로 보내기</p>
-        <p>Ctrl + Shift + ]</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+          맨 아래로 보내기
+        </p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+          Ctrl + Shift + ]
+        </p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          moveUp(activeObject);
-          onClick();
+          if (hasActiveObject && activeObject) {
+            moveUp(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>위로 보내기</p>
-        <p>Ctrl + [</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>위로 보내기</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + [</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          moveDown(activeObject);
-          onClick();
+          if (hasActiveObject && activeObject) {
+            moveDown(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>아래로 보내기</p>
-        <p>Ctrl + ]</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>아래로 보내기</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + ]</p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/ControlZindex.tsx
+++ b/widgets/mainPoster/components/context-menu/ControlZindex.tsx
@@ -32,7 +32,7 @@ function ControlZindex({ onClick }: Props) {
         <p className={cn(!hasActiveObject && 'text-gray-400')}>
           맨 위로 보내기
         </p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
           Ctrl + Shift + [
         </p>
       </button>
@@ -53,7 +53,7 @@ function ControlZindex({ onClick }: Props) {
         <p className={cn(!hasActiveObject && 'text-gray-400')}>
           맨 아래로 보내기
         </p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
           Ctrl + Shift + ]
         </p>
       </button>
@@ -72,7 +72,9 @@ function ControlZindex({ onClick }: Props) {
         }}
       >
         <p className={cn(!hasActiveObject && 'text-gray-400')}>위로 보내기</p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + [</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
+          Ctrl + [
+        </p>
       </button>
       <button
         type="button"
@@ -89,7 +91,9 @@ function ControlZindex({ onClick }: Props) {
         }}
       >
         <p className={cn(!hasActiveObject && 'text-gray-400')}>아래로 보내기</p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + ]</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
+          Ctrl + ]
+        </p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/ControlZindex.tsx
+++ b/widgets/mainPoster/components/context-menu/ControlZindex.tsx
@@ -1,78 +1,60 @@
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
+import { FabricObjectWithLock } from '../../types/fabric';
+
 interface Props {
   onClick: () => void;
 }
 
 function ControlZindex({ onClick }: Props) {
-  const { canvas } = useFabricContext();
-  const activeObject = canvas?.getActiveObject();
-
-  const moveUp = () => {
-    if (!activeObject || !canvas) return;
-    canvas.bringObjectForward(activeObject);
-    canvas.requestRenderAll();
-  };
-
-  const moveDown = () => {
-    if (!activeObject || !canvas) return;
-    canvas.sendObjectBackwards(activeObject);
-    canvas.requestRenderAll();
-  };
-
-  const moveTop = () => {
-    if (!activeObject || !canvas) return;
-    canvas.bringObjectToFront(activeObject);
-    canvas.requestRenderAll();
-  };
-
-  const moveBottom = () => {
-    if (!activeObject || !canvas) return;
-    canvas.sendObjectToBack(activeObject);
-    canvas.requestRenderAll();
-  };
+  const { canvas, moveUp, moveDown, moveTop, moveBottom } = useFabricContext();
+  const activeObject = canvas?.getActiveObject() as FabricObjectWithLock;
 
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          moveTop();
+          moveTop(activeObject);
           onClick();
         }}
       >
-        맨 위로 보내기
+        <p>맨 위로 보내기</p>
+        <p>Ctrl + Shift + [</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          moveBottom();
+          moveBottom(activeObject);
           onClick();
         }}
       >
-        맨 아래로 보내기
+        <p>맨 아래로 보내기</p>
+        <p>Ctrl + Shift + ]</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          moveUp();
+          moveUp(activeObject);
           onClick();
         }}
       >
-        위로 보내기
+        <p>위로 보내기</p>
+        <p>Ctrl + [</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          moveDown();
+          moveDown(activeObject);
           onClick();
         }}
       >
-        아래로 보내기
+        <p>아래로 보내기</p>
+        <p>Ctrl + ]</p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
+++ b/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
@@ -27,7 +27,9 @@ function CopyAndPaste({ onClick }: Props) {
         }}
       >
         <p className={cn(!hasActiveObject && 'text-gray-400')}>복사</p>
-        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + C</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400 font-[12px]')}>
+          Ctrl + C
+        </p>
       </button>
       <button
         type="button"
@@ -44,7 +46,9 @@ function CopyAndPaste({ onClick }: Props) {
         }}
       >
         <p className={cn(!hasClipboard && 'text-gray-400')}>붙여넣기</p>
-        <p className={cn(!hasClipboard && 'text-gray-400')}>Ctrl + V</p>
+        <p className={cn(!hasClipboard && 'text-gray-400 font-[12px]')}>
+          Ctrl + V
+        </p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
+++ b/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 interface Props {
@@ -5,31 +6,45 @@ interface Props {
 }
 
 function CopyAndPaste({ onClick }: Props) {
-  const { copy, paste } = useFabricContext();
+  const { copy, paste, activeInfo, clipboard } = useFabricContext();
+  const hasActiveObject = activeInfo.type !== null;
+  const hasClipboard = clipboard !== null;
 
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasActiveObject}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasActiveObject && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={async () => {
-          await copy();
-          onClick();
+          if (hasActiveObject) {
+            await copy();
+            onClick();
+          }
         }}
       >
-        <p>복사</p>
-        <p>Ctrl + C</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>복사</p>
+        <p className={cn(!hasActiveObject && 'text-gray-400')}>Ctrl + C</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!hasClipboard}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !hasClipboard && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={async () => {
-          await paste();
-          onClick();
+          if (hasClipboard) {
+            await paste();
+            onClick();
+          }
         }}
       >
-        <p>붙여넣기</p>
-        <p>Ctrl + V</p>
+        <p className={cn(!hasClipboard && 'text-gray-400')}>붙여넣기</p>
+        <p className={cn(!hasClipboard && 'text-gray-400')}>Ctrl + V</p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/LockObject.tsx
+++ b/widgets/mainPoster/components/context-menu/LockObject.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/shared/utils/cn';
+
 import { useFabricContext } from '../../context/FabricContext';
 import { FabricObjectWithLock } from '../../types/fabric';
 
@@ -6,32 +8,52 @@ interface Props {
 }
 
 export const LockObject = ({ onClick }: Props) => {
-  const { canvas, lock, unLock } = useFabricContext();
+  const { canvas, lock, unLock, activeInfo } = useFabricContext();
+  const hasActiveObject = activeInfo.type !== null;
   const activeObject = canvas?.getActiveObject() as FabricObjectWithLock;
+
+  const isLocked = activeInfo.isLocked;
+
+  const canLock = hasActiveObject && !isLocked;
+  const canUnlock = hasActiveObject && isLocked;
 
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!canLock}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !canLock && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          lock(activeObject);
-          onClick();
+          if (canLock && activeObject) {
+            lock(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>잠그기</p>
-        <p>Ctrl + L</p>
+        <p className={cn(!canLock && 'text-gray-400')}>잠그기</p>
+        <p className={cn(!canLock && 'text-gray-400')}>Ctrl + L</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!canUnlock}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !canUnlock && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          unLock(activeObject);
-          onClick();
+          if (canUnlock && activeObject) {
+            unLock(activeObject);
+            onClick();
+          }
         }}
       >
-        <p>잠금 해제하기</p>
-        <p>Ctrl + Shift + L</p>
+        <p className={cn(!canUnlock && 'text-gray-400')}>잠금 해제하기</p>
+        <p className={cn(!canUnlock && 'text-gray-400')}>
+          Ctrl + Shift + L
+        </p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/LockObject.tsx
+++ b/widgets/mainPoster/components/context-menu/LockObject.tsx
@@ -6,60 +6,32 @@ interface Props {
 }
 
 export const LockObject = ({ onClick }: Props) => {
-  const { canvas } = useFabricContext();
+  const { canvas, lock, unLock } = useFabricContext();
   const activeObject = canvas?.getActiveObject() as FabricObjectWithLock;
-
-  const lock = () => {
-    if (!activeObject) return;
-    activeObject.set({
-      lockMovementX: true,
-      lockMovementY: true,
-      lockScalingX: true,
-      lockScalingY: true,
-      lockRotation: true,
-      hasControls: false,
-      editable: false,
-      isLocked: true,
-    });
-    canvas?.requestRenderAll();
-  };
-
-  const unLock = () => {
-    if (!activeObject) return;
-    activeObject.set({
-      lockMovementX: false,
-      lockMovementY: false,
-      lockScalingX: false,
-      lockScalingY: false,
-      lockRotation: false,
-      hasControls: true,
-      editable: true,
-      isLocked: false,
-    });
-    canvas?.requestRenderAll();
-  };
 
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          lock();
+          lock(activeObject);
           onClick();
         }}
       >
-        잠그기
+        <p>잠그기</p>
+        <p>Ctrl + L</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200"
+        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
         onClick={() => {
-          unLock();
+          unLock(activeObject);
           onClick();
         }}
       >
-        잠금 해제하기
+        <p>잠금 해제하기</p>
+        <p>Ctrl + Shift + L</p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/LockObject.tsx
+++ b/widgets/mainPoster/components/context-menu/LockObject.tsx
@@ -34,7 +34,7 @@ export const LockObject = ({ onClick }: Props) => {
         }}
       >
         <p className={cn(!canLock && 'text-gray-400')}>잠그기</p>
-        <p className={cn(!canLock && 'text-gray-400')}>Ctrl + L</p>
+        <p className={cn(!canLock && 'text-gray-400 font-[12px]')}>Ctrl + L</p>
       </button>
       <button
         type="button"
@@ -51,7 +51,7 @@ export const LockObject = ({ onClick }: Props) => {
         }}
       >
         <p className={cn(!canUnlock && 'text-gray-400')}>잠금 해제하기</p>
-        <p className={cn(!canUnlock && 'text-gray-400')}>
+        <p className={cn(!canUnlock && 'text-gray-400 font-[12px]')}>
           Ctrl + Shift + L
         </p>
       </button>

--- a/widgets/mainPoster/components/context-menu/UndoRedo.tsx
+++ b/widgets/mainPoster/components/context-menu/UndoRedo.tsx
@@ -1,38 +1,33 @@
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
-
 interface Props {
   onClick: () => void;
 }
-
-function CopyAndPaste({ onClick }: Props) {
-  const { copy, paste } = useFabricContext();
-
+export const UndoRedo = ({ onClick }: Props) => {
+  const { undo, redo } = useFabricContext();
   return (
     <>
       <button
         type="button"
         className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
-        onClick={async () => {
-          await copy();
+        onClick={() => {
+          undo();
           onClick();
         }}
       >
-        <p>복사</p>
-        <p>Ctrl + C</p>
+        <p>되돌리기</p>
+        <p>Ctrl + Z</p>
       </button>
       <button
         type="button"
         className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
-        onClick={async () => {
-          await paste();
+        onClick={() => {
+          redo();
           onClick();
         }}
       >
-        <p>붙여넣기</p>
-        <p>Ctrl + V</p>
+        <p>다시하기</p>
+        <p>Ctrl + Shift + Z</p>
       </button>
     </>
   );
-}
-
-export default CopyAndPaste;
+};

--- a/widgets/mainPoster/components/context-menu/UndoRedo.tsx
+++ b/widgets/mainPoster/components/context-menu/UndoRedo.tsx
@@ -1,32 +1,48 @@
+import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
+
 interface Props {
   onClick: () => void;
 }
+
 export const UndoRedo = ({ onClick }: Props) => {
-  const { undo, redo } = useFabricContext();
+  const { undo, redo, canUndo, canRedo } = useFabricContext();
+
   return (
     <>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!canUndo}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !canUndo && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          undo();
-          onClick();
+          if (canUndo) {
+            undo();
+            onClick();
+          }
         }}
       >
-        <p>되돌리기</p>
-        <p>Ctrl + Z</p>
+        <p className={cn(!canUndo && 'text-gray-400')}>되돌리기</p>
+        <p className={cn(!canUndo && 'text-gray-400')}>Ctrl + Z</p>
       </button>
       <button
         type="button"
-        className="hover:bg-gray-100 active:bg-gray-200 flex justify-between"
+        disabled={!canRedo}
+        className={cn(
+          'hover:bg-gray-100 active:bg-gray-200 flex justify-between px-1 rounded transition-colors',
+          !canRedo && 'opacity-50 cursor-not-allowed grayscale'
+        )}
         onClick={() => {
-          redo();
-          onClick();
+          if (canRedo) {
+            redo();
+            onClick();
+          }
         }}
       >
-        <p>다시하기</p>
-        <p>Ctrl + Shift + Z</p>
+        <p className={cn(!canRedo && 'text-gray-400')}>다시하기</p>
+        <p className={cn(!canRedo && 'text-gray-400')}>Ctrl + Shift + Z</p>
       </button>
     </>
   );

--- a/widgets/mainPoster/components/context-menu/UndoRedo.tsx
+++ b/widgets/mainPoster/components/context-menu/UndoRedo.tsx
@@ -25,7 +25,7 @@ export const UndoRedo = ({ onClick }: Props) => {
         }}
       >
         <p className={cn(!canUndo && 'text-gray-400')}>되돌리기</p>
-        <p className={cn(!canUndo && 'text-gray-400')}>Ctrl + Z</p>
+        <p className={cn(!canUndo && 'text-gray-400 font-[12px]')}>Ctrl + Z</p>
       </button>
       <button
         type="button"
@@ -42,7 +42,9 @@ export const UndoRedo = ({ onClick }: Props) => {
         }}
       >
         <p className={cn(!canRedo && 'text-gray-400')}>다시하기</p>
-        <p className={cn(!canRedo && 'text-gray-400')}>Ctrl + Shift + Z</p>
+        <p className={cn(!canRedo && 'text-gray-400 font-[12px]')}>
+          Ctrl + Shift + Z
+        </p>
       </button>
     </>
   );

--- a/widgets/mainPoster/context/FabricContext.tsx
+++ b/widgets/mainPoster/context/FabricContext.tsx
@@ -16,7 +16,7 @@ type FabricContextType = ReturnType<typeof useFabric> &
     initialData?: string;
     canUndo: boolean;
     canRedo: boolean;
-    clipboard: any; // FabricObject | null
+    clipboard: any;
   };
 
 const FabricContext = createContext<FabricContextType | null>(null);

--- a/widgets/mainPoster/context/FabricContext.tsx
+++ b/widgets/mainPoster/context/FabricContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode, useMemo } from 'react';
 
 import { useFabric } from '../hooks/useFabric';
 import { useFabricBackground } from '../hooks/useFabricBackground';
@@ -14,6 +14,9 @@ type FabricContextType = ReturnType<typeof useFabric> &
   ReturnType<typeof useFabricBackground> &
   ReturnType<typeof useFabricText> & {
     initialData?: string;
+    canUndo: boolean;
+    canRedo: boolean;
+    clipboard: any; // FabricObject | null
   };
 
 const FabricContext = createContext<FabricContextType | null>(null);
@@ -44,14 +47,24 @@ export const FabricProvider = ({
     saveHistory: fabricValues.saveHistory,
   });
 
-  const value = {
-    ...fabricValues,
-    ...fabricDiagramValues,
-    ...fabricImageValues,
-    ...fabricTextValues,
-    ...fabricBackgroundValues,
-    initialData,
-  };
+  const value = useMemo(
+    () => ({
+      ...fabricValues,
+      ...fabricDiagramValues,
+      ...fabricImageValues,
+      ...fabricTextValues,
+      ...fabricBackgroundValues,
+      initialData,
+    }),
+    [
+      fabricValues,
+      fabricDiagramValues,
+      fabricImageValues,
+      fabricTextValues,
+      fabricBackgroundValues,
+      initialData,
+    ]
+  );
 
   return (
     <FabricContext.Provider value={value}>{children}</FabricContext.Provider>

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -397,7 +397,21 @@ export const useFabric = () => {
       return isVisible;
     });
 
-    const propertiesToInclude = ['filters', 'id', 'name'];
+    const propertiesToInclude = [
+      'filters',
+      'id',
+      'name',
+      'isLocked',
+      'lockMovementX',
+      'lockMovementY',
+      'lockScalingX',
+      'lockScalingY',
+      'lockRotation',
+      'hasControls',
+      'editable',
+      'selectable',
+      'evented',
+    ];
     const json = canvas.toObject(propertiesToInclude);
     json.objects = filteredData.map(obj => obj.toObject(propertiesToInclude));
     return json;

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -1,57 +1,98 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Canvas, FabricObject, Textbox, IText, ActiveSelection } from 'fabric';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { ActiveObject } from '../types/fabric';
 export const useFabric = () => {
   const [canvas, setCanvas] = useState<Canvas | null>(null);
   const [activeInfo, setActiveInfo] = useState<ActiveObject>({
     type: null,
+    isLocked: false,
     filters: [],
     styles: {},
   });
   const [clipboard, setClipboard] = useState<FabricObject | null>(null);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
   const undoStack = useRef<string[]>([]);
   const redoStack = useRef<string[]>([]);
   const isUpdating = useRef<boolean>(false);
   const MAX_STACK_SIZE = 30;
 
-  const handleDeleteShape = (
-    canvas: Canvas,
-    e?: KeyboardEvent,
-    flag?: boolean
-  ) => {
-    // 페이지 내의 포스터 캔버스가 아닌곳에서 키보드 이벤트 발생시 작동 중지
-    const activeObjects = canvas.getActiveObjects();
-    const isHoveringCanvas = canvas.elements.container.matches(':hover');
-    if (!isHoveringCanvas && activeObjects.length === 0) return;
-    const exist = activeObjects.length > 0 ? true : false;
+  const saveHistory = useCallback(() => {
+    if (isUpdating.current || !canvas) return;
 
-    if (exist) {
-      const isEditing = activeObjects.some(
-        obj => obj instanceof Textbox && obj.isEditing
-      );
+    // 객체 상태 직렬화 시 filters 등 커스텀 속성 및 잠금 관련 속성 포함
+    const json = JSON.stringify(
+      canvas.toObject([
+        'filters',
+        'id',
+        'name',
+        'isLocked',
+        'lockMovementX',
+        'lockMovementY',
+        'lockScalingX',
+        'lockScalingY',
+        'lockRotation',
+        'hasControls',
+        'editable',
+        'selectable',
+        'evented',
+      ])
+    );
 
-      if (isEditing) return;
-      if (e?.key === 'Delete' || flag === true) {
-        e?.preventDefault();
+    const prevState = undoStack.current[undoStack.current.length - 1];
+    if (prevState === json) return;
 
-        canvas.remove(...activeObjects);
+    undoStack.current.push(json);
 
-        canvas.discardActiveObject();
-        canvas.requestRenderAll();
-      }
-    } else if (!exist && e?.key === 'Backspace') {
-      const checkGoToBack = confirm(
-        '정말 뒤돌아가시겠습니까? 저장되지 않은 내역은 모두 사라집니다'
-      );
-      if (!checkGoToBack) {
-        e.preventDefault();
-      }
+    if (undoStack.current.length > MAX_STACK_SIZE) {
+      undoStack.current.shift();
     }
-  };
 
-  const handleDeleteEmptyShape = (canvas: Canvas) => {
+    if (redoStack.current.length > 0) {
+      redoStack.current.length = 0;
+    }
+
+    setCanUndo(undoStack.current.length > 1);
+    setCanRedo(redoStack.current.length > 0);
+  }, [canvas]);
+
+  const handleDeleteShape = useCallback(
+    (canvas: Canvas, e?: KeyboardEvent, flag?: boolean) => {
+      // 페이지 내의 포스터 캔버스가 아닌곳에서 키보드 이벤트 발생시 작동 중지
+      const activeObjects = canvas.getActiveObjects();
+      const isHoveringCanvas = canvas.elements.container.matches(':hover');
+      if (!isHoveringCanvas && activeObjects.length === 0) return;
+      const exist = activeObjects.length > 0 ? true : false;
+
+      if (exist) {
+        const isEditing = activeObjects.some(
+          obj => obj instanceof Textbox && obj.isEditing
+        );
+
+        if (isEditing) return;
+        if (e?.key === 'Delete' || flag === true) {
+          e?.preventDefault();
+
+          canvas.remove(...activeObjects);
+
+          canvas.discardActiveObject();
+          canvas.requestRenderAll();
+        }
+      } else if (!exist && e?.key === 'Backspace') {
+        const checkGoToBack = confirm(
+          '정말 뒤돌아가시겠습니까? 저장되지 않은 내역은 모두 사라집니다'
+        );
+        if (!checkGoToBack) {
+          e?.preventDefault();
+        }
+      }
+    },
+    []
+  );
+
+  const handleDeleteEmptyShape = useCallback((canvas: Canvas) => {
     const deleteEmptyShape = (opt: { target: IText }) => {
       const textObject = opt.target;
 
@@ -75,17 +116,17 @@ export const useFabric = () => {
     return () => {
       canvas.off('text:editing:exited', deleteEmptyShape);
     };
-  };
+  }, []);
 
-  const copy = async () => {
+  const copy = useCallback(async () => {
     if (!canvas) return;
     const activeObject = canvas.getActiveObject();
     if (!activeObject) return;
     const cloned = await activeObject.clone();
     setClipboard(cloned);
-  };
+  }, [canvas]);
 
-  const paste = async () => {
+  const paste = useCallback(async () => {
     if (!clipboard || !canvas) return;
     isUpdating.current = true;
 
@@ -137,67 +178,87 @@ export const useFabric = () => {
     canvas.requestRenderAll();
     isUpdating.current = false;
     saveHistory();
-  };
+  }, [canvas, clipboard, saveHistory]);
 
-  const moveUp = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    canvas.bringObjectForward(activeObject);
-    canvas.requestRenderAll();
-  };
+  const moveUp = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      canvas.bringObjectForward(activeObject);
+      canvas.requestRenderAll();
+    },
+    [canvas]
+  );
 
-  const moveDown = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    canvas.sendObjectBackwards(activeObject);
-    canvas.requestRenderAll();
-  };
+  const moveDown = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      canvas.sendObjectBackwards(activeObject);
+      canvas.requestRenderAll();
+    },
+    [canvas]
+  );
 
-  const moveTop = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    canvas.bringObjectToFront(activeObject);
-    canvas.requestRenderAll();
-  };
+  const moveTop = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      canvas.bringObjectToFront(activeObject);
+      canvas.requestRenderAll();
+    },
+    [canvas]
+  );
 
-  const moveBottom = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    canvas.sendObjectToBack(activeObject);
-    canvas.requestRenderAll();
-  };
+  const moveBottom = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      canvas.sendObjectToBack(activeObject);
+      canvas.requestRenderAll();
+    },
+    [canvas]
+  );
 
-  const lock = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    activeObject.set({
-      lockMovementX: true,
-      lockMovementY: true,
-      lockScalingX: true,
-      lockScalingY: true,
-      lockRotation: true,
-      hasControls: false,
-      editable: false,
-      isLocked: true,
-    });
-    canvas?.requestRenderAll();
-  };
+  const lock = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      activeObject.set({
+        lockMovementX: true,
+        lockMovementY: true,
+        lockScalingX: true,
+        lockScalingY: true,
+        lockRotation: true,
+        hasControls: false,
+        editable: false,
+        isLocked: true,
+      });
+      canvas?.requestRenderAll();
+      saveHistory();
+    },
+    [canvas, saveHistory]
+  );
 
-  const unLock = (activeObject: FabricObject) => {
-    if (!activeObject || !canvas) return;
-    activeObject.set({
-      lockMovementX: false,
-      lockMovementY: false,
-      lockScalingX: false,
-      lockScalingY: false,
-      lockRotation: false,
-      hasControls: true,
-      editable: true,
-      isLocked: false,
-    });
-    canvas?.requestRenderAll();
-  };
+  const unLock = useCallback(
+    (activeObject: FabricObject) => {
+      if (!activeObject || !canvas) return;
+      activeObject.set({
+        lockMovementX: false,
+        lockMovementY: false,
+        lockScalingX: false,
+        lockScalingY: false,
+        lockRotation: false,
+        isLocked: false,
+        hasControls: true,
+        editable: true,
+      });
+      canvas?.requestRenderAll();
+      saveHistory();
+    },
+    [canvas, saveHistory]
+  );
 
-  const syncActiveObjectInfo = (canvas: Canvas) => {
+  const syncActiveObjectInfo = useCallback((canvas: Canvas) => {
     const activeObjects = canvas.getActiveObjects();
 
     if (activeObjects.length === 0) {
-      setActiveInfo({ type: null, filters: [], styles: {} });
+      setActiveInfo({ type: null, isLocked: false, filters: [], styles: {} });
       return;
     }
 
@@ -206,6 +267,7 @@ export const useFabric = () => {
     // UI 버튼 활성화를 위해 필요한 정보만 추출
     setActiveInfo({
       type: primaryObject.type,
+      isLocked: (primaryObject as any).isLocked || false,
       filters: (primaryObject as any).filters || [],
       styles: {
         fontWeight: (primaryObject as any).fontWeight,
@@ -219,46 +281,44 @@ export const useFabric = () => {
         strokeWidth: primaryObject.strokeWidth,
       },
     });
-  };
+  }, []);
 
   // 캔버스 초기화 시 이벤트 리스너 등록
-  const setupEventListeners = (canvas: Canvas) => {
-    const events = [
-      'selection:created',
-      'selection:updated',
-      'selection:cleared',
-      'object:modified',
-      'text:selection:changed', // 텍스트 내부 드래그 시 스타일 대응
-    ];
+  const setupEventListeners = useCallback(
+    (canvas: Canvas) => {
+      // 1. 객체 선택 상태 동기화 (UI 업데이트용)
+      const selectionEvents = [
+        'selection:created',
+        'selection:updated',
+        'selection:cleared',
+        'text:selection:changed',
+      ];
 
-    events.forEach(event => {
-      canvas.on(event as any, () => syncActiveObjectInfo(canvas));
-    });
-  };
+      const handleSelection = () => syncActiveObjectInfo(canvas);
 
-  const saveHistory = () => {
-    if (isUpdating.current || !canvas) return;
+      selectionEvents.forEach(event => {
+        canvas.off(event as any, handleSelection);
+        canvas.on(event as any, handleSelection);
+      });
 
-    // 객체 상태 직렬화 시 filters 등 커스텀 속성도 포함
-    const json = JSON.stringify(
-      canvas.toObject(['filters', 'id', 'name', 'isLocked'])
-    );
+      // 2. 조작 내역 저장 (Undo/Redo용)
+      const historyEvents = [
+        'object:modified',
+        'object:added',
+        'object:removed',
+      ];
 
-    const prevState = undoStack.current[undoStack.current.length - 1];
-    if (prevState === json) return;
+      const handleHistory = () => saveHistory();
 
-    undoStack.current.push(json);
+      historyEvents.forEach(event => {
+        canvas.off(event as any, handleHistory);
+        canvas.on(event as any, handleHistory);
+      });
+    },
+    [syncActiveObjectInfo, saveHistory]
+  );
 
-    if (undoStack.current.length > MAX_STACK_SIZE) {
-      undoStack.current.shift();
-    }
-
-    if (redoStack.current.length > 0) {
-      redoStack.current.length = 0;
-    }
-  };
-
-  const undo = async () => {
+  const undo = useCallback(async () => {
     if (undoStack.current.length <= 1 || isUpdating.current || !canvas) return;
 
     isUpdating.current = true;
@@ -283,9 +343,12 @@ export const useFabric = () => {
 
     canvas.requestRenderAll();
     isUpdating.current = false;
-  };
+    syncActiveObjectInfo(canvas);
+    setCanUndo(undoStack.current.length > 1);
+    setCanRedo(redoStack.current.length > 0);
+  }, [canvas, syncActiveObjectInfo]);
 
-  const redo = async () => {
+  const redo = useCallback(async () => {
     if (redoStack.current.length === 0 || isUpdating.current || !canvas) return;
 
     isUpdating.current = true;
@@ -309,9 +372,12 @@ export const useFabric = () => {
       canvas.requestRenderAll();
     }
     isUpdating.current = false;
-  };
+    syncActiveObjectInfo(canvas);
+    setCanUndo(undoStack.current.length > 1);
+    setCanRedo(redoStack.current.length > 0);
+  }, [canvas, syncActiveObjectInfo]);
 
-  const exportIntersectedJSON = () => {
+  const exportIntersectedJSON = useCallback(() => {
     if (!canvas) return;
     const canvasWidth = canvas.width;
     const canvasHeight = canvas.height;
@@ -335,7 +401,7 @@ export const useFabric = () => {
     const json = canvas.toObject(propertiesToInclude);
     json.objects = filteredData.map(obj => obj.toObject(propertiesToInclude));
     return json;
-  };
+  }, [canvas]);
 
   return {
     canvas,
@@ -357,5 +423,8 @@ export const useFabric = () => {
     unLock,
     saveHistory,
     exportIntersectedJSON,
+    clipboard,
+    canUndo,
+    canRedo,
   };
 };

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -185,8 +185,9 @@ export const useFabric = () => {
       if (!activeObject || !canvas) return;
       canvas.bringObjectForward(activeObject);
       canvas.requestRenderAll();
+      saveHistory();
     },
-    [canvas]
+    [canvas, saveHistory]
   );
 
   const moveDown = useCallback(
@@ -194,8 +195,9 @@ export const useFabric = () => {
       if (!activeObject || !canvas) return;
       canvas.sendObjectBackwards(activeObject);
       canvas.requestRenderAll();
+      saveHistory();
     },
-    [canvas]
+    [canvas, saveHistory]
   );
 
   const moveTop = useCallback(
@@ -203,8 +205,9 @@ export const useFabric = () => {
       if (!activeObject || !canvas) return;
       canvas.bringObjectToFront(activeObject);
       canvas.requestRenderAll();
+      saveHistory();
     },
-    [canvas]
+    [canvas, saveHistory]
   );
 
   const moveBottom = useCallback(
@@ -212,8 +215,9 @@ export const useFabric = () => {
       if (!activeObject || !canvas) return;
       canvas.sendObjectToBack(activeObject);
       canvas.requestRenderAll();
+      saveHistory();
     },
-    [canvas]
+    [canvas, saveHistory]
   );
 
   const lock = useCallback(

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -139,6 +139,60 @@ export const useFabric = () => {
     saveHistory();
   };
 
+  const moveUp = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    canvas.bringObjectForward(activeObject);
+    canvas.requestRenderAll();
+  };
+
+  const moveDown = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    canvas.sendObjectBackwards(activeObject);
+    canvas.requestRenderAll();
+  };
+
+  const moveTop = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    canvas.bringObjectToFront(activeObject);
+    canvas.requestRenderAll();
+  };
+
+  const moveBottom = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    canvas.sendObjectToBack(activeObject);
+    canvas.requestRenderAll();
+  };
+
+  const lock = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    activeObject.set({
+      lockMovementX: true,
+      lockMovementY: true,
+      lockScalingX: true,
+      lockScalingY: true,
+      lockRotation: true,
+      hasControls: false,
+      editable: false,
+      isLocked: true,
+    });
+    canvas?.requestRenderAll();
+  };
+
+  const unLock = (activeObject: FabricObject) => {
+    if (!activeObject || !canvas) return;
+    activeObject.set({
+      lockMovementX: false,
+      lockMovementY: false,
+      lockScalingX: false,
+      lockScalingY: false,
+      lockRotation: false,
+      hasControls: true,
+      editable: true,
+      isLocked: false,
+    });
+    canvas?.requestRenderAll();
+  };
+
   const syncActiveObjectInfo = (canvas: Canvas) => {
     const activeObjects = canvas.getActiveObjects();
 
@@ -295,6 +349,12 @@ export const useFabric = () => {
     paste,
     redo,
     undo,
+    moveUp,
+    moveDown,
+    moveTop,
+    moveBottom,
+    lock,
+    unLock,
     saveHistory,
     exportIntersectedJSON,
   };

--- a/widgets/mainPoster/hooks/useInitFabricData.ts
+++ b/widgets/mainPoster/hooks/useInitFabricData.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 export const useInitFabricData = () => {
-  const { canvas, initialData } = useFabricContext();
+  const { canvas, initialData, saveHistory } = useFabricContext();
 
   useEffect(() => {
     if (!canvas || !initialData) return;
@@ -12,6 +12,7 @@ export const useInitFabricData = () => {
       try {
         await canvas.loadFromJSON(initialData);
         canvas.requestRenderAll();
+        saveHistory();
       } catch (error) {
         console.error('Failed to load canvas data:', error);
       }

--- a/widgets/mainPoster/hooks/useKeyboardEvents.ts
+++ b/widgets/mainPoster/hooks/useKeyboardEvents.ts
@@ -53,7 +53,7 @@ export const useKeyboardEvents = (
       }
 
       // 잠그기 ctrl + l
-      if (mod && e.code === 'KeyL') {
+      if (mod && !e.shiftKey && e.code === 'KeyL') {
         const activeObj = canvas.getActiveObject();
         const isEditingText =
           activeObj && 'isEditing' in activeObj && activeObj.isEditing;
@@ -97,7 +97,7 @@ export const useKeyboardEvents = (
       }
 
       // 위로 보내기 ctrl + [
-      if (mod && e.code === 'BracketLeft') {
+      if (mod && !e.shiftKey && e.code === 'BracketLeft') {
         const activeObj = canvas.getActiveObject();
         const isEditingText =
           activeObj && 'isEditing' in activeObj && activeObj.isEditing;
@@ -108,7 +108,7 @@ export const useKeyboardEvents = (
       }
 
       // 아래로 보내기 ctrl + ]
-      if (mod && e.code === 'BracketRight') {
+      if (mod && !e.shiftKey && e.code === 'BracketRight') {
         const activeObj = canvas.getActiveObject();
         const isEditingText =
           activeObj && 'isEditing' in activeObj && activeObj.isEditing;

--- a/widgets/mainPoster/hooks/useKeyboardEvents.ts
+++ b/widgets/mainPoster/hooks/useKeyboardEvents.ts
@@ -1,0 +1,173 @@
+import { Canvas } from 'fabric';
+import { useEffect, RefObject } from 'react';
+
+import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
+
+export const useKeyboardEvents = (
+  canvas: Canvas | null,
+  isMouseInCanvasRef: RefObject<boolean>
+) => {
+  const {
+    copy,
+    paste,
+    lock,
+    unLock,
+    moveUp,
+    moveDown,
+    moveTop,
+    moveBottom,
+    undo,
+    redo,
+    handleDeleteShape,
+  } = useFabricContext();
+
+  useEffect(() => {
+    if (!canvas) return;
+
+    const handleKeyboard = (e: KeyboardEvent) => {
+      const hasActiveObj = canvas.getActiveObjects().length > 0;
+      if (!isMouseInCanvasRef.current && !hasActiveObj) return;
+
+      const mod = e.ctrlKey || e.metaKey;
+
+      // 복사 ctrl + c
+      if (mod && e.code === 'KeyC') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          copy();
+        }
+      }
+
+      // 붙여넣기 ctrl + v
+      if (mod && e.code === 'KeyV') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (!isEditingText) {
+          e.preventDefault();
+          paste();
+        }
+      }
+
+      // 잠그기 ctrl + l
+      if (mod && e.code === 'KeyL') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          lock(activeObj);
+        }
+      }
+
+      // 잠금 해제 ctrl + shift + l
+      if (mod && e.shiftKey && e.code === 'KeyL') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          unLock(activeObj);
+        }
+      }
+
+      // 맨 위로 보내기 ctrl + shift + [
+      if (mod && e.shiftKey && e.code === 'BracketLeft') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveTop(activeObj);
+        }
+      }
+
+      // 맨 아래로 보내기 ctrl + shift + ]
+      if (mod && e.shiftKey && e.code === 'BracketRight') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveBottom(activeObj);
+        }
+      }
+
+      // 위로 보내기 ctrl + [
+      if (mod && e.code === 'BracketLeft') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveUp(activeObj);
+        }
+      }
+
+      // 아래로 보내기 ctrl + ]
+      if (mod && e.code === 'BracketRight') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+        if (activeObj && !isEditingText) {
+          e.preventDefault();
+          moveDown(activeObj);
+        }
+      }
+
+      // 삭제 delete
+      if (e.key === 'Delete') {
+        handleDeleteShape(canvas, e);
+      }
+
+      // 되돌리기 ctrl + z
+      if (mod && !e.shiftKey && e.code === 'KeyZ') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+
+        if (!isEditingText) {
+          e.preventDefault();
+          undo();
+        }
+      }
+
+      // 다시하기 ctrl + shift + z
+      if (mod && e.shiftKey && e.code === 'KeyZ') {
+        const activeObj = canvas.getActiveObject();
+        const isEditingText =
+          activeObj && 'isEditing' in activeObj && activeObj.isEditing;
+
+        if (!isEditingText) {
+          e.preventDefault();
+          redo();
+        }
+      }
+
+      if (e.key === 'Escape') {
+        canvas.discardActiveObject();
+        canvas.renderAll();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyboard);
+    return () => window.removeEventListener('keydown', handleKeyboard);
+  }, [
+    canvas,
+    isMouseInCanvasRef,
+    copy,
+    paste,
+    handleDeleteShape,
+    moveUp,
+    moveDown,
+    moveTop,
+    moveBottom,
+    lock,
+    unLock,
+    undo,
+    redo,
+  ]);
+};

--- a/widgets/mainPoster/types/fabric.ts
+++ b/widgets/mainPoster/types/fabric.ts
@@ -114,6 +114,7 @@ export type DragPoints = {
 
 export interface ActiveObject {
   type: string | null;
+  isLocked: boolean;
   filters?: any;
   styles: Record<string, any>;
 }


### PR DESCRIPTION
## 작업 개요

숏컷 추가, 컨텍스트 메뉴 케이스별 처리, im/export 테스트

## 작업 내용

- 숏컷 추가 및 기능 추가
- 컨텍스트 메뉴를 조건에 따라 활성화, 비활성화 처리
- 재편집 페이지 데이터 불러오기 다시 추가
- 재편집시 잠금 상태 반영되도록 변경

## 테스트 결과 보고
import, export 테스트 모두 완료했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 되돌리기/다시하기 UI 및 단축키 추가(Ctrl+Z / Ctrl+Shift+Z).
  * 키보드 단축으로 잠금/해제(Ctrl+L / Ctrl+Shift+L), Z-순서 조정, 복사/붙여넣기(Ctrl+C / Ctrl+V), 삭제(Delete), Escape(선택 해제) 지원.
  * 초기 불러오기 시 잠긴 객체에 대해 이동/스케일/회전/편집 제한을 일관 적용.

* **UX Improvements**
  * 컨텍스트 메뉴 및 버튼에 단축키 표시 추가.
  * 사용 불가 상태에 대한 시각적 피드백(투명도·그레이스케일·커서·레이블 흐림) 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->