### PR TITLE
[feat] 게스트 페이지 넓이 조정

### DIFF
--- a/app/guest/[id]/guestPage.test.tsx
+++ b/app/guest/[id]/guestPage.test.tsx
@@ -55,13 +55,15 @@ const guestMainPosterMock = jest.fn((props: { json: unknown }) => {
   );
 });
 
-const guestRendererMock = jest.fn((props: { blocks: unknown }) => {
-  return React.createElement(
-    'div',
-    { 'data-testid': 'guest-renderer' },
-    JSON.stringify(props.blocks)
-  );
-});
+const guestRendererMock = jest.fn(
+  (props: { blocks: unknown; bulkData: unknown }) => {
+    return React.createElement(
+      'div',
+      { 'data-testid': 'guest-renderer' },
+      JSON.stringify(props.blocks)
+    );
+  }
+);
 
 const guestBgmMock = jest.fn((props: { bgm: unknown }) => {
   return React.createElement(
@@ -77,7 +79,8 @@ jest.mock('@/app/guest/[id]/components/GuestMainPoster', () => ({
 
 jest.mock('@/app/guest/[id]/components/GuestRenderer', () => ({
   __esModule: true,
-  default: (props: { blocks: unknown }) => guestRendererMock(props),
+  default: (props: { blocks: unknown; bulkData: unknown }) =>
+    guestRendererMock(props),
 }));
 
 jest.mock('@/app/guest/[id]/components/GuestBgm', () => ({
@@ -112,6 +115,27 @@ const validGuestPayload = {
     userBgmTitle: null,
     userBgmDuration: null,
     userBgmFileId: null,
+  },
+  bulkData: {
+    backgroundColor: '#ffffff',
+    titleData: {
+      font: 'Inter',
+      fontSize: '24px',
+      color: '#000000',
+      bold: false,
+      italic: false,
+      align: 'center',
+      isDefault: true,
+    },
+    bodyData: {
+      font: 'Inter',
+      fontSize: '16px',
+      color: '#000000',
+      bold: false,
+      italic: false,
+      align: 'center',
+      isDefault: true,
+    },
   },
 };
 
@@ -179,6 +203,7 @@ describe('GuestPage 서버 컴포넌트 테스트', () => {
 
     expect(guestRendererMock).toHaveBeenCalledWith({
       blocks: validGuestPayload.blocks,
+      bulkData: validGuestPayload.bulkData,
     });
 
     expect(guestBgmMock).toHaveBeenCalledWith({
@@ -188,6 +213,8 @@ describe('GuestPage 서버 컴포넌트 테스트', () => {
     expect(html).toContain('data-testid="guest-main-poster"');
     expect(html).toContain('data-testid="guest-renderer"');
     expect(html).toContain('data-testid="guest-bgm"');
+    expect(html).toContain('max-w-[430px]');
+    expect(html).toContain('max-w-[375px]');
   });
 
   it('fetch 실패(res.ok === false)면 notFound()를 호출한다', async () => {

--- a/app/guest/[id]/page.tsx
+++ b/app/guest/[id]/page.tsx
@@ -110,7 +110,9 @@ export default async function GuestPage({
         }}
       >
         <GuestMainPoster json={payload.mainPoster} />
-        <GuestRenderer blocks={payload.blocks} bulkData={payload.bulkData} />
+        <div className="mx-auto w-full max-w-[375px]">
+          <GuestRenderer blocks={payload.blocks} bulkData={payload.bulkData} />
+        </div>
         <GuestBgm bgm={payload.bgm} />
       </div>
     </main>

--- a/app/guest/[id]/utils/guestBlockTypeGuards.test.ts
+++ b/app/guest/[id]/utils/guestBlockTypeGuards.test.ts
@@ -177,6 +177,7 @@ describe('isGuestPayload 테스트', () => {
       ...validPayload,
       bulkData: {
         ...validPayload.bulkData,
+        bodyData: undefined,
       },
     };
 


### PR DESCRIPTION
## 작업 개요

게스트 페이지에서 일반 콘텐츠 렌더 영역이 미리보기 패널과 동일한 폭 기준으로 보이도록 레이아웃을 조정했습니다.

## 작업 내용

- [x] 게스트 페이지 전체 프레임 최대 너비 430px 유지
- [x] 게스트 렌더러 영역 최대 너비 375px 적용
- [x] 게스트 렌더러 영역 중앙 정렬
- [x] 게스트 페이지 테스트 payload에 bulkData 반영
- [x] bulkData 타입가드 테스트 케이스 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npm test -- app/guest`
  - Test Suites: 2 passed
  - Tests: 14 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 게스트 페이지 콘텐츠가 중앙 정렬되고 최대 폭으로 제약되어 더욱 일관된 디스플레이를 제공합니다.

* **테스트**
  * 데이터 구조 검증 범위가 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->