### PR TITLE
[Feat] 초대장 썸네일(포스터) 추출 및 적용

### DIFF
--- a/app/api/drive/_lib/ensureThumbnailFile.ts
+++ b/app/api/drive/_lib/ensureThumbnailFile.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+
+import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
+import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+
+import { escapeDriveQueryValue } from './escapeQueryValue';
+
+export const APP_IDENTIFIER = 'Bread-Barbershop';
+export const THUMBNAIL_NAME = 'invitation-thumbnail.json';
+export const THUMBNAIL_KIND = 'invitation_thumbnail_json';
+
+export type ThumbnailPayload = {
+  name: string;
+  mimeType: string;
+  dataUrl: string;
+  width: number;
+  height: number;
+  createdAt: string;
+};
+
+export type EnsureThumbnailFileResult = {
+  thumbnailFileId: string | null;
+  reused: boolean;
+};
+
+/**
+ * invitation 폴더 내에 단일 invitation-thumbnail.json 파일이 존재하는지 확인합니다.
+ */
+export async function ensureThumbnailFile(
+  invitationFolderId: string
+): Promise<EnsureThumbnailFileResult> {
+  if (!invitationFolderId) {
+    throw new DriveHttpError('invitationFolderId is required', 400, {
+      invitationFolderId,
+    });
+  }
+
+  // 1) 기존 파일 검색
+  const q = [
+    `'${escapeDriveQueryValue(invitationFolderId)}' in parents`,
+    `trashed=false`,
+    `appProperties has { key='app_id' and value='${escapeDriveQueryValue(APP_IDENTIFIER)}' }`,
+    `appProperties has { key='kind' and value='${THUMBNAIL_KIND}' }`,
+    `name='${escapeDriveQueryValue(THUMBNAIL_NAME)}'`,
+  ].join(' and ');
+
+  const searchParams = new URLSearchParams({
+    q,
+    spaces: 'drive',
+    fields: 'files(id,name,createdTime,appProperties)',
+    orderBy: 'createdTime',
+    pageSize: '10',
+  });
+
+  const searchRes = await googleFetch(
+    `https://www.googleapis.com/drive/v3/files?${searchParams.toString()}`
+  );
+
+  const searchData = (await searchRes.json().catch(() => ({}))) as {
+    files?: Array<{ id: string }>;
+    error?: unknown;
+  };
+
+  if (!searchRes.ok) {
+    throw new DriveHttpError(
+      'invitation-thumbnail.json search failed',
+      searchRes.status,
+      searchData
+    );
+  }
+
+  const found = searchData.files ?? [];
+  if (found.length > 0) {
+    return { thumbnailFileId: found[0].id, reused: true };
+  }
+
+  // 2) 파일이 없는 경우 null 반환
+  return { thumbnailFileId: null, reused: false };
+}

--- a/app/api/drive/thumbnail/route.ts
+++ b/app/api/drive/thumbnail/route.ts
@@ -1,0 +1,210 @@
+import 'server-only';
+
+import { NextResponse } from 'next/server';
+
+import {
+  APP_IDENTIFIER,
+  ensureThumbnailFile,
+  THUMBNAIL_KIND,
+  THUMBNAIL_NAME,
+  ThumbnailPayload,
+} from '@/app/api/drive/_lib/ensureThumbnailFile';
+import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
+import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+import { publishPermissionWithRetry } from '@/app/api/drive/_lib/publishPermissionWithRetry';
+
+/**
+ * POST: 초대장 썸네일 데이터를 invitation-thumbnail.json에 저장합니다.
+ *
+ * Body: { invitationFolderId: string, thumbnailData: ThumbnailPayload }
+ */
+export async function POST(req: Request) {
+  try {
+    const { invitationFolderId, thumbnailData } = (await req.json()) as {
+      invitationFolderId: string;
+      thumbnailData: ThumbnailPayload;
+    };
+
+    if (!invitationFolderId) {
+      return NextResponse.json(
+        { ok: false, error: 'invitationFolderId 필수' },
+        { status: 400 }
+      );
+    }
+
+    // 1) 파일 정보 시도
+    const { thumbnailFileId } = await ensureThumbnailFile(invitationFolderId);
+
+    // 2) 파일 업데이트 시 기존 파일 삭제 후 재생성
+    if (thumbnailFileId) {
+      await deleteThumbnailFile(thumbnailFileId);
+    }
+    const finalFileId = await createThumbnailFile(
+      invitationFolderId,
+      thumbnailData
+    );
+
+    // 3) 공개 권한 설정
+    await publishPermissionWithRetry(finalFileId);
+
+    const publicUrl = `https://drive.google.com/uc?export=download&id=${finalFileId}`;
+
+    return NextResponse.json({
+      ok: true,
+      thumbnailFileId: finalFileId,
+      publicUrl,
+    });
+  } catch (err) {
+    if (err instanceof DriveHttpError) {
+      return NextResponse.json(
+        { ok: false, error: err.message, details: err.details },
+        { status: err.status }
+      );
+    }
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : '알 수 없는 오류',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET: invitationFolderId로 invitation-thumbnail.json을 조회합니다.
+ */
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const invitationFolderId = searchParams.get('invitationFolderId')?.trim();
+
+    if (!invitationFolderId) {
+      return NextResponse.json(
+        { ok: false, error: 'invitationFolderId 필수' },
+        { status: 400 }
+      );
+    }
+
+    const { thumbnailFileId } = await ensureThumbnailFile(invitationFolderId);
+
+    if (!thumbnailFileId) {
+      return NextResponse.json(
+        { ok: false, error: '썸네일 파일이 존재하지 않습니다.' },
+        { status: 404 }
+      );
+    }
+
+    const data = await loadThumbnailFileData(thumbnailFileId);
+
+    return NextResponse.json({ ok: true, thumbnailFileId, data });
+  } catch (err) {
+    if (err instanceof DriveHttpError) {
+      return NextResponse.json(
+        { ok: false, error: err.message, details: err.details },
+        { status: err.status }
+      );
+    }
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : '알 수 없는 오류',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+async function loadThumbnailFileData(fileId: string) {
+  const res = await googleFetch(
+    `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
+      fileId
+    )}?alt=media`,
+    { cache: 'no-store' }
+  );
+
+  if (!res.ok) {
+    throw new DriveHttpError(
+      '파일 조회 실패',
+      res.status,
+      await res.json().catch(() => ({}))
+    );
+  }
+
+  return res.json();
+}
+
+async function createThumbnailFile(
+  invitationFolderId: string,
+  thumbnailData: ThumbnailPayload
+): Promise<string> {
+  const metaRes = await googleFetch(
+    'https://www.googleapis.com/drive/v3/files',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: THUMBNAIL_NAME,
+        mimeType: 'application/json',
+        parents: [invitationFolderId],
+        appProperties: {
+          app_id: APP_IDENTIFIER,
+          kind: THUMBNAIL_KIND,
+        },
+      }),
+    }
+  );
+
+  const created = (await metaRes.json()) as { id: string };
+  if (!metaRes.ok || !created.id) {
+    throw new DriveHttpError(
+      '파일 메타데이터 생성 실패',
+      metaRes.status,
+      created
+    );
+  }
+
+  await updateThumbnailFile(created.id, thumbnailData);
+  return created.id;
+}
+
+async function deleteThumbnailFile(fileId: string): Promise<void> {
+  const res = await googleFetch(
+    `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}`,
+    {
+      method: 'DELETE',
+    }
+  );
+
+  if (!res.ok && res.status !== 404) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new DriveHttpError('기존 파일 삭제 실패', res.status, errorData);
+  }
+}
+
+async function updateThumbnailFile(
+  fileId: string,
+  thumbnailData: ThumbnailPayload
+): Promise<string> {
+  const uploadRes = await googleFetch(
+    `https://www.googleapis.com/upload/drive/v3/files/${encodeURIComponent(
+      fileId
+    )}?uploadType=media&supportsAllDrives=true`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+      body: JSON.stringify(thumbnailData),
+    }
+  );
+
+  if (!uploadRes.ok) {
+    const errorData = await uploadRes.json().catch(() => ({}));
+    throw new DriveHttpError(
+      '파일 내용 업데이트 실패',
+      uploadRes.status,
+      errorData
+    );
+  }
+
+  return fileId;
+}

--- a/app/api/drive/thumbnail/route.ts
+++ b/app/api/drive/thumbnail/route.ts
@@ -32,17 +32,24 @@ export async function POST(req: Request) {
       );
     }
 
-    // 1) 파일 정보 시도
+    if (!thumbnailData || !thumbnailData.dataUrl) {
+      return NextResponse.json(
+        { ok: false, error: 'thumbnailData 및 dataUrl 필수' },
+        { status: 400 }
+      );
+    }
+
+    // 1) 기존 파일 확인
     const { thumbnailFileId } = await ensureThumbnailFile(invitationFolderId);
 
-    // 2) 파일 업데이트 시 기존 파일 삭제 후 재생성
-    if (thumbnailFileId) {
-      await deleteThumbnailFile(thumbnailFileId);
-    }
+    // 2) 새 파일 생성 성공 후 기존 파일 삭제
     const finalFileId = await createThumbnailFile(
       invitationFolderId,
       thumbnailData
     );
+    if (thumbnailFileId && finalFileId !== thumbnailFileId) {
+      await deleteThumbnailFile(thumbnailFileId);
+    }
 
     // 3) 공개 권한 설정
     await publishPermissionWithRetry(finalFileId);

--- a/app/api/drive/thumbnail/route.ts
+++ b/app/api/drive/thumbnail/route.ts
@@ -171,8 +171,13 @@ async function createThumbnailFile(
     );
   }
 
-  await updateThumbnailFile(created.id, thumbnailData);
-  return created.id;
+  try {
+    await updateThumbnailFile(created.id, thumbnailData);
+    return created.id;
+  } catch (error) {
+    await deleteThumbnailFile(created.id);
+    throw error;
+  }
 }
 
 async function deleteThumbnailFile(fileId: string): Promise<void> {

--- a/app/dashboard/components/carousel/CarouselWrapper.tsx
+++ b/app/dashboard/components/carousel/CarouselWrapper.tsx
@@ -31,7 +31,10 @@ function CarouselWrapper({ initialInvites = [] }: CarouselWrapperProps) {
 
         return {
           id: invite.folderId,
-          image: showcaseItem.image,
+          image:
+            invite.thumbnailUrl && invite.thumbnailUrl !== ''
+              ? invite.thumbnailUrl
+              : showcaseItem.image,
           alt: showcaseItem.alt,
           invite,
         };

--- a/app/dashboard/components/carousel/carouselTypes.ts
+++ b/app/dashboard/components/carousel/carouselTypes.ts
@@ -4,7 +4,7 @@ import { InviteListItem } from '@/app/dashboard/types';
 
 export type CarouselCardItem = {
   id: string;
-  image: StaticImageData;
+  image: string | StaticImageData;
   alt: string;
   invite?: InviteListItem;
 };

--- a/app/dashboard/server/loadDashboardInvitations.ts
+++ b/app/dashboard/server/loadDashboardInvitations.ts
@@ -10,6 +10,8 @@ const APP_IDENTIFIER = 'Bread-Barbershop';
 const INVITATION_KIND = 'invitation';
 const PUBLISHED_JSON_NAME = 'published.json';
 const PUBLISHED_JSON_KIND = 'invitation_published_json';
+const THUMBNAIL_NAME = 'invitation-thumbnail.json';
+const THUMBNAIL_KIND = 'invitation_thumbnail_json';
 
 type DriveListResponse = {
   files?: Array<{
@@ -29,9 +31,20 @@ type DriveSearchResponse = {
   error?: unknown;
 };
 
-function isPublishedPayload(
+function isThumbnailPayload(
   value: unknown
 ): value is {
+  dataUrl: string;
+} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'dataUrl' in value &&
+    typeof value.dataUrl === 'string'
+  );
+}
+
+function isPublishedPayload(value: unknown): value is {
   guestUrl: string;
 } {
   return (
@@ -42,7 +55,9 @@ function isPublishedPayload(
   );
 }
 
-async function loadPublishedUrl(invitationFolderId: string): Promise<string | null> {
+async function loadPublishedUrl(
+  invitationFolderId: string
+): Promise<string | null> {
   try {
     const q = [
       `'${escapeDriveQueryValue(invitationFolderId)}' in parents`,
@@ -96,6 +111,62 @@ async function loadPublishedUrl(invitationFolderId: string): Promise<string | nu
   }
 }
 
+async function loadThumbnailUrl(
+  invitationFolderId: string
+): Promise<string | null> {
+  try {
+    const q = [
+      `'${escapeDriveQueryValue(invitationFolderId)}' in parents`,
+      `trashed=false`,
+      `appProperties has { key='app_id' and value='${escapeDriveQueryValue(
+        APP_IDENTIFIER
+      )}' }`,
+      `appProperties has { key='kind' and value='${THUMBNAIL_KIND}' }`,
+      `name='${escapeDriveQueryValue(THUMBNAIL_NAME)}'`,
+    ].join(' and ');
+
+    const searchParams = new URLSearchParams({
+      q,
+      spaces: 'drive',
+      fields: 'files(id)',
+      pageSize: '1',
+    });
+
+    const searchRes = await googleFetch(
+      `https://www.googleapis.com/drive/v3/files?${searchParams.toString()}`,
+      { cache: 'no-store' }
+    );
+    const searchData = (await searchRes
+      .json()
+      .catch(() => ({}))) as DriveSearchResponse;
+
+    if (!searchRes.ok) {
+      return null;
+    }
+
+    const thumbnailFileId = searchData.files?.[0]?.id;
+    if (!thumbnailFileId) {
+      return null;
+    }
+
+    const contentRes = await googleFetch(
+      `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
+        thumbnailFileId
+      )}?alt=media`,
+      { cache: 'no-store' }
+    );
+
+    if (!contentRes.ok) {
+      return null;
+    }
+
+    const content = (await contentRes.json().catch(() => null)) as unknown;
+    return isThumbnailPayload(content) ? content.dataUrl : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function loadDashboardInvitations(): Promise<LoadInvitationResponse> {
   const workspaceFolderId = await findWorkspaceFolderId();
 
@@ -130,7 +201,9 @@ export async function loadDashboardInvitations(): Promise<LoadInvitationResponse
   );
 
   const listRes = await googleFetch(url.toString(), { cache: 'no-store' });
-  const listData = (await listRes.json().catch(() => ({}))) as DriveListResponse;
+  const listData = (await listRes
+    .json()
+    .catch(() => ({}))) as DriveListResponse;
 
   if (!listRes.ok) {
     throw new DriveHttpError('초대장 목록 조회 실패', listRes.status, listData);
@@ -150,6 +223,7 @@ export async function loadDashboardInvitations(): Promise<LoadInvitationResponse
     invitationFolders.map(async invite => ({
       ...invite,
       publishedUrl: await loadPublishedUrl(invite.folderId),
+      thumbnailUrl: await loadThumbnailUrl(invite.folderId),
     }))
   );
 

--- a/app/dashboard/server/loadDashboardInvitations.ts
+++ b/app/dashboard/server/loadDashboardInvitations.ts
@@ -1,5 +1,9 @@
 import 'server-only';
 
+import {
+  THUMBNAIL_KIND,
+  THUMBNAIL_NAME,
+} from '@/app/api/drive/_lib/ensureThumbnailFile';
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { escapeDriveQueryValue } from '@/app/api/drive/_lib/escapeQueryValue';
 import { findWorkspaceFolderId } from '@/app/api/drive/_lib/findWorkspaceFolderId';
@@ -10,8 +14,6 @@ const APP_IDENTIFIER = 'Bread-Barbershop';
 const INVITATION_KIND = 'invitation';
 const PUBLISHED_JSON_NAME = 'published.json';
 const PUBLISHED_JSON_KIND = 'invitation_published_json';
-const THUMBNAIL_NAME = 'invitation-thumbnail.json';
-const THUMBNAIL_KIND = 'invitation_thumbnail_json';
 
 type DriveListResponse = {
   files?: Array<{
@@ -31,9 +33,7 @@ type DriveSearchResponse = {
   error?: unknown;
 };
 
-function isThumbnailPayload(
-  value: unknown
-): value is {
+function isThumbnailPayload(value: unknown): value is {
   dataUrl: string;
 } {
   return (
@@ -220,11 +220,17 @@ export async function loadDashboardInvitations(): Promise<LoadInvitationResponse
     .filter(x => Boolean(x.invitationUuid));
 
   const invites = await Promise.all(
-    invitationFolders.map(async invite => ({
-      ...invite,
-      publishedUrl: await loadPublishedUrl(invite.folderId),
-      thumbnailUrl: await loadThumbnailUrl(invite.folderId),
-    }))
+    invitationFolders.map(async invite => {
+      const [publishedUrl, thumbnailUrl] = await Promise.all([
+        loadPublishedUrl(invite.folderId),
+        loadThumbnailUrl(invite.folderId),
+      ]);
+      return {
+        ...invite,
+        publishedUrl,
+        thumbnailUrl,
+      };
+    })
   );
 
   return {

--- a/app/dashboard/types.ts
+++ b/app/dashboard/types.ts
@@ -4,6 +4,7 @@ export type InviteListItem = {
   createdTime?: string;
   invitationUuid?: string;
   publishedUrl?: string | null;
+  thumbnailUrl?: string | null;
 };
 
 export type KakaoShareData = {

--- a/app/guest/[id]/components/GuestMainPoster.tsx
+++ b/app/guest/[id]/components/GuestMainPoster.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { Canvas } from 'fabric';
+import { StaticCanvas } from 'fabric';
 import { useEffect, useRef, useState } from 'react';
 
 import '@/widgets/mainPoster/libs/customImage-filter';
 
 export const GuestMainPoster = ({ json }: { json: unknown }) => {
-  const [canvas, setCanvas] = useState<Canvas | null>(null);
+  const [canvas, setCanvas] = useState<StaticCanvas | null>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [renderStartTime] = useState(() => performance.now());
   const canvasInitTime = useRef<number>(0);
@@ -14,9 +14,9 @@ export const GuestMainPoster = ({ json }: { json: unknown }) => {
     if (!canvasRef.current) return;
 
     const startInit = performance.now();
-    const fabricCanvas = new Canvas(canvasRef.current, {
-      width: 365,
-      height: 812,
+    const fabricCanvas = new StaticCanvas(canvasRef.current, {
+      width: 375,
+      height: 750,
       selection: false,
       skipTargetFind: true,
       renderOnAddRemove: false,
@@ -36,8 +36,6 @@ export const GuestMainPoster = ({ json }: { json: unknown }) => {
 
     const loadStart = performance.now();
     canvas.loadFromJSON(json).then(() => {
-      canvas.discardActiveObject();
-      canvas.selection = false;
       canvas.requestRenderAll();
 
       const loadEnd = performance.now();

--- a/app/oauthTest/utils/saveInvitationFlow.ts
+++ b/app/oauthTest/utils/saveInvitationFlow.ts
@@ -347,10 +347,11 @@ export async function saveInvitationFlow(params: {
     }
   }
 
+  let thumbnailSaveFailed = false;
   // 6) 초대장 썸네일 데이터 저장
   if (invitationThumbnail && invitationThumbnail.dataUrl) {
     try {
-      await fetch('/api/drive/thumbnail', {
+      const thumbnailResponse = await fetch('/api/drive/thumbnail', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -358,7 +359,11 @@ export async function saveInvitationFlow(params: {
           thumbnailData: invitationThumbnail,
         }),
       });
+      if (!thumbnailResponse.ok) {
+        throw new Error(`thumbnail save failed: ${thumbnailResponse.status}`);
+      }
     } catch (error) {
+      thumbnailSaveFailed = true;
       console.error('초대장 썸네일 데이터 저장 실패:', error);
     }
   }
@@ -366,7 +371,8 @@ export async function saveInvitationFlow(params: {
   const totalFailed =
     imagesStep.final.fail.length +
     audioStep.final.fail.length +
-    dataStep.final.fail.length;
+    dataStep.final.fail.length +
+    (thumbnailSaveFailed ? 1 : 0);
 
   return {
     success: totalFailed === 0,

--- a/app/oauthTest/utils/saveInvitationFlow.ts
+++ b/app/oauthTest/utils/saveInvitationFlow.ts
@@ -66,6 +66,15 @@ type BulkJson = {
   bodyData: BulkData;
 };
 
+type InvitationThumbnail = {
+  name: string;
+  mimeType: string;
+  dataUrl: string;
+  width: number;
+  height: number;
+  createdAt: string;
+};
+
 export async function saveInvitationFlow(params: {
   bulkData: BulkJson;
   images: UploadTask[];
@@ -74,6 +83,7 @@ export async function saveInvitationFlow(params: {
   bgmData: BgmData;
   invitationUuid?: string; // 수정 진입이면 해당 파라미터가 존재함.
   mainPoster: MainPosterData;
+  invitationThumbnail: InvitationThumbnail;
 }): Promise<{
   success: boolean;
   invitationUuid: string;
@@ -93,9 +103,16 @@ export async function saveInvitationFlow(params: {
     usedAccessToken: string;
   };
 }> {
-  // 여기에 포스터 데이터 추가
-  const { bulkData, images, audio, data, bgmData, invitationUuid, mainPoster } =
-    params;
+  const {
+    bulkData,
+    images,
+    audio,
+    data,
+    bgmData,
+    invitationUuid,
+    mainPoster,
+    invitationThumbnail,
+  } = params;
 
   // 1) 서버에서 폴더 구조 + fresh 토큰 받기
   const prepRes = await fetch('/api/drive/saveInvitation', {
@@ -234,7 +251,6 @@ export async function saveInvitationFlow(params: {
       : null,
   };
 
-  // 여기에 포스터 데이터 추가
   const payload: InvitationPayload = {
     bulkData: bulkData,
     blocks: newData,
@@ -328,6 +344,22 @@ export async function saveInvitationFlow(params: {
     } catch (error) {
       // 공유 데이터 저장 실패는 전체 저장 실패로 간주하지 않음
       console.error('공유 데이터 저장 실패:', error);
+    }
+  }
+
+  // 6) 초대장 썸네일 데이터 저장
+  if (invitationThumbnail && invitationThumbnail.dataUrl) {
+    try {
+      await fetch('/api/drive/thumbnail', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          invitationFolderId: prep.invitationFolderId,
+          thumbnailData: invitationThumbnail,
+        }),
+      });
+    } catch (error) {
+      console.error('초대장 썸네일 데이터 저장 실패:', error);
     }
   }
 

--- a/widgets/editor/preview/hooks/useInvitationUpload.ts
+++ b/widgets/editor/preview/hooks/useInvitationUpload.ts
@@ -12,7 +12,7 @@ import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 export const useInvitationUpload = () => {
   const editorData = useEditorStore(useShallow(selectUploadData));
 
-  const { exportIntersectedJSON } = useFabricContext();
+  const { exportIntersectedJSON, exportCanvasPreview } = useFabricContext();
 
   const {
     selectedBgmId,
@@ -63,6 +63,15 @@ export const useInvitationUpload = () => {
         version: '7.1.0',
         objects: [],
       };
+      const invitationThumbnail = exportCanvasPreview() ?? {
+        name: 'invitation-thumbnail.png',
+        mimeType: 'image/png',
+        dataUrl: '',
+        width: 0,
+        height: 0,
+        createdAt: '',
+      };
+
       if (editorData.invitationUuid === '') {
         const saveResult = await saveInvitationFlow({
           bulkData,
@@ -71,6 +80,7 @@ export const useInvitationUpload = () => {
           data: editorData.block,
           bgmData, // bgm의 data 버전.
           mainPoster,
+          invitationThumbnail,
         });
         editorData.setInvitationUuid(saveResult.invitationUuid);
         editorData.setImageFolderId(saveResult.folders.imageFolderId);
@@ -91,6 +101,7 @@ export const useInvitationUpload = () => {
           data: editorData.block,
           bgmData, // bgm의 data 버전.
           mainPoster,
+          invitationThumbnail,
           invitationUuid: editorData.invitationUuid,
         });
         editorData.setInvitationUuid(saveResult.invitationUuid);

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -93,8 +93,8 @@ export const MainPosterPreview = () => {
     if (!canvasRef.current) return;
 
     const fabricCanvas = new Canvas(canvasRef.current, {
-      width: 365,
-      height: 812,
+      width: 375,
+      height: 750,
       fireRightClick: true,
       stopContextMenu: true,
     });
@@ -284,13 +284,13 @@ export const MainPosterPreview = () => {
           setIsEdit(false);
           selectedBlock('mainPoster');
         }}
-        className={cn('relative w-[365px] h-[812px] shrink-0')}
+        className={cn('relative w-[375px] h-[750px] shrink-0')}
       >
         {selectedId === 'mainPoster' && (
           <div
             data-canvas="true"
             className={cn(
-              'absolute inset-0 w-full h-full ring-1 ring-inset ring-primary rounded-lg pointer-events-none'
+              'absolute inset-0 z-10 w-full h-full ring-1 ring-inset ring-primary rounded-lg pointer-events-none'
             )}
           />
         )}

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -481,10 +481,6 @@ export const useFabric = () => {
     } catch (error) {
       console.error('캔버스 썸네일 생성 중 오류 발생.:', error);
 
-      if (error instanceof Error) {
-        console.error(error);
-      }
-
       return undefined;
     }
   }, [canvas]);

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -447,6 +447,48 @@ export const useFabric = () => {
     return json;
   }, [canvas]);
 
+  const exportCanvasPreview = useCallback(() => {
+    if (!canvas) return;
+
+    try {
+      const canvasWidth = canvas.getWidth();
+      const canvasHeight = canvas.getHeight();
+
+      if (!canvasWidth || !canvasHeight) {
+        console.warn('캔버스 썸네일 생성 중 캔버스 유효하지 않음.', {
+          width: canvasWidth,
+          height: canvasHeight,
+        });
+        return;
+      }
+
+      canvas.requestRenderAll();
+
+      const previewDataUrl = canvas.toDataURL({
+        format: 'png',
+        quality: 1,
+        multiplier: 2,
+      });
+
+      return {
+        name: 'invitation-thumbnail.png',
+        mimeType: 'image/png',
+        dataUrl: previewDataUrl,
+        width: canvasWidth,
+        height: canvasHeight,
+        createdAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      console.error('캔버스 썸네일 생성 중 오류 발생.:', error);
+
+      if (error instanceof Error) {
+        console.error(error);
+      }
+
+      return undefined;
+    }
+  }, [canvas]);
+
   return {
     canvas,
     setCanvas,
@@ -467,6 +509,7 @@ export const useFabric = () => {
     unLock,
     saveHistory,
     exportIntersectedJSON,
+    exportCanvasPreview,
     clipboard,
     canUndo,
     canRedo,

--- a/widgets/mainPoster/libs/aligning-guidelines.ts
+++ b/widgets/mainPoster/libs/aligning-guidelines.ts
@@ -210,7 +210,9 @@ export function initAligningGuidelines(
   };
 
   const beforeRender = () => {
-    state.canvas.clearContext(state.canvas.contextTop);
+    const ctx = state.canvas.contextTop;
+    if (!ctx) return;
+    state.canvas.clearContext(ctx);
   };
 
   const afterRender = () => {


### PR DESCRIPTION
## 작업 개요

초대장 썸네일(포스터) 추출 및 적용




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 초대장 썸네일 업로드·저장 및 공개 다운로드 URL 제공 (생성/대체/재사용 처리)
  * 서버 API로 썸네일 조회 및 반환 기능 추가

* **UI 개선**
  * 대시보드에 커스텀 썸네일 표시 지원
  * 캔버스 미리보기 내보내기 기능 추가 및 미리보기 해상도/치수 조정
  * 메인 포스터 선택 오버레이 레이어링(z-index) 조정

* **버그 수정**
  * 캔버스 렌더링 컨텍스트 안정성 개선 (널 검사 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->