### PR TITLE
[feat] 연락처 컴포넌트 리뉴얼

### DIFF
--- a/components/organisms/phone/Phone.schema.ts
+++ b/components/organisms/phone/Phone.schema.ts
@@ -1,13 +1,10 @@
-type PhoneContact = {
-  label: string;
-  number: string;
-};
+import { PhoneGroup } from './utils/phone.types';
 
 export const phoneSchema = {
   type: null,
   fields: {
-    contacts: {
-      default: [] as PhoneContact[],
+    groups: {
+      default: [] as PhoneGroup[],
       required: true,
     },
   },

--- a/components/organisms/phone/Phone.tsx
+++ b/components/organisms/phone/Phone.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Button, UtilityButton } from '@/components/atoms/button';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
@@ -33,13 +33,12 @@ function Phone({ blockInfo, id }: Props) {
   const [openContactMenuId, setOpenContactMenuId] = useState<string | null>(
     null
   );
-  const [groups, setGroups] = useState<PhoneGroup[]>(() => [
-    ...getInitialPhoneGroups(blockInfo.props.groups),
-  ]);
-
-  useEffect(() => {
-    updateBlock(id, { groups });
-  }, [groups, id, updateBlock]);
+  const fallbackGroupsByIdRef = useRef<Record<string, PhoneGroup[]>>({});
+  const storedGroups = blockInfo.props.groups;
+  const groups =
+    storedGroups && storedGroups.length > 0
+      ? storedGroups
+      : (fallbackGroupsByIdRef.current[id] ??= getInitialPhoneGroups());
 
   useEffect(() => {
     if (!openContactMenuId) return;
@@ -55,29 +54,29 @@ function Phone({ blockInfo, id }: Props) {
     };
   }, [openContactMenuId]);
 
-  const handleDeleteContact = (groupIndex: number, contactId: string) => {
-    setGroups(prevGroups =>
-      deletePhoneContact(prevGroups, groupIndex, contactId)
-    );
-    setOpenContactMenuId(null);
+  const updateGroups = (nextGroups: PhoneGroup[]) => {
+    updateBlock(id, { groups: nextGroups });
   };
 
   const handleAddContact = (groupIndex: number) => {
-    setGroups(prevGroups => addPhoneContact(prevGroups, groupIndex));
+    updateGroups(addPhoneContact(groups, groupIndex));
   };
 
   const handleAddGroup = () => {
-    setGroups(addPhoneGroup);
+    updateGroups(addPhoneGroup(groups));
   };
 
   const handleDeleteGroup = (groupId: string) => {
-    setGroups(prevGroups => deletePhoneGroup(prevGroups, groupId));
+    updateGroups(deletePhoneGroup(groups, groupId));
+  };
+
+  const handleDeleteContact = (groupIndex: number, contactId: string) => {
+    updateGroups(deletePhoneContact(groups, groupIndex, contactId));
+    setOpenContactMenuId(null);
   };
 
   const handleGroupNameChange = (groupIndex: number, name: string) => {
-    setGroups(prevGroups =>
-      updatePhoneGroupName(prevGroups, groupIndex, name)
-    );
+    updateGroups(updatePhoneGroupName(groups, groupIndex, name));
   };
 
   const handleContactLabelChange = (
@@ -85,8 +84,8 @@ function Phone({ blockInfo, id }: Props) {
     contactIndex: number,
     label: string
   ) => {
-    setGroups(prevGroups =>
-      updatePhoneContactLabel(prevGroups, groupIndex, contactIndex, label)
+    updateGroups(
+      updatePhoneContactLabel(groups, groupIndex, contactIndex, label)
     );
   };
 
@@ -95,8 +94,8 @@ function Phone({ blockInfo, id }: Props) {
     contactIndex: number,
     number: string
   ) => {
-    setGroups(prevGroups =>
-      updatePhoneContactNumber(prevGroups, groupIndex, contactIndex, number)
+    updateGroups(
+      updatePhoneContactNumber(groups, groupIndex, contactIndex, number)
     );
   };
 

--- a/components/organisms/phone/Phone.tsx
+++ b/components/organisms/phone/Phone.tsx
@@ -1,129 +1,165 @@
-﻿import { ChangeEvent, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { UtilityButton } from '@/components/atoms/button';
-import { MultiField } from '@/components/molecules/multi-field';
+import { Button, UtilityButton } from '@/components/atoms/button';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
+import { Popup } from '@/components/organisms/popup/Popup';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
 
-type PhoneContact = {
-  label: string;
-  number: string;
-};
-
-const MAX_MULTI_FIELDS = 10;
-const EMPTY_CONTACT: PhoneContact = { label: '', number: '' };
+import { PhoneGroupEdit } from './components/PhoneGroupEdit';
+import { PhoneGroupSection } from './components/PhoneGroupSection';
+import { getInitialPhoneGroups } from './utils/createPhoneGroup';
+import { MAX_PHONE_GROUPS } from './utils/phone.constants';
+import { PhoneGroup } from './utils/phone.types';
+import {
+  addPhoneContact,
+  addPhoneGroup,
+  deletePhoneContact,
+  deletePhoneGroup,
+  updatePhoneContactLabel,
+  updatePhoneContactNumber,
+  updatePhoneGroupName,
+} from './utils/updatePhoneGroups';
 
 interface Props {
   blockInfo: EditorBlock<'phone'>;
   id: string;
 }
 
-// 연락처가 하나도 없을 때도 입력할 수 있도록 최소 1행은 화면에 노출한다.
-function createInitialRows(contacts: PhoneContact[]) {
-  return contacts.length > 0 ? contacts : [EMPTY_CONTACT];
-}
-
-// 저장 제외 기준: 명칭/번호가 모두 비어 있으면 빈 행으로 본다.
-function isEmptyContact(contact: PhoneContact) {
-  return (
-    contact.label.trim().length === 0 && contact.number.trim().length === 0
-  );
-}
-
-// 스토어에는 유효한 연락처만 저장하고, 빈 행은 로컬 UI 상태로만 유지한다.
-function sanitizeContacts(contacts: PhoneContact[]) {
-  return contacts.filter(contact => !isEmptyContact(contact));
-}
-
-// 연락처 번호는 숫자만 저장되도록 정규화한다.
-function normalizeContactValue(key: 'label' | 'number', value: string): string {
-  if (key === 'number') {
-    return value.replace(/\D/g, '');
-  }
-
-  return value;
-}
-
 function Phone({ blockInfo, id }: Props) {
   const updateBlock = useEditorStore(state => state.updateBlock);
-  const storedContacts = blockInfo.props.contacts ?? [];
-  const [rowsById, setRowsById] = useState<Record<string, PhoneContact[]>>({});
-  const rows = rowsById[id] ?? createInitialRows(storedContacts);
-  const lastRow = rows[rows.length - 1] ?? EMPTY_CONTACT;
-  const isAddDisabled =
-    rows.length >= MAX_MULTI_FIELDS || isEmptyContact(lastRow);
+  const [isGroupPopupOpen, setIsGroupPopupOpen] = useState(false);
+  const [openContactMenuId, setOpenContactMenuId] = useState<string | null>(
+    null
+  );
+  const [groups, setGroups] = useState<PhoneGroup[]>(() => [
+    ...getInitialPhoneGroups(blockInfo.props.groups),
+  ]);
 
-  // 현재 블록(id)에 해당하는 로컬 입력 행 상태를 갱신한다.
-  const setRowsForCurrentBlock = (nextRows: PhoneContact[]) => {
-    setRowsById(prev => ({
-      ...prev,
-      [id]: nextRows,
-    }));
-  };
+  useEffect(() => {
+    updateBlock(id, { groups });
+  }, [groups, id, updateBlock]);
 
-  // 로컬 입력 상태에서 빈 행을 제거한 뒤 editor store에 반영한다.
-  const persistContacts = (nextRows: PhoneContact[]) => {
-    updateBlock(id, { contacts: sanitizeContacts(nextRows) });
-  };
+  useEffect(() => {
+    if (!openContactMenuId) return;
 
-  // 각 입력 필드(label/number) 변경을 처리한다.
-  const handleContactChange =
-    (index: number, key: 'label' | 'number') =>
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const normalizedValue = normalizeContactValue(key, e.target.value);
-      const nextRows = rows.map((contact, contactIndex) =>
-        contactIndex === index
-          ? { ...contact, [key]: normalizedValue }
-          : contact
-      );
-
-      setRowsForCurrentBlock(nextRows);
-      persistContacts(nextRows);
+    const handleClickOutside = () => {
+      setOpenContactMenuId(null);
     };
 
-  // 마지막 행이 비어있지 않을 때만 새 빈 행을 추가한다.
-  const handleAddUtility = () => {
-    if (isAddDisabled) {
-      return;
-    }
+    document.addEventListener('click', handleClickOutside);
 
-    setRowsForCurrentBlock([...rows, { ...EMPTY_CONTACT }]);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [openContactMenuId]);
+
+  const handleDeleteContact = (groupIndex: number, contactId: string) => {
+    setGroups(prevGroups =>
+      deletePhoneContact(prevGroups, groupIndex, contactId)
+    );
+    setOpenContactMenuId(null);
+  };
+
+  const handleAddContact = (groupIndex: number) => {
+    setGroups(prevGroups => addPhoneContact(prevGroups, groupIndex));
+  };
+
+  const handleAddGroup = () => {
+    setGroups(addPhoneGroup);
+  };
+
+  const handleDeleteGroup = (groupId: string) => {
+    setGroups(prevGroups => deletePhoneGroup(prevGroups, groupId));
+  };
+
+  const handleGroupNameChange = (groupIndex: number, name: string) => {
+    setGroups(prevGroups =>
+      updatePhoneGroupName(prevGroups, groupIndex, name)
+    );
+  };
+
+  const handleContactLabelChange = (
+    groupIndex: number,
+    contactIndex: number,
+    label: string
+  ) => {
+    setGroups(prevGroups =>
+      updatePhoneContactLabel(prevGroups, groupIndex, contactIndex, label)
+    );
+  };
+
+  const handleContactNumberChange = (
+    groupIndex: number,
+    contactIndex: number,
+    number: string
+  ) => {
+    setGroups(prevGroups =>
+      updatePhoneContactNumber(prevGroups, groupIndex, contactIndex, number)
+    );
+  };
+
+  const handleContactMenuToggle = (contactId: string) => {
+    setOpenContactMenuId(currentId =>
+      currentId === contactId ? null : contactId
+    );
   };
 
   return (
     <LeftEditorWrapper ariaLabel="연락처">
-      <NavigationBar>연락처</NavigationBar>
-      {rows.map((contact, index) => (
-        <MultiField
-          key={`phone-multi-field-${index}`}
-          label="명칭 & 번호"
-          subInputProps={{
-            size: 'fixed',
-            className: 'w-[85px]',
-            placeholder: '명칭',
-            value: contact.label,
-            maxLength: 15,
-            onChange: handleContactChange(index, 'label'),
-          }}
-          mainInputProps={{
-            size: 'full',
-            type: 'tel',
-            inputMode: 'numeric',
-            pattern: '[0-9]*',
-            placeholder: '010-1234-5678',
-            value: contact.number,
-            onChange: handleContactChange(index, 'number'),
-          }}
-          className="py-1.5"
+      <NavigationBar
+        action={
+          <UtilityButton
+            size="md"
+            variant="primary"
+            onClick={() => setIsGroupPopupOpen(true)}
+          >
+            그룹편집
+          </UtilityButton>
+        }
+        direction="right"
+      >
+        연락처
+      </NavigationBar>
+
+      {groups.map((group, groupIndex) => (
+        <PhoneGroupSection
+          key={`phone-group-${group.id}`}
+          group={group}
+          groupIndex={groupIndex}
+          openContactMenuId={openContactMenuId}
+          onAddContact={handleAddContact}
+          onContactDelete={handleDeleteContact}
+          onContactLabelChange={handleContactLabelChange}
+          onContactMenuToggle={handleContactMenuToggle}
+          onContactNumberChange={handleContactNumberChange}
+          onGroupNameChange={handleGroupNameChange}
         />
       ))}
-      <div className="w-full h-8 flex justify-center">
-        <UtilityButton onClick={handleAddUtility} disabled={isAddDisabled}>
-          추가 +
-        </UtilityButton>
-      </div>
+
+      <Button
+        size="md"
+        variant="borderless"
+        onClick={handleAddGroup}
+        disabled={groups.length >= MAX_PHONE_GROUPS}
+        className="text-primary"
+      >
+        + 그룹 추가
+      </Button>
+
+      {isGroupPopupOpen && (
+        <Popup
+          popupTitle="그룹 편집"
+          onClose={() => setIsGroupPopupOpen(false)}
+          wrapperClassName="w-[200px] pt-1 pb-4"
+        >
+          <PhoneGroupEdit
+            groups={groups}
+            onDeleteGroup={handleDeleteGroup}
+          />
+        </Popup>
+      )}
     </LeftEditorWrapper>
   );
 }

--- a/components/organisms/phone/PhonePreview.tsx
+++ b/components/organisms/phone/PhonePreview.tsx
@@ -13,7 +13,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 function PhonePreview({ blockInfo, className, ...rest }: Props) {
   return (
     <MiddlePreviewWrapper noTitle={true} className={className} {...rest}>
-      <PhonePreviewPopup contacts={blockInfo.props.contacts} />
+      <PhonePreviewPopup groups={blockInfo.props.groups} />
     </MiddlePreviewWrapper>
   );
 }

--- a/components/organisms/phone/components/PhoneContactField.tsx
+++ b/components/organisms/phone/components/PhoneContactField.tsx
@@ -1,0 +1,78 @@
+import { CircleMinus, EllipsisVertical } from 'lucide-react';
+
+import { MultiField } from '@/components/molecules/multi-field';
+
+import { formatPhoneNumber } from '../utils/formatPhoneNumber';
+import { PhoneContact } from '../utils/phone.types';
+
+interface PhoneContactFieldProps {
+  contact: PhoneContact;
+  isMenuOpen: boolean;
+  canDelete: boolean;
+  onLabelChange: (label: string) => void;
+  onNumberChange: (number: string) => void;
+  onDelete: () => void;
+  onMenuToggle: () => void;
+}
+
+export function PhoneContactField({
+  contact,
+  isMenuOpen,
+  canDelete,
+  onLabelChange,
+  onNumberChange,
+  onDelete,
+  onMenuToggle,
+}: PhoneContactFieldProps) {
+  return (
+    <div className="relative flex w-full items-center gap-1.5 py-1.5">
+      <MultiField
+        label="연락처"
+        subInputProps={{
+          size: 'fixed',
+          className: 'w-[65px] h-8',
+          placeholder: '명칭',
+          value: contact.label,
+          onChange: e => onLabelChange(e.target.value),
+        }}
+        mainInputProps={{
+          size: 'full',
+          type: 'tel',
+          inputMode: 'numeric',
+          className: 'flex-1',
+          placeholder: '번호를 기입해 주세요.',
+          value: formatPhoneNumber(contact.number),
+          onChange: e => onNumberChange(e.target.value),
+        }}
+        className="min-w-0 flex-1"
+      />
+      <button
+        type="button"
+        aria-label="연락처 메뉴"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg hover:bg-btn-hover active:bg-btn-pressed"
+        onClick={event => {
+          event.stopPropagation();
+          onMenuToggle();
+        }}
+      >
+        <EllipsisVertical className="size-6 text-black" />
+      </button>
+      {isMenuOpen && (
+        <div
+          className="absolute right-0 top-10 z-10 rounded-lg border border-border-neutral bg-white shadow-edit"
+          onClick={event => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            disabled={!canDelete}
+            className="flex w-21.5 h-8 items-center gap-4 whitespace-nowrap px-2 text-sm enabled:hover:bg-btn-hover disabled:cursor-not-allowed disabled:text-btn-disabled"
+            onClick={onDelete}
+          >
+            <CircleMinus className="h-4 w-4" />
+            삭제
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/organisms/phone/components/PhoneGroupEdit.tsx
+++ b/components/organisms/phone/components/PhoneGroupEdit.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/atoms/button';
+
+import { PhoneGroup } from '../utils/phone.types';
+
+interface PhoneGroupEditProps {
+  groups: PhoneGroup[];
+  onDeleteGroup: (groupId: string) => void;
+}
+
+export function PhoneGroupEdit({ groups, onDeleteGroup }: PhoneGroupEditProps) {
+  return (
+    <div className="flex flex-col gap-4 items-center w-full">
+      {groups.map((group, index) => (
+        <div
+          key={`phone-group-edit-${group.id}`}
+          className="flex flex-col gap-2 items-start w-full"
+        >
+          <div className="flex items-center justify-between w-full">
+            <p className="text-text-primary text-sm font-semibold">
+              {group.name || `${index + 1}번 그룹`}
+            </p>
+            {groups.length > 1 && (
+              <Button
+                size="sm"
+                variant="borderless"
+                onClick={() => onDeleteGroup(group.id)}
+                type="button"
+                className="text-btn-close flex items-center px-2 justify-end w-fit"
+              >
+                삭제
+              </Button>
+            )}
+          </div>
+          <div className="border-l border-text-secondary ml-2 pl-2 w-full">
+            {group.contacts.map((contact, contactIndex) => (
+              <div
+                key={`phone-group-edit-${group.id}-contact-${contact.id}`}
+                className="flex items-center justify-between h-8"
+              >
+                <p className="text-text-secondary font-semibold text-xs">
+                  {contact.label || `연락처 ${contactIndex + 1}번`}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/organisms/phone/components/PhoneGroupSection.tsx
+++ b/components/organisms/phone/components/PhoneGroupSection.tsx
@@ -1,0 +1,88 @@
+import { Fragment } from 'react';
+
+import { Divider } from '@/components/atoms/divider';
+import { ActionField } from '@/components/molecules/action-field';
+
+import { MAX_CONTACTS_PER_GROUP } from '../utils/phone.constants';
+import { PhoneGroup } from '../utils/phone.types';
+
+import { PhoneContactField } from './PhoneContactField';
+
+interface PhoneGroupSectionProps {
+  group: PhoneGroup;
+  groupIndex: number;
+  openContactMenuId: string | null;
+  onAddContact: (groupIndex: number) => void;
+  onContactDelete: (groupIndex: number, contactId: string) => void;
+  onContactLabelChange: (
+    groupIndex: number,
+    contactIndex: number,
+    label: string
+  ) => void;
+  onContactMenuToggle: (contactId: string) => void;
+  onContactNumberChange: (
+    groupIndex: number,
+    contactIndex: number,
+    number: string
+  ) => void;
+  onGroupNameChange: (groupIndex: number, name: string) => void;
+}
+
+export function PhoneGroupSection({
+  group,
+  groupIndex,
+  openContactMenuId,
+  onAddContact,
+  onContactDelete,
+  onContactLabelChange,
+  onContactMenuToggle,
+  onContactNumberChange,
+  onGroupNameChange,
+}: PhoneGroupSectionProps) {
+  return (
+    <Fragment>
+      {groupIndex > 0 && (
+        <div className="w-full flex py-1.5">
+          <Divider
+            className="w-14.25 -translate-x-2 items-center"
+            padding="none"
+          />
+        </div>
+      )}
+
+      <ActionField
+        label="그룹명"
+        inputProps={{
+          placeholder: '그룹명(선택사항)',
+          value: group.name,
+          onChange: e => onGroupNameChange(groupIndex, e.target.value),
+        }}
+        buttonProps={{
+          size: 'sm',
+          children: '연락처 추가',
+          disabled: group.contacts.length >= MAX_CONTACTS_PER_GROUP,
+          onClick: () => onAddContact(groupIndex),
+          className: 'w-[76px] h-8',
+        }}
+        className="w-full py-1.5"
+      />
+
+      {group.contacts.map((contact, contactIndex) => (
+        <PhoneContactField
+          key={`phone-group-${group.id}-contact-field-${contact.id}`}
+          contact={contact}
+          isMenuOpen={openContactMenuId === contact.id}
+          canDelete={group.contacts.length > 1}
+          onMenuToggle={() => onContactMenuToggle(contact.id)}
+          onDelete={() => onContactDelete(groupIndex, contact.id)}
+          onLabelChange={label =>
+            onContactLabelChange(groupIndex, contactIndex, label)
+          }
+          onNumberChange={number =>
+            onContactNumberChange(groupIndex, contactIndex, number)
+          }
+        />
+      ))}
+    </Fragment>
+  );
+}

--- a/components/organisms/phone/components/PhonePreviewPopup.tsx
+++ b/components/organisms/phone/components/PhonePreviewPopup.tsx
@@ -7,21 +7,25 @@ import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationB
 import Message from '@/shared/assets/icons/message.svg';
 import PhoneIcon from '@/shared/assets/icons/phoneIcon.svg';
 
-type PhoneContact = {
-  label: string;
-  number: string;
-};
+import { PhoneGroup } from '../utils/phone.types';
 
 interface Props {
-  contacts?: PhoneContact[];
+  groups?: PhoneGroup[];
 }
 
-function PhonePreviewPopup({ contacts = [] }: Props) {
+function PhonePreviewPopup({ groups = [] }: Props) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const visibleContacts = contacts.filter(
-    contact =>
-      contact.label.trim().length > 0 || contact.number.trim().length > 0
-  );
+  const visibleGroups = groups
+    .map(group => ({
+      ...group,
+      contacts: group.contacts.filter(
+        contact =>
+          contact.label.trim().length > 0 || contact.number.trim().length > 0
+      ),
+    }))
+    .filter(
+      group => group.name.trim().length > 0 || group.contacts.length > 0
+    );
 
   return (
     <>
@@ -64,38 +68,56 @@ function PhonePreviewPopup({ contacts = [] }: Props) {
             </NavigationBar>
 
             <ul className="max-h-120 overflow-y-auto space-y-2 pr-1">
-              {visibleContacts.length === 0 && (
+              {visibleGroups.length === 0 && (
                 <li className="px-2 py-3 text-sm text-text-secondary text-center">
                   표시할 연락처가 없습니다.
                 </li>
               )}
 
-              {visibleContacts.map((contact, index) => (
-                <li
-                  key={`${contact.label}-${contact.number}-${index}`}
-                  className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg hover:bg-black/5 transition-colors"
-                >
-                  <p className="text-sm font-semibold text-text-primary">
-                    {contact.label || `연락처 ${index + 1}`}
-                  </p>
+              {visibleGroups.map((group, groupIndex) => (
+                <li key={group.id} className="space-y-1">
+                  {(group.name || visibleGroups.length > 1) && (
+                    <p className="px-3 pt-2 text-xs font-semibold text-text-secondary text-left">
+                      {group.name || `${groupIndex + 1}번 그룹`}
+                    </p>
+                  )}
 
-                  <div className="flex items-center gap-2">
-                    <a
-                      href={`tel:${contact.number}`}
-                      aria-label="전화 걸기"
-                      className="flex items-center justify-center w-9 h-9 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
-                    >
-                      <PhoneIcon className="w-7 h-7 text-text-secondary" />
-                    </a>
+                  <ul className="space-y-1">
+                    {group.contacts.length === 0 && (
+                      <li className="px-3 py-2 text-sm text-text-secondary text-center">
+                        표시할 연락처가 없습니다.
+                      </li>
+                    )}
 
-                    <a
-                      href={`sms:${contact.number}`}
-                      aria-label="문자 보내기"
-                      className="flex items-center justify-center w-9 h-9 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
-                    >
-                      <Message className="w-5 h-5 text-text-secondary" />
-                    </a>
-                  </div>
+                    {group.contacts.map((contact, contactIndex) => (
+                      <li
+                        key={contact.id}
+                        className="flex items-center justify-between gap-3 py-2 pl-3"
+                      >
+                        <p className="text-sm font-semibold text-text-primary">
+                          {contact.label || `연락처 ${contactIndex + 1}`}
+                        </p>
+
+                        <div className="flex items-center gap-2">
+                          <a
+                            href={`tel:${contact.number}`}
+                            aria-label="전화 걸기"
+                            className="flex items-center justify-center w-9 h-9 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
+                          >
+                            <PhoneIcon className="w-7 h-7 text-text-secondary" />
+                          </a>
+
+                          <a
+                            href={`sms:${contact.number}`}
+                            aria-label="문자 보내기"
+                            className="flex items-center justify-center w-9 h-9 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
+                          >
+                            <Message className="w-5 h-5 text-text-secondary" />
+                          </a>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
                 </li>
               ))}
             </ul>

--- a/components/organisms/phone/utils/createPhoneGroup.ts
+++ b/components/organisms/phone/utils/createPhoneGroup.ts
@@ -1,0 +1,20 @@
+import { PhoneContact, PhoneGroup } from './phone.types';
+
+/** 빈 연락처 입력 행을 생성한다. */
+export const createPhoneContact = (): PhoneContact => ({
+  id: crypto.randomUUID(),
+  label: '',
+  number: '',
+});
+
+/** 연락처 1개를 가진 빈 그룹을 생성한다. */
+export const createPhoneGroup = (): PhoneGroup => ({
+  id: crypto.randomUUID(),
+  name: '',
+  contacts: [createPhoneContact()],
+});
+
+/** 저장된 그룹이 없으면 기본 그룹 1개를 반환한다. */
+export const getInitialPhoneGroups = (groups?: PhoneGroup[]) => {
+  return groups && groups.length > 0 ? groups : [createPhoneGroup()];
+};

--- a/components/organisms/phone/utils/formatPhoneNumber.ts
+++ b/components/organisms/phone/utils/formatPhoneNumber.ts
@@ -1,0 +1,31 @@
+/** 전화번호를 한국 번호 형식의 하이픈 표기로 변환한다. */
+export function formatPhoneNumber(value: string) {
+  const numbers = value.replace(/\D/g, '');
+
+  if (numbers.startsWith('02')) {
+    if (numbers.length <= 2) return numbers;
+    if (numbers.length <= 5) {
+      return `${numbers.slice(0, 2)}-${numbers.slice(2)}`;
+    }
+    if (numbers.length <= 9) {
+      return `${numbers.slice(0, 2)}-${numbers.slice(2, 5)}-${numbers.slice(5)}`;
+    }
+
+    return `${numbers.slice(0, 2)}-${numbers.slice(2, 6)}-${numbers.slice(6, 10)}`;
+  }
+
+  if (numbers.length <= 3) return numbers;
+  if (numbers.length <= 7) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+  }
+  if (numbers.length <= 10) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3, 6)}-${numbers.slice(6)}`;
+  }
+
+  return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
+}
+
+/** 전화번호 입력값에서 숫자만 남기고 최대 11자리로 제한한다. */
+export function normalizePhoneNumber(value: string) {
+  return value.replace(/\D/g, '').slice(0, 11);
+}

--- a/components/organisms/phone/utils/phone.constants.ts
+++ b/components/organisms/phone/utils/phone.constants.ts
@@ -1,0 +1,5 @@
+/** 연락처 그룹의 최대 개수 */
+export const MAX_PHONE_GROUPS = 4;
+
+/** 그룹 하나에 추가할 수 있는 연락처 최대 개수 */
+export const MAX_CONTACTS_PER_GROUP = 10;

--- a/components/organisms/phone/utils/phone.types.ts
+++ b/components/organisms/phone/utils/phone.types.ts
@@ -1,0 +1,13 @@
+/** 연락처 입력 행 데이터 */
+export type PhoneContact = {
+  id: string;
+  label: string;
+  number: string;
+};
+
+/** 연락처 그룹 데이터 */
+export type PhoneGroup = {
+  id: string;
+  name: string;
+  contacts: PhoneContact[];
+};

--- a/components/organisms/phone/utils/updatePhoneGroups.ts
+++ b/components/organisms/phone/utils/updatePhoneGroups.ts
@@ -1,0 +1,96 @@
+import { createPhoneContact, createPhoneGroup } from './createPhoneGroup';
+import { normalizePhoneNumber } from './formatPhoneNumber';
+import { MAX_CONTACTS_PER_GROUP, MAX_PHONE_GROUPS } from './phone.constants';
+import { PhoneGroup } from './phone.types';
+
+/** 최대 개수를 넘지 않으면 새 그룹을 추가한다. */
+export function addPhoneGroup(groups: PhoneGroup[]) {
+  if (groups.length >= MAX_PHONE_GROUPS) return groups;
+
+  return [...groups, createPhoneGroup()];
+}
+
+/** 최소 1개 그룹을 남기고 선택한 그룹을 삭제한다. */
+export function deletePhoneGroup(groups: PhoneGroup[], groupId: string) {
+  if (groups.length <= 1) return groups;
+
+  return groups.filter(group => group.id !== groupId);
+}
+
+/** 선택한 그룹에 연락처를 추가한다. */
+export function addPhoneContact(groups: PhoneGroup[], groupIndex: number) {
+  return groups.map((group, index) =>
+    index === groupIndex && group.contacts.length < MAX_CONTACTS_PER_GROUP
+      ? { ...group, contacts: [...group.contacts, createPhoneContact()] }
+      : group
+  );
+}
+
+/** 최소 1개 연락처를 남기고 선택한 연락처를 삭제한다. */
+export function deletePhoneContact(
+  groups: PhoneGroup[],
+  groupIndex: number,
+  contactId: string
+) {
+  return groups.map((group, index) =>
+    index === groupIndex && group.contacts.length > 1
+      ? {
+          ...group,
+          contacts: group.contacts.filter(contact => contact.id !== contactId),
+        }
+      : group
+  );
+}
+
+/** 선택한 그룹의 그룹명을 변경한다. */
+export function updatePhoneGroupName(
+  groups: PhoneGroup[],
+  groupIndex: number,
+  name: string
+) {
+  return groups.map((group, index) =>
+    index === groupIndex ? { ...group, name } : group
+  );
+}
+
+/** 선택한 연락처의 명칭을 변경한다. */
+export function updatePhoneContactLabel(
+  groups: PhoneGroup[],
+  groupIndex: number,
+  contactIndex: number,
+  label: string
+) {
+  return groups.map((group, index) =>
+    index === groupIndex
+      ? {
+          ...group,
+          contacts: group.contacts.map((contact, innerIndex) =>
+            innerIndex === contactIndex ? { ...contact, label } : contact
+          ),
+        }
+      : group
+  );
+}
+
+/** 선택한 연락처의 번호를 숫자만 남겨 저장한다. */
+export function updatePhoneContactNumber(
+  groups: PhoneGroup[],
+  groupIndex: number,
+  contactIndex: number,
+  number: string
+) {
+  const normalizedNumber = normalizePhoneNumber(number);
+
+  return groups.map((group, index) =>
+    index === groupIndex
+      ? {
+          ...group,
+          contacts: group.contacts.map((contact, innerIndex) =>
+            innerIndex === contactIndex
+              ? { ...contact, number: normalizedNumber }
+              : contact
+          ),
+        }
+      : group
+  );
+}


### PR DESCRIPTION
## 작업 개요

Phone 컴포넌트의 연락처 그룹/연락처 입력 UI를 구성하고, 프리뷰 렌더링까지 연결했습니다.

## 작업 내용

- [x] 그룹명 + 연락처 추가 액션 필드 구현
- [x] 그룹 추가/삭제 및 그룹 편집 팝업 구현
- [x] 그룹별 연락처 추가/삭제 UI 구현
- [x] 전화번호 자동 하이픈 포맷팅 및 숫자 저장 처리
- [x] Phone 상태를 store에 저장하고 프리뷰 팝업과 연결
- [x] Phone 관련 유틸/컴포넌트 분리 및 JSDoc 정리
- [x] 프리뷰 연락처 row hover/padding UI 조정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npm run lint -- components/organisms/phone`
- `npx tsc --noEmit --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 연락처를 그룹으로 정리하는 기능 추가 (최대 4개 그룹, 그룹당 최대 10개 연락처)
  * 그룹 이름 편집 및 그룹별 연락처 관리 기능 추가
  * 연락처 레이블 및 전화번호 입력 UI 개선

* **Bug Fixes**
  * 전화번호 형식 정규화 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->