### PR TITLE
[feat] 인사말 컴포넌트 영문제목 추가 및 텍스트에디터 셀렉터 짤림 오류 수정

### DIFF
--- a/components/molecules/selector/Selector.tsx
+++ b/components/molecules/selector/Selector.tsx
@@ -150,7 +150,7 @@ export const Selector = <T extends Option>({
         ref={popoverRef}
         popover="auto"
         className={cn(
-          'z-10 rounded-b-lg overflow-y-auto max-h-72 textarea-custom-scrollbar shadow-lg border-none p-0 m-0 fixed',
+          'z-10 rounded-b-lg overflow-y-auto max-h-72 shadow-lg border-none p-0 m-0 fixed list-none',
           selected ? 'bg-bg-base' : 'bg-border-neutral'
         )}
         style={{
@@ -165,7 +165,7 @@ export const Selector = <T extends Option>({
             key={option.value}
             onClick={() => handleSelect(option)}
             className={cn(
-              'flex items-center py-1 text-sm text-text-primary cursor-pointer hover:bg-bg-sub transition-colors',
+              'flex w-full items-center py-1 text-sm text-text-primary cursor-pointer hover:bg-bg-sub transition-colors',
               showCheckbox ? 'pr-2' : 'px-2'
             )}
             role="option"

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -139,7 +139,7 @@ export function TextEditor({
           selected={fontSizeSelected}
           onSelect={handleFontSizeSelect}
           placeholder="폰트 크기"
-          className="font-semibold"
+          className="w-20 font-semibold"
         />
 
         <TextEditorButton
@@ -191,6 +191,8 @@ export function TextEditor({
           options={TEXT_ALIGN_OPTIONS}
           selected={textAlignSelected}
           onSelect={handleTextAlignSelect}
+          className="w-14"
+          showCheckbox={false}
         />
       </div>
 

--- a/components/organisms/greeting/Greeting.schema.ts
+++ b/components/organisms/greeting/Greeting.schema.ts
@@ -7,6 +7,14 @@ export const greetingSchema = {
       default: '인사말',
       required: true,
     },
+    checkedEnglishTitle: {
+      default: false,
+      required: true,
+    },
+    englishTitle: {
+      default: 'INVITATION',
+      required: false,
+    },
     messageJson: {
       default: null as JSONContent | null,
       required: false,

--- a/components/organisms/greeting/Greeting.tsx
+++ b/components/organisms/greeting/Greeting.tsx
@@ -2,6 +2,8 @@ import { Plus } from 'lucide-react';
 import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { UtilityButton } from '@/components/atoms/button';
+import { Label } from '@/components/atoms/label/Label';
+import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { TextEditor } from '@/components/molecules/text-editor';
 import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
@@ -21,6 +23,9 @@ interface Props {
   blockInfo: EditorBlock<'greeting'>;
   id: string;
 }
+
+const DEFAULT_GREETING_TITLE = '인사말';
+const DEFAULT_GREETING_ENGLISH_TITLE = 'INVITATION';
 
 function createParagraphJson(text: string): JSONContent {
   const lines = text.replace(/\r\n/g, '\n').split('\n');
@@ -44,6 +49,12 @@ function createParagraphJson(text: string): JSONContent {
 
 function Greeting({ blockInfo, id }: Props) {
   const updateBlock = useEditorStore(state => state.updateBlock);
+  const {
+    title,
+    checkedEnglishTitle = false,
+    englishTitle = DEFAULT_GREETING_ENGLISH_TITLE,
+    messageJson,
+  } = blockInfo.props;
   const [isSamplePopupOpen, setIsSamplePopupOpen] = useState(false);
   const [editorResetKey, setEditorResetKey] = useState(0);
   const debouncedUpdateMessage = useMemo(
@@ -58,13 +69,39 @@ function Greeting({ blockInfo, id }: Props) {
   );
 
   useEffect(() => {
+    if (title === '') {
+      updateBlock(id, { title: DEFAULT_GREETING_TITLE });
+    }
+  }, [id, title, updateBlock]);
+
+  useEffect(() => {
+    if (englishTitle === '') {
+      updateBlock(id, { englishTitle: DEFAULT_GREETING_ENGLISH_TITLE });
+    }
+  }, [englishTitle, id, updateBlock]);
+
+  useEffect(() => {
     return () => {
       debouncedUpdateMessage.cancel();
     };
   }, [debouncedUpdateMessage]);
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { title: e.target.value });
+    const nextTitle = e.target.value;
+    updateBlock(id, { title: nextTitle || DEFAULT_GREETING_TITLE });
+  };
+
+  const handleEnglishTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextEnglishTitle = e.target.value;
+    updateBlock(id, {
+      englishTitle: nextEnglishTitle || DEFAULT_GREETING_ENGLISH_TITLE,
+    });
+  };
+
+  const handleEnglishTitleCheckedChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    updateBlock(id, { checkedEnglishTitle: e.target.checked });
   };
 
   const handleEditorChange = (json: JSONContent) => {
@@ -84,17 +121,33 @@ function Greeting({ blockInfo, id }: Props) {
   };
 
   return (
-    <LeftEditorWrapper ariaLabel="인사말">
+    <LeftEditorWrapper ariaLabel="인사말" className="gap-4">
       <NavigationBar>인사말</NavigationBar>
       <TextField
+        key={`title-${id}`}
         label="제목"
         inputProps={{
-          placeholder: '제목을 입력해 주세요',
-          value: blockInfo.props.title,
+          placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+          defaultValue: title === DEFAULT_GREETING_TITLE ? '' : title,
           onChange: handleTitleChange,
         }}
         className="text-center w-full"
       />
+      {checkedEnglishTitle && (
+        <TextField
+          key={`english-title-${id}`}
+          label="영문제목"
+          inputProps={{
+            placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+            defaultValue:
+              englishTitle === DEFAULT_GREETING_ENGLISH_TITLE
+                ? ''
+                : englishTitle,
+            onChange: handleEnglishTitleChange,
+          }}
+          className="text-center w-full"
+        />
+      )}
 
       <NavigationBar
         action={
@@ -114,11 +167,21 @@ function Greeting({ blockInfo, id }: Props) {
 
       <TextEditor
         key={`${id}-${editorResetKey}`}
-        value={blockInfo.props.messageJson}
+        value={messageJson}
         defaultText="내용을 입력해 주세요"
         defaultAlign="center"
         onChange={handleEditorChange}
       />
+
+      <section className="flex flex-row gap-2 items-center w-full">
+        <Label className="font-semibold">추가기능</Label>
+        <Checkbox
+          checked={checkedEnglishTitle}
+          onChange={handleEnglishTitleCheckedChange}
+        >
+          영문 제목 추가
+        </Checkbox>
+      </section>
 
       {isSamplePopupOpen && (
         <PopupOptions

--- a/components/organisms/greeting/GreetingPreview.tsx
+++ b/components/organisms/greeting/GreetingPreview.tsx
@@ -17,15 +17,24 @@ function GreetingPreview({
   titleClassName,
   ...rest
 }: Props) {
+  const {
+    title,
+    checkedEnglishTitle = false,
+    englishTitle = '',
+    messageJson,
+    messageHtml,
+  } = blockInfo.props;
   const html =
-    blockInfo.props.messageHtml ??
-    tiptapJsonToHtmlUniversal(blockInfo.props.messageJson);
+    messageHtml ?? tiptapJsonToHtmlUniversal(messageJson);
 
   return (
     <MiddlePreviewWrapper
       className={className}
-      enTitle="INVITATION"
-      koTitle={blockInfo.props.title}
+      checkedEnglishTitle={checkedEnglishTitle}
+      enTitle={englishTitle}
+      enTitleDefault="INVITATION"
+      koTitle={title}
+      koTitleDefault="인사말"
       titleClassName={titleClassName}
       {...rest}
     >


### PR DESCRIPTION
## 작업 개요

그리팅 컴포넌트에 영문 제목 추가 기능을 적용하고, 텍스트 에디터 드롭다운 UI 깨짐을 수정했습니다.

## 작업 내용

- [x] 그리팅 컴포넌트에 영문 제목 추가 체크박스 및 입력 필드 추가
- [x] 그리팅 제목/영문 제목 기본값 및 프리뷰 표시 처리 수정
- [x] 텍스트 에디터 폰트 크기/문단정렬 드롭다운 잘림 및 hover 배경 영역 문제 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npx eslint components\organisms\greeting\...` 통과
- `npx eslint components\molecules\text-editor\TextEditor.tsx components\molecules\selector\Selector.tsx` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인사말 블록에서 영문제목을 선택적으로 설정하고 표시할 수 있는 기능이 추가되었습니다.

## 개선 사항
* 편집 도구의 다양한 UI 컨트롤(선택기, 텍스트 정렬 등)의 레이아웃과 스타일이 개선되었습니다.
* 한글과 영문 제목을 동시에 관리할 수 있는 인터페이스가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->