### PR TITLE
[feat] 신랑 신부 소개 영문제목 추가 및 디자인 수정

### DIFF
--- a/components/organisms/couple-introduction/CoupleIntroduction.schema.ts
+++ b/components/organisms/couple-introduction/CoupleIntroduction.schema.ts
@@ -24,7 +24,15 @@ export const coupleIntroductionSchema = {
       required: false,
     },
     title: {
-      default: '',
+      default: '신랑・신부 소개',
+      required: false,
+    },
+    checkedEnglishTitle: {
+      default: false,
+      required: false,
+    },
+    englishTitle: {
+      default: 'INTRODUCTION',
       required: false,
     },
     messageJson: {

--- a/components/organisms/couple-introduction/CoupleIntroduction.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroduction.tsx
@@ -19,6 +19,9 @@ interface Props {
   id: string;
 }
 
+const DEFAULT_COUPLE_INTRODUCTION_TITLE = '신랑・신부 소개';
+const DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE = 'INTRODUCTION';
+
 function CoupleIntroduction({ blockInfo, id }: Props) {
   const updateBlock = useEditorStore(state => state.updateBlock);
   const updateImage = useEditorStore(state => state.updateImage);
@@ -27,9 +30,10 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
     bride = '',
     groomImage = [],
     brideImage = [],
-    title = '',
+    title = DEFAULT_COUPLE_INTRODUCTION_TITLE,
+    checkedEnglishTitle = false,
+    englishTitle = DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE,
     messageJson = null,
-    showTitle = false,
     showContent = false,
     brideFirst = false,
   } = blockInfo.props;
@@ -44,6 +48,20 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
       }, 300),
     [id, updateBlock]
   );
+
+  useEffect(() => {
+    if (title === '') {
+      updateBlock(id, { title: DEFAULT_COUPLE_INTRODUCTION_TITLE });
+    }
+  }, [id, title, updateBlock]);
+
+  useEffect(() => {
+    if (englishTitle === '') {
+      updateBlock(id, {
+        englishTitle: DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE,
+      });
+    }
+  }, [englishTitle, id, updateBlock]);
 
   useEffect(() => {
     return () => {
@@ -84,7 +102,18 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
   };
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { title: e.target.value });
+    const nextTitle = e.target.value;
+    updateBlock(id, {
+      title: nextTitle || DEFAULT_COUPLE_INTRODUCTION_TITLE,
+    });
+  };
+
+  const handleEnglishTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextEnglishTitle = e.target.value;
+    updateBlock(id, {
+      englishTitle:
+        nextEnglishTitle || DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE,
+    });
   };
 
   const handleEditorChange = (json: JSONContent) => {
@@ -142,15 +171,43 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
     <LeftEditorWrapper className="items-start" ariaLabel="신랑 신부 소개">
       <NavigationBar>신랑・신부 소개</NavigationBar>
 
-      {profileFields.map((profile, index) => (
+      <TextField
+        key={`title-${id}`}
+        label="제목"
+        inputProps={{
+          placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+          defaultValue:
+            title === DEFAULT_COUPLE_INTRODUCTION_TITLE ? '' : title,
+          onChange: handleTitleChange,
+        }}
+        className="w-full text-center py-1.5"
+      />
+
+      {checkedEnglishTitle && (
+        <TextField
+          key={`english-title-${id}`}
+          label="영문제목"
+          inputProps={{
+            placeholder: '입력하지 않을 시 기본 문구로 작성됩니다.',
+            defaultValue:
+              englishTitle === DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE
+                ? ''
+                : englishTitle,
+            onChange: handleEnglishTitleChange,
+          }}
+          className="w-full text-center py-1.5"
+        />
+      )}
+
+      <div className="w-15 flex flex-col items-center gap-1">
+        <div className="w-0.5 h-1.5 rounded-sm bg-text-secondary" />
+        <div className="w-0.5 h-2 rounded-sm bg-text-secondary" />
+        <div className="w-0.5 h-1.5 rounded-sm bg-text-secondary" />
+      </div>
+
+      {profileFields.map(profile => (
         <Fragment key={profile.key}>
           <div className="flex flex-col gap-2 w-full">
-            {index !== 0 && (
-              <div className="flex flex-col items-center gap-1">
-                <div className="w-0.5 h-1 rounded-sm bg-text-secondary" />
-                <div className="w-0.5 h-1 rounded-sm bg-text-secondary" />
-              </div>
-            )}
             <TextField
               label={profile.label}
               inputProps={{
@@ -173,19 +230,6 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
         </Fragment>
       ))}
 
-      {/* 제목 추가 체크박스가 true일때. */}
-      {showTitle && (
-        <TextField
-          label="제목"
-          inputProps={{
-            placeholder: '제목을 입력해 주세요.',
-            value: title,
-            onChange: handleTitleChange,
-          }}
-          className="w-full text-center py-1.5"
-        />
-      )}
-
       {/* 내용 추가 체크박스가 true일때. */}
       {showContent && (
         <>
@@ -207,12 +251,14 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
           <div className="flex gap-2">
             <Checkbox
               className="gap-1 pl-1 font-medium text-text-secondary"
-              checked={showTitle}
-              onChange={e => updateBlock(id, { showTitle: e.target.checked })}
+              checked={checkedEnglishTitle}
+              onChange={e =>
+                updateBlock(id, { checkedEnglishTitle: e.target.checked })
+              }
             >
-              제목 추가
+              영문 제목 추가
             </Checkbox>
-            
+
             <Checkbox
               className="gap-1 pl-1 font-medium text-text-secondary"
               checked={showContent}

--- a/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
@@ -34,9 +34,10 @@ function CoupleIntroductionPreview({
     brideImage = [],
     images = [],
     title = '',
+    checkedEnglishTitle = false,
+    englishTitle = '',
     messageJson = null,
     messageHtml = null,
-    showTitle = false,
     showContent = false,
     brideFirst = false,
   } = blockInfo.props;
@@ -101,8 +102,11 @@ function CoupleIntroductionPreview({
     <MiddlePreviewWrapper
       className={className}
       titleClassName={titleClassName}
-      enTitle="INTRODUCTION"
-      koTitle={showTitle && title ? title : '신랑・신부 소개'}
+      checkedEnglishTitle={checkedEnglishTitle}
+      enTitle={englishTitle}
+      enTitleDefault="INTRODUCTION"
+      koTitle={title}
+      koTitleDefault="신랑・신부 소개"
       {...rest}
     >
       <div className="flex flex-row gap-4.5">


### PR DESCRIPTION
## 작업 개요

커플인트로덕션 컴포넌트의 제목/영문 제목 동작을 수정하고, 텍스트 에디터 드롭다운 UI 문제를 개선했습니다.

## 작업 내용

- [x] 커플인트로덕션 제목을 항상 노출되도록 변경
- [x] 커플인트로덕션 영문 제목 추가 기능 적용
- [x] 커플인트로덕션 디바이더 위치 및 표시 방식 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npx eslint components\organisms\couple-introduction\...` 통과
- `npx eslint components\molecules\text-editor\TextEditor.tsx components\molecules\selector\Selector.tsx` 통과
