### PR TITLE
[feat] 일괄편집 컬러픽커 위치 조정

### DIFF
--- a/components/molecules/preview-text-editor/TextEditorPreview.tsx
+++ b/components/molecules/preview-text-editor/TextEditorPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useRef, useState } from 'react';
+import { type ReactNode } from 'react';
 
 import TextEditorButton from '@/components/atoms/text-editor-button/TextEditorButton';
 import AlignCenterIcon from '@/shared/assets/icons/alignCenter.svg';
@@ -16,10 +16,15 @@ import { Selector } from '../selector';
 import BulkColorPicker from './components/ColorPicker';
 import { useBulkEditor } from './hooks/useBulkEditor';
 
+import type { BulkColorPickerId } from './types';
+
 interface TextEditorPreviewProps {
   children: ReactNode;
   value: BulkData;
   onChange: (bulkData: BulkData) => void;
+  colorPickerId: BulkColorPickerId;
+  activeColorPickerId: BulkColorPickerId | null;
+  onActiveColorPickerChange: (id: BulkColorPickerId | null) => void;
 }
 
 const FONT_SIZE_OPTIONS: FontOption[] = [
@@ -48,10 +53,11 @@ export function TextEditorPreview({
   children,
   value,
   onChange,
+  colorPickerId,
+  activeColorPickerId,
+  onActiveColorPickerChange,
 }: TextEditorPreviewProps) {
-  const [colorPickerOpen, setColorPickerOpen] = useState(false);
-
-  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
+  const colorPickerOpen = activeColorPickerId === colorPickerId;
 
   const fontSizeSelected =
     FONT_SIZE_OPTIONS.find(option => option.value === value.fontSize) ??
@@ -70,7 +76,7 @@ export function TextEditorPreview({
     handleTextColorSelect,
   } = useBulkEditor(value, onChange);
   const handleColorPickerToggle = () => {
-    setColorPickerOpen(prev => !prev);
+    onActiveColorPickerChange(colorPickerOpen ? null : colorPickerId);
   };
 
   return (
@@ -93,7 +99,7 @@ export function TextEditorPreview({
             className="font-semibold"
             addPopWidth={20}
           />
-          <div className="relative" ref={colorPickerContainerRef}>
+          <div className="relative">
             <TextEditorButton
               icon={<FontColorIcon />}
               label="글자색"
@@ -103,8 +109,7 @@ export function TextEditorPreview({
             {colorPickerOpen && (
               <BulkColorPicker
                 initialHex={value.color}
-                onClose={() => setColorPickerOpen(false)}
-                containerRef={colorPickerContainerRef}
+                onClose={() => onActiveColorPickerChange(null)}
                 onChange={handleTextColorSelect}
               />
             )}

--- a/components/molecules/preview-text-editor/components/ColorPicker.tsx
+++ b/components/molecules/preview-text-editor/components/ColorPicker.tsx
@@ -24,6 +24,9 @@ const TRIGGER_GAP = 8;
 const PANEL_GAP = 12;
 const LEFT_PANEL_SELECTOR = '[data-editor-left-panel]';
 
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), Math.max(min, max));
+
 export default function BulkColorPicker({
   initialHex = '#FF4D6D',
   onClose,
@@ -46,29 +49,40 @@ export default function BulkColorPicker({
       const trigger = containerRef?.current;
       const picker = pickerRef.current;
 
-      if (!trigger || !picker) return;
+      if (!picker) return;
 
-      const triggerRect = trigger.getBoundingClientRect();
       const pickerWidth = picker.offsetWidth;
       const pickerHeight = picker.offsetHeight;
-      const panel = trigger.closest(LEFT_PANEL_SELECTOR);
+      const triggerRect = trigger?.getBoundingClientRect();
+      const panel =
+        trigger?.closest(LEFT_PANEL_SELECTOR) ??
+        document.querySelector(LEFT_PANEL_SELECTOR);
       const panelRect = panel?.getBoundingClientRect();
       const maxLeft = window.innerWidth - pickerWidth - VIEWPORT_GAP;
+
       const preferredLeft = panelRect
         ? panelRect.right + PANEL_GAP
-        : triggerRect.right - pickerWidth;
-      const left = Math.min(Math.max(preferredLeft, VIEWPORT_GAP), maxLeft);
-      const preferredTop = panelRect
+        : triggerRect
+          ? triggerRect.right - pickerWidth
+          : (window.innerWidth - pickerWidth) / 2;
+      const left = clamp(preferredLeft, VIEWPORT_GAP, maxLeft);
+
+      const maxTop = window.innerHeight - pickerHeight - VIEWPORT_GAP;
+      const preferredTop = triggerRect
         ? triggerRect.top
-        : triggerRect.bottom + TRIGGER_GAP;
-      const top =
-        preferredTop + pickerHeight <= window.innerHeight - VIEWPORT_GAP ||
-        triggerRect.top - pickerHeight - TRIGGER_GAP < VIEWPORT_GAP
-          ? Math.min(
-              preferredTop,
-              window.innerHeight - pickerHeight - VIEWPORT_GAP
+        : panelRect
+          ? panelRect.top + (panelRect.height - pickerHeight) / 2
+          : (window.innerHeight - pickerHeight) / 2;
+      const top = triggerRect
+        ? preferredTop + pickerHeight <= window.innerHeight - VIEWPORT_GAP ||
+          triggerRect.top - pickerHeight - TRIGGER_GAP < VIEWPORT_GAP
+          ? clamp(preferredTop, VIEWPORT_GAP, maxTop)
+          : clamp(
+              triggerRect.top - pickerHeight - TRIGGER_GAP,
+              VIEWPORT_GAP,
+              maxTop
             )
-          : triggerRect.top - pickerHeight - TRIGGER_GAP;
+        : clamp(preferredTop, VIEWPORT_GAP, maxTop);
 
       setPopoverStyle({
         position: 'fixed',
@@ -86,8 +100,10 @@ export default function BulkColorPicker({
     window.addEventListener('scroll', updatePosition, true);
 
     const resizeObserver = new ResizeObserver(updatePosition);
+    const panel = document.querySelector(LEFT_PANEL_SELECTOR);
     if (containerRef?.current) resizeObserver.observe(containerRef.current);
     if (pickerRef.current) resizeObserver.observe(pickerRef.current);
+    if (panel) resizeObserver.observe(panel);
 
     return () => {
       window.cancelAnimationFrame(animationFrameId);

--- a/components/molecules/preview-text-editor/types.ts
+++ b/components/molecules/preview-text-editor/types.ts
@@ -1,0 +1,1 @@
+export type BulkColorPickerId = 'title' | 'body' | 'background';

--- a/widgets/editor/leftPanel/components/BackGroundEdit.tsx
+++ b/widgets/editor/leftPanel/components/BackGroundEdit.tsx
@@ -1,17 +1,25 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import { Radio } from '@/components/atoms/radio';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import BulkColorPicker from '@/components/molecules/preview-text-editor/components/ColorPicker';
+import type { BulkColorPickerId } from '@/components/molecules/preview-text-editor/types';
 import SectionArrow from '@/shared/assets/icons/sectionArrow.svg';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 
-function BackGroundEdit() {
-  const [colorPickerOpen, setColorPickerOpen] = useState(false);
-  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
+type BackGroundEditProps = {
+  activeColorPickerId: BulkColorPickerId | null;
+  onActiveColorPickerChange: (id: BulkColorPickerId | null) => void;
+};
+
+function BackGroundEdit({
+  activeColorPickerId,
+  onActiveColorPickerChange,
+}: BackGroundEditProps) {
+  const colorPickerOpen = activeColorPickerId === 'background';
 
   const { backgroundColor, setBackgroundColor } = useEditorStore(
     useShallow(state => ({
@@ -25,9 +33,8 @@ function BackGroundEdit() {
       <div
         className={`w-fit px-[14px] py-1 flex gap-2 relative ${colorPickerOpen ? 'border border-primary rounded-sm' : ''}`}
         onClick={() => {
-          setColorPickerOpen(!colorPickerOpen);
+          onActiveColorPickerChange(colorPickerOpen ? null : 'background');
         }}
-        ref={colorPickerContainerRef}
       >
         <div className="flex items-center gap-2">
           <div onClick={e => e.stopPropagation()}>
@@ -35,7 +42,9 @@ function BackGroundEdit() {
               type="checkbox"
               name="backgroundColor"
               checked={colorPickerOpen}
-              onChange={() => setColorPickerOpen(!colorPickerOpen)}
+              onChange={() =>
+                onActiveColorPickerChange(colorPickerOpen ? null : 'background')
+              }
             />
           </div>
           <p className="font-semibold text-sm">색상</p>
@@ -54,8 +63,7 @@ function BackGroundEdit() {
         {colorPickerOpen && (
           <BulkColorPicker
             initialHex={backgroundColor}
-            onClose={() => setColorPickerOpen(false)}
-            containerRef={colorPickerContainerRef}
+            onClose={() => onActiveColorPickerChange(null)}
             onChange={setBackgroundColor}
           />
         )}

--- a/widgets/editor/leftPanel/components/BodyEdit.tsx
+++ b/widgets/editor/leftPanel/components/BodyEdit.tsx
@@ -5,12 +5,21 @@ import { useShallow } from 'zustand/shallow';
 import { UtilityButton } from '@/components/atoms/button';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { TextEditorPreview } from '@/components/molecules/preview-text-editor';
+import type { BulkColorPickerId } from '@/components/molecules/preview-text-editor/types';
 import { BODY_BULK_DATA } from '@/shared/data/sample/bulkData';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { BulkData } from '@/shared/types/block';
 import { toStyle } from '@/shared/utils/toStyle';
 
-function BodyEdit() {
+type BodyEditProps = {
+  activeColorPickerId: BulkColorPickerId | null;
+  onActiveColorPickerChange: (id: BulkColorPickerId | null) => void;
+};
+
+function BodyEdit({
+  activeColorPickerId,
+  onActiveColorPickerChange,
+}: BodyEditProps) {
   const { bodyData, setBodyData } = useEditorStore(
     useShallow(state => ({
       bodyData: state.bodyData,
@@ -40,7 +49,13 @@ function BodyEdit() {
       >
         본문 편집
       </NavigationBar>
-      <TextEditorPreview value={bulkBodyData} onChange={setBulkBodyData}>
+      <TextEditorPreview
+        value={bulkBodyData}
+        onChange={setBulkBodyData}
+        colorPickerId="body"
+        activeColorPickerId={activeColorPickerId}
+        onActiveColorPickerChange={onActiveColorPickerChange}
+      >
         <div className="w-full h-full flex flex-col gap-1 ">
           <p
             className="font-base text-base"

--- a/widgets/editor/leftPanel/components/BulkEdit.tsx
+++ b/widgets/editor/leftPanel/components/BulkEdit.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { BulkColorPickerId } from '@/components/molecules/preview-text-editor/types';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 
 import BackGroundEdit from './BackGroundEdit';
@@ -5,12 +10,24 @@ import BodyEdit from './BodyEdit';
 import TitleEdit from './TitleEdit';
 
 function BulkEdit() {
+  const [activeColorPickerId, setActiveColorPickerId] =
+    useState<BulkColorPickerId | null>(null);
+
   return (
     <div className="w-full bg-white rounded-b-lg shadow-edit border border-t-0 border-black/5 transition-all duration-300 ease-in-out">
       <LeftEditorWrapper className="overflow-x-hidden">
-        <TitleEdit />
-        <BodyEdit />
-        <BackGroundEdit />
+        <TitleEdit
+          activeColorPickerId={activeColorPickerId}
+          onActiveColorPickerChange={setActiveColorPickerId}
+        />
+        <BodyEdit
+          activeColorPickerId={activeColorPickerId}
+          onActiveColorPickerChange={setActiveColorPickerId}
+        />
+        <BackGroundEdit
+          activeColorPickerId={activeColorPickerId}
+          onActiveColorPickerChange={setActiveColorPickerId}
+        />
       </LeftEditorWrapper>
     </div>
   );

--- a/widgets/editor/leftPanel/components/TitleEdit.tsx
+++ b/widgets/editor/leftPanel/components/TitleEdit.tsx
@@ -6,12 +6,21 @@ import { useShallow } from 'zustand/shallow';
 import { UtilityButton } from '@/components/atoms/button';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { TextEditorPreview } from '@/components/molecules/preview-text-editor';
+import type { BulkColorPickerId } from '@/components/molecules/preview-text-editor/types';
 import { TITLE_BULK_DATA } from '@/shared/data/sample/bulkData';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { BulkData } from '@/shared/types/block';
 import { toStyle } from '@/shared/utils/toStyle';
 
-function TitleEdit() {
+type TitleEditProps = {
+  activeColorPickerId: BulkColorPickerId | null;
+  onActiveColorPickerChange: (id: BulkColorPickerId | null) => void;
+};
+
+function TitleEdit({
+  activeColorPickerId,
+  onActiveColorPickerChange,
+}: TitleEditProps) {
   const { titleData, setTitleData } = useEditorStore(
     useShallow(state => ({
       titleData: state.titleData,
@@ -41,7 +50,13 @@ function TitleEdit() {
         >
           제목 편집
         </NavigationBar>
-        <TextEditorPreview value={bulkTitleData} onChange={setBulkTitleData}>
+        <TextEditorPreview
+          value={bulkTitleData}
+          onChange={setBulkTitleData}
+          colorPickerId="title"
+          activeColorPickerId={activeColorPickerId}
+          onActiveColorPickerChange={onActiveColorPickerChange}
+        >
           <div
             className={`w-full h-full flex flex-col gap-1 ${bulkTitleData.font}`}
           >


### PR DESCRIPTION
## 작업 개요

일괄편집 컬러픽커 위치와 열림 상태 관리를 수정했습니다.

## 작업 내용

- [x] 일괄편집 컬러픽커가 패널 오른쪽 세로 중앙에 뜨도록 위치 조정
- [x] 제목/본문/배경 컬러픽커 중 하나만 열리도록 상태 공유 처리
- [x] 포스터 컬러픽커에는 영향 없도록 일괄편집 전용 경로만 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npm run lint` 통과
