### PR TITLE
[style] place 스타일 수정

### DIFF
--- a/components/molecules/selector/Selector.style.ts
+++ b/components/molecules/selector/Selector.style.ts
@@ -1,0 +1,52 @@
+import { cva, VariantProps } from 'class-variance-authority';
+
+export const selectorVariants = cva(
+  'flex items-center justify-between w-full text-sm transition-all overflow-hidden',
+  {
+    variants: {
+      type: {
+        normal: '',
+        editor: '',
+      },
+      isOpen: {
+        true: 'rounded-t-lg border-b-transparent',
+        false: 'rounded-lg',
+      },
+      hasValue: {
+        true: '',
+        false: '',
+      },
+    },
+    compoundVariants: [
+      // normal 타입: isOpen에 따라 배경색 결정
+      {
+        type: 'normal',
+        isOpen: true,
+        className: 'bg-bg-base',
+      },
+      {
+        type: 'normal',
+        isOpen: false,
+        className: 'bg-border-neutral',
+      },
+      // editor 타입: hasValue에 따라 배경색 결정
+      {
+        type: 'editor',
+        hasValue: true,
+        className: 'bg-bg-base',
+      },
+      {
+        type: 'editor',
+        hasValue: false,
+        className: 'bg-border-neutral',
+      },
+    ],
+    defaultVariants: {
+      type: 'editor',
+      isOpen: false,
+      hasValue: false,
+    },
+  }
+);
+
+export type SelectorVariants = VariantProps<typeof selectorVariants>;

--- a/components/molecules/selector/Selector.tsx
+++ b/components/molecules/selector/Selector.tsx
@@ -3,12 +3,15 @@ import React, { useState, useRef, useEffect, ChangeEvent } from 'react';
 
 import { cn } from '@/shared/utils/cn';
 
+import { selectorVariants } from './Selector.style';
+
 interface Option {
   label: string | React.ReactNode;
   value: string;
 }
 
 interface SelectorProps<T> {
+  type?: 'normal' | 'editor';
   options: T[];
   placeholder?: string;
   className?: string;
@@ -18,6 +21,7 @@ interface SelectorProps<T> {
 }
 
 export const Selector = <T extends Option>({
+  type = 'editor',
   options,
   placeholder = '선택',
   className,
@@ -81,13 +85,7 @@ export const Selector = <T extends Option>({
 
   return (
     <div ref={containerRef} className={cn('relative', className)}>
-      <div
-        className={cn(
-          'flex items-center justify-between w-full text-sm transition-all overflow-hidden',
-          hasValue || isCustomInput ? 'bg-bg-base' : 'bg-border-neutral',
-          isOpen ? 'rounded-t-lg border-b-transparent' : 'rounded-lg'
-        )}
-      >
+      <div className={cn(selectorVariants({ type, isOpen, hasValue }))}>
         {isCustomInput ? (
           <input
             ref={inputRef}

--- a/components/organisms/myFamily/MyFamilyPreview.tsx
+++ b/components/organisms/myFamily/MyFamilyPreview.tsx
@@ -31,12 +31,11 @@ export const MyFamilyPreview = ({
   return (
     <MiddlePreviewWrapper
       className={className}
-      enTitle={
-        checkedEnglishTitle && englishTitle && englishTitle.length > 1
-          ? englishTitle
-          : 'MY FAMILY'
-      }
-      koTitle={title && title.length > 1 ? title : '저희 가족을 소개합니다.'}
+      checkedEnglishTitle={checkedEnglishTitle}
+      enTitle={englishTitle}
+      enTitleDefault="MY FAMILY"
+      koTitle={title}
+      koTitleDefault="저희 가족을 소개합니다."
       titleClassName={titleClassName}
       childClassName="w-full flex flex-col gap-6"
       {...rest}

--- a/components/organisms/place/Place.schema.ts
+++ b/components/organisms/place/Place.schema.ts
@@ -2,7 +2,11 @@ export const placeSchema = {
   type: null,
   fields: {
     title: {
-      default: '오시는 길',
+      default: '',
+      required: true,
+    },
+    englishTitle: {
+      default: '',
       required: true,
     },
     country: {
@@ -23,6 +27,10 @@ export const placeSchema = {
     },
     placeTel: {
       default: '',
+      required: true,
+    },
+    checkedEnglishTitle: {
+      default: false,
       required: true,
     },
     openMap: {

--- a/components/organisms/place/Place.tsx
+++ b/components/organisms/place/Place.tsx
@@ -34,10 +34,12 @@ export function Place({ blockInfo, id }: Props) {
 
   const {
     title,
+    englishTitle,
     placeName,
     placeDetail,
     placeAddress,
     placeTel,
+    checkedEnglishTitle,
     openMap,
     openNavi,
     lng,
@@ -76,17 +78,30 @@ export function Place({ blockInfo, id }: Props) {
   return (
     <>
       <NaverMapScript onReady={() => setIsScriptLoaded(true)} />
-      <LeftEditorWrapper className="gap-4" ariaLabel="오시는 길">
-        <NavigationBar>오시는 길</NavigationBar>
-        <TextField
-          label="제목"
-          inputProps={{
-            placeholder: '오시는 길',
-            onChange: e => handleUpdateBlock('title', e.target.value),
-            value: title,
-          }}
-          className="w-full text-center"
-        />
+      <LeftEditorWrapper className="gap-4 pb-3" ariaLabel="오시는 길">
+        <div className="flex flex-col gap-1 w-full">
+          <NavigationBar>오시는 길</NavigationBar>
+          <TextField
+            label="제목"
+            inputProps={{
+              placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+              onChange: e => handleUpdateBlock('title', e.target.value),
+              value: title,
+            }}
+            className="w-full text-center"
+          />
+        </div>
+        {checkedEnglishTitle && (
+          <TextField
+            label="영문제목"
+            inputProps={{
+              placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+              value: englishTitle,
+              onChange: e => handleUpdateBlock('englishTitle', e.target.value),
+            }}
+            className="text-center w-full"
+          />
+        )}
         <section className="flex flex-row gap-2 w-full">
           <Label
             htmlFor="address"
@@ -95,6 +110,8 @@ export function Place({ blockInfo, id }: Props) {
             주소
           </Label>
           <Selector
+            type="normal"
+            className="w-[63px]"
             placeholder="국내"
             options={[
               { value: '국내', label: '국내' },
@@ -157,10 +174,18 @@ export function Place({ blockInfo, id }: Props) {
           }}
           className="w-full text-center"
         />
-        <section className="flex flex-row gap-1 items-center w-full">
-          <Label className="font-semibold">추가 기능</Label>
+        <section className="flex flex-row gap-2 items-center w-full">
+          <Label className="font-semibold">추가기능</Label>
           <div>
-            <div>
+            <div className="flex flex-row gap-2 items-center">
+              <Checkbox
+                onChange={e =>
+                  handleUpdateBlock('checkedEnglishTitle', e.target.checked)
+                }
+                checked={checkedEnglishTitle}
+              >
+                영문 제목 추가
+              </Checkbox>
               <Checkbox
                 direction="right"
                 onChange={() => handleUpdateBlock('openMap', !openMap)}
@@ -174,7 +199,7 @@ export function Place({ blockInfo, id }: Props) {
               onChange={() => handleUpdateBlock('openNavi', !openNavi)}
               checked={openNavi}
             >
-              내비 앱 바로가기 버튼(네이버, 카카오, 티맵)
+              내비 앱 바로가기 버튼(카카오,티맵,네이버)
             </Checkbox>
           </div>
         </section>

--- a/components/organisms/place/PlacePreview.tsx
+++ b/components/organisms/place/PlacePreview.tsx
@@ -22,14 +22,15 @@ export const PlacePreview = ({
   ...rest
 }: Props) => {
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
-  const { placeName, placeDetail, placeAddress, placeTel } = blockInfo.props;
+  const { title, placeName, placeDetail, placeAddress, placeTel } =
+    blockInfo.props;
 
   return (
     <MiddlePreviewWrapper
       className={className}
       titleClassName={titleClassName}
       enTitle="LOCATION"
-      koTitle={blockInfo.props.title}
+      koTitle={title && title.length > 1 ? title : '오시는 길'}
       {...rest}
     >
       <NaverMapScript onReady={() => setIsScriptLoaded(true)} />

--- a/components/organisms/place/PlacePreview.tsx
+++ b/components/organisms/place/PlacePreview.tsx
@@ -22,15 +22,25 @@ export const PlacePreview = ({
   ...rest
 }: Props) => {
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
-  const { title, placeName, placeDetail, placeAddress, placeTel } =
-    blockInfo.props;
+  const {
+    title,
+    englishTitle,
+    placeName,
+    placeDetail,
+    placeAddress,
+    placeTel,
+    checkedEnglishTitle,
+  } = blockInfo.props;
 
   return (
     <MiddlePreviewWrapper
       className={className}
       titleClassName={titleClassName}
-      enTitle="LOCATION"
-      koTitle={title && title.length > 1 ? title : '오시는 길'}
+      checkedEnglishTitle={checkedEnglishTitle}
+      enTitle={englishTitle}
+      enTitleDefault="LOCATION"
+      koTitle={title}
+      koTitleDefault="오시는 길"
       {...rest}
     >
       <NaverMapScript onReady={() => setIsScriptLoaded(true)} />

--- a/components/organisms/wrapper/MiddlePreviewWrapper.tsx
+++ b/components/organisms/wrapper/MiddlePreviewWrapper.tsx
@@ -8,8 +8,11 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   className: string;
   noTitle?: boolean;
   titleClassName?: string;
+  checkedEnglishTitle?: boolean;
   enTitle?: string;
+  enTitleDefault?: string;
   koTitle?: string;
+  koTitleDefault?: string;
   childClassName?: string;
 }
 
@@ -18,8 +21,11 @@ export const MiddlePreviewWrapper = ({
   className,
   noTitle = false,
   titleClassName,
+  checkedEnglishTitle,
   enTitle,
+  enTitleDefault,
   koTitle,
+  koTitleDefault,
   childClassName,
   ...rest
 }: Props) => {
@@ -30,8 +36,14 @@ export const MiddlePreviewWrapper = ({
     >
       {!noTitle && (
         <PreviewTitle
-          enTitle={enTitle}
-          koTitle={koTitle}
+          enTitle={
+            checkedEnglishTitle
+              ? enTitle && enTitle.length > 1
+                ? enTitle
+                : enTitleDefault
+              : ''
+          }
+          koTitle={koTitle && koTitle.length > 1 ? koTitle : koTitleDefault}
           titleClassName={titleClassName}
         />
       )}


### PR DESCRIPTION
## 작업 개요

place 스타일 수정

## 작업 내용

- 셀렉터의 타입을 normal/editor(default)로 구분하여 선택됐을때 회색처리할지 흰배경으로 처리할지 나눌 수 있습니다
- 리치텍스트에서 셀렉터를 쓰는 경우는 editor 타입을, 기본 컴포넌트에서는 normal 타입을 사용하시면 됩니다
  - `<Selector type="normal">` 과 같은 형태로 사용해주시면 됩니다
- 영문제목이 추가됨에 따라 Preivew에서 Title 영역이 개편됐습니다
  - 아래와 같이 defualt값과 커스텀값만 전달해주시면 됩니다
<img width="1192" height="728" alt="code" src="https://github.com/user-attachments/assets/2b53e014-0555-4746-b226-75123a17fcd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 장소 정보에 영문 제목 입력 및 토글 기능 추가

* **개선사항**
  * 네비게이션 지도 앱 순서 변경 (카카오, 티맵, 네이버)
  * 선택자 컴포넌트 스타일링 개선
  * 제목 입력 필드 플레이스홀더 텍스트 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->