### PR TITLE
Revert "revert: move guest page work off main"

### DIFF
--- a/app/guest/[id]/components/GuestBgm.tsx
+++ b/app/guest/[id]/components/GuestBgm.tsx
@@ -24,9 +24,40 @@ function clampVolume(volume: number) {
   return Math.min(1, Math.max(0, volume));
 }
 
+function BgmPlaybackHint({ isDismissed }: { isDismissed: boolean }) {
+  const [isMounted, setIsMounted] = useState(true);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const showTimer = window.setTimeout(() => setIsVisible(true), 50);
+    const fadeTimer = window.setTimeout(() => setIsVisible(false), 4300);
+    const unmountTimer = window.setTimeout(() => setIsMounted(false), 5000);
+
+    return () => {
+      window.clearTimeout(showTimer);
+      window.clearTimeout(fadeTimer);
+      window.clearTimeout(unmountTimer);
+    };
+  }, []);
+
+  if (!isMounted) return null;
+
+  return (
+    <div
+      className={`pointer-events-none absolute right-14 top-4 z-50 flex h-8 items-center rounded-full bg-black/55 px-3 text-xs font-medium text-white shadow-sm backdrop-blur-md transition-opacity duration-700 ${
+        isVisible && !isDismissed ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      클릭하면 음악이 재생됩니다
+    </div>
+  );
+}
+
 function GuestBgm({ bgm }: GuestBgmProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [isOn, setIsOn] = useState(false);
+  const [isHintDismissed, setIsHintDismissed] = useState(false);
+  const [isPosterReady, setIsPosterReady] = useState(false);
 
   const src = useMemo(() => {
     if (!bgm.selectedBgmId) return null;
@@ -94,14 +125,31 @@ function GuestBgm({ bgm }: GuestBgmProps) {
     };
   }, []);
 
+  useEffect(() => {
+    const handlePosterReady = () => setIsPosterReady(true);
+
+    window.addEventListener('guest-main-poster-ready', handlePosterReady, {
+      once: true,
+    });
+
+    return () => {
+      window.removeEventListener('guest-main-poster-ready', handlePosterReady);
+    };
+  }, []);
+
+  const handleToggle = () => {
+    setIsHintDismissed(true);
+    setIsOn(prev => !prev);
+  };
+
   return (
     <>
       <audio ref={audioRef} preload="none" />
       {src && (
-        <BgmToggleButton
-          isOn={isOn}
-          onToggle={() => setIsOn(prev => !prev)}
-        />
+        <>
+          {isPosterReady && <BgmPlaybackHint isDismissed={isHintDismissed} />}
+          <BgmToggleButton isOn={isOn} onToggle={handleToggle} />
+        </>
       )}
     </>
   );

--- a/app/guest/[id]/components/GuestMainPoster.tsx
+++ b/app/guest/[id]/components/GuestMainPoster.tsx
@@ -1,22 +1,40 @@
 'use client';
 import { StaticCanvas } from 'fabric';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import '@/widgets/mainPoster/libs/customImage-filter';
 
+const POSTER_BASE_WIDTH = 375;
+const POSTER_BASE_HEIGHT = 750;
+
 export const GuestMainPoster = ({ json }: { json: unknown }) => {
   const [canvas, setCanvas] = useState<StaticCanvas | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [renderStartTime] = useState(() => performance.now());
   const canvasInitTime = useRef<number>(0);
+
+  const updateCanvasSize = useCallback(() => {
+    if (!canvas || !containerRef.current) return;
+
+    const width = containerRef.current.clientWidth || POSTER_BASE_WIDTH;
+    const scale = width / POSTER_BASE_WIDTH;
+
+    canvas.setDimensions({
+      width,
+      height: POSTER_BASE_HEIGHT * scale,
+    });
+    canvas.setZoom(scale);
+    canvas.requestRenderAll();
+  }, [canvas]);
 
   useEffect(() => {
     if (!canvasRef.current) return;
 
     const startInit = performance.now();
     const fabricCanvas = new StaticCanvas(canvasRef.current, {
-      width: 375,
-      height: 750,
+      width: POSTER_BASE_WIDTH,
+      height: POSTER_BASE_HEIGHT,
       selection: false,
       skipTargetFind: true,
       renderOnAddRemove: false,
@@ -32,11 +50,28 @@ export const GuestMainPoster = ({ json }: { json: unknown }) => {
   }, []);
 
   useEffect(() => {
+    if (!canvas || !containerRef.current) return;
+
+    updateCanvasSize();
+
+    const resizeObserver = new ResizeObserver(updateCanvasSize);
+    resizeObserver.observe(containerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [canvas, updateCanvasSize]);
+
+  useEffect(() => {
     if (!canvas || !json) return;
 
     const loadStart = performance.now();
     canvas.loadFromJSON(json).then(() => {
+      updateCanvasSize();
       canvas.requestRenderAll();
+      window.requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('guest-main-poster-ready'));
+      });
 
       const loadEnd = performance.now();
       const totalTime = loadEnd - renderStartTime;
@@ -49,11 +84,11 @@ export const GuestMainPoster = ({ json }: { json: unknown }) => {
       );
       console.info(`- JSON Load Time: ${jsonLoadTime.toFixed(2)}ms`);
     });
-  }, [canvas, json, renderStartTime]);
+  }, [canvas, json, renderStartTime, updateCanvasSize]);
 
   return (
-    <div className="rounded-lg overflow-hidden">
-      <canvas ref={canvasRef} className="w-full" />
+    <div ref={containerRef} className="w-full overflow-hidden">
+      <canvas ref={canvasRef} />
     </div>
   );
 };

--- a/app/guest/[id]/guestPage.test.tsx
+++ b/app/guest/[id]/guestPage.test.tsx
@@ -214,7 +214,7 @@ describe('GuestPage 서버 컴포넌트 테스트', () => {
     expect(html).toContain('data-testid="guest-renderer"');
     expect(html).toContain('data-testid="guest-bgm"');
     expect(html).toContain('max-w-[430px]');
-    expect(html).toContain('max-w-[375px]');
+    expect(html).toContain('min-w-[375px]');
   });
 
   it('fetch 실패(res.ok === false)면 notFound()를 호출한다', async () => {

--- a/app/guest/[id]/page.tsx
+++ b/app/guest/[id]/page.tsx
@@ -104,13 +104,13 @@ export default async function GuestPage({
   return (
     <main className="min-h-screen bg-neutral-50">
       <div
-        className="relative mx-auto w-full max-w-[430px] bg-white shadow-sm"
+        className="relative mx-auto w-full min-w-[375px] max-w-[430px] bg-white shadow-sm"
         style={{
           backgroundColor: payload.bulkData.backgroundColor,
         }}
       >
         <GuestMainPoster json={payload.mainPoster} />
-        <div className="mx-auto w-full max-w-[375px]">
+        <div className="mx-auto w-full">
           <GuestRenderer blocks={payload.blocks} bulkData={payload.bulkData} />
         </div>
         <GuestBgm bgm={payload.bgm} />

--- a/components/organisms/account/preview/AccountsPerGroupPreview.tsx
+++ b/components/organisms/account/preview/AccountsPerGroupPreview.tsx
@@ -1,5 +1,9 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
 import { openAccountApp } from '@/app/api/account/openAccountApp';
 import { Button } from '@/components/atoms/button';
+import { ToastBar } from '@/components/molecules/toast/ToastBar';
 import CopyIcon from '@/shared/assets/icons/copy.svg';
 import KakaoIcon from '@/shared/assets/icons/kakao.svg';
 
@@ -10,6 +14,31 @@ type Account = {
   kakao: boolean;
 };
 
+const copyTextToClipboard = async (text: string) => {
+  if (navigator.clipboard?.writeText && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  const isCopied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+
+  if (!isCopied) {
+    throw new Error('Failed to copy account text');
+  }
+};
+
 export const AccountsPerGroupPreview = ({
   isOpenAccount,
   accountList,
@@ -17,9 +46,32 @@ export const AccountsPerGroupPreview = ({
   isOpenAccount: boolean;
   accountList: Account[];
 }) => {
+  const [showCopyToast, setShowCopyToast] = useState(false);
+  const [isCopyToastVisible, setIsCopyToastVisible] = useState(false);
+  const [copyToastKey, setCopyToastKey] = useState(0);
+
+  useEffect(() => {
+    if (copyToastKey === 0) return;
+
+    const fadeTimer = window.setTimeout(() => {
+      setIsCopyToastVisible(false);
+    }, 1500);
+    const unmountTimer = window.setTimeout(() => {
+      setShowCopyToast(false);
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(fadeTimer);
+      window.clearTimeout(unmountTimer);
+    };
+  }, [copyToastKey]);
+
   const handleCopyAccount = async (bank: string, account: string) => {
     try {
-      await navigator.clipboard.writeText(`${bank} ${account}`);
+      await copyTextToClipboard(`${bank} ${account}`);
+      setShowCopyToast(true);
+      setIsCopyToastVisible(true);
+      setCopyToastKey(prev => prev + 1);
       return true;
     } catch (error) {
       console.error('복사 실패:', error);
@@ -30,48 +82,67 @@ export const AccountsPerGroupPreview = ({
     openAccountApp();
   };
 
+  const copyToast =
+    showCopyToast && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            className={`fixed left-1/2 top-[calc(env(safe-area-inset-top)+16px)] z-[9999] w-[calc(100%-32px)] max-w-[375px] -translate-x-1/2 transition-opacity duration-500 ${
+              isCopyToastVisible ? 'opacity-100' : 'opacity-0'
+            }`}
+          >
+            <ToastBar variant="success" message="복사되었습니다." />
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
-    <div className="flex flex-col gap-3">
-      {isOpenAccount &&
-        accountList.map((account: Account, j: number) => (
-          <div key={j} className="flex items-center gap-2 w-full">
-            <Button
-              type="button"
-              variant="borderless"
-              className="w-8 h-8 flex-center"
-              onClick={() => handleCopyAccount(account.bank, account.account)}
-            >
-              <CopyIcon />
-            </Button>
-            <div className="flex flex-col w-full justify-center text-start h-[50px]">
-              <p className="text-[13px] text-start font-semibold text-border-liner">
-                {account.name}
-              </p>
-              <p className="text-[13px] font-normal text-border-liner">
-                {account.bank}
-              </p>
-              <p className="text-[13px] font-normal text-border-liner">
-                {account.account}
-              </p>
-            </div>
-            {account.kakao === true && (
+    <>
+      {copyToast}
+      <div className="flex flex-col gap-3">
+        {isOpenAccount &&
+          accountList.map((account: Account, j: number) => (
+            <div key={j} className="flex items-center gap-2 w-full">
               <Button
                 type="button"
                 variant="borderless"
-                className="w-10"
-                onClick={async () => {
-                  const success = await handleCopyAccount(
-                    account.bank,
-                    account.account
-                  );
-                  if (success) handleOpenKakao();
-                }}
+                className="w-8 h-8 flex-center"
+                onClick={() =>
+                  handleCopyAccount(account.bank, account.account)
+                }
               >
-                <KakaoIcon />
+                <CopyIcon />
               </Button>
-            )}
-          </div>
-        ))}
-    </div>
+              <div className="flex flex-col w-full justify-center text-start h-[50px]">
+                <p className="text-[13px] text-start font-semibold text-border-liner">
+                  {account.name}
+                </p>
+                <p className="text-[13px] font-normal text-border-liner">
+                  {account.bank}
+                </p>
+                <p className="text-[13px] font-normal text-border-liner">
+                  {account.account}
+                </p>
+              </div>
+              {account.kakao === true && (
+                <Button
+                  type="button"
+                  variant="borderless"
+                  className="w-10"
+                  onClick={async () => {
+                    const success = await handleCopyAccount(
+                      account.bank,
+                      account.account
+                    );
+                    if (success) handleOpenKakao();
+                  }}
+                >
+                  <KakaoIcon />
+                </Button>
+              )}
+            </div>
+          ))}
+      </div>
+    </>
   );
 };

--- a/components/organisms/interview/InterviewPreview.tsx
+++ b/components/organisms/interview/InterviewPreview.tsx
@@ -67,7 +67,7 @@ export const InterviewPreview = ({
           options={carouselOptions}
           isButtonShow={false}
           className="h-full w-full"
-          carouselClassName="gap-3"
+          carouselClassName="gap-8"
           autoscroll={isAutoScrollActive}
           autoscrollOptions={autoscrollOptions}
           loop={isAutoScrollActive}
@@ -77,7 +77,7 @@ export const InterviewPreview = ({
               key={`${question.questionId}-${index}`}
               className={cn(
                 'w-full',
-                (displayItems?.length ?? 0) > 1 && index === 0 ? 'ml-3' : '',
+                (displayItems?.length ?? 0) > 1 && index === 0 ? 'ml-8' : '',
                 (displayItems?.length ?? 0) === 1 && 'flex-center'
               )}
             >

--- a/components/organisms/myFamilyWedding/Member.tsx
+++ b/components/organisms/myFamilyWedding/Member.tsx
@@ -54,6 +54,7 @@ export const Member = ({
         <Selector
           type="normal"
           className="w-21.5"
+          customInputClassName="text-center"
           placeholder="관계"
           options={[
             { value: '부', label: '부' },

--- a/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
+++ b/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
@@ -1,6 +1,5 @@
 import Flower from '@/shared/assets/icons/flower.svg';
 import type { EditorBlock } from '@/shared/types/block';
-import { cn } from '@/shared/utils/cn';
 
 import { MiddlePreviewWrapper } from '../wrapper/MiddlePreviewWrapper';
 
@@ -20,7 +19,7 @@ export const MyFamilyWeddingPreview = ({
 
   return (
     <MiddlePreviewWrapper
-      className={cn(className, 'py-0')}
+      className={className}
       enTitle="MY FAMILY"
       noTitle={true}
       titleClassName={titleClassName}

--- a/components/organisms/notice/NoticePreview.tsx
+++ b/components/organisms/notice/NoticePreview.tsx
@@ -79,7 +79,7 @@ export const NoticePreview = ({
               key={`preview-${notice.noticeId}-${index}`}
               className={cn(
                 'w-full',
-                displayNoticeList.length > 1 && index === 0 ? 'ml-8' : '',
+                (displayNoticeList?.length ?? 0) > 1 && index === 0 ? 'ml-8' : '',
                 displayNoticeList.length === 1 && 'flex-center'
               )}
             >

--- a/components/organisms/notice/NoticePreview.tsx
+++ b/components/organisms/notice/NoticePreview.tsx
@@ -69,7 +69,7 @@ export const NoticePreview = ({
           options={carouselOptions}
           isButtonShow={false}
           className="h-full w-full"
-          carouselClassName="gap-3"
+          carouselClassName="gap-8"
           autoscroll={isAutoScrollActive}
           autoscrollOptions={autoscrollOptions}
           loop={isAutoScrollActive}
@@ -79,7 +79,7 @@ export const NoticePreview = ({
               key={`preview-${notice.noticeId}-${index}`}
               className={cn(
                 'w-full',
-                displayNoticeList.length > 1 && index === 0 ? 'ml-3' : '',
+                displayNoticeList.length > 1 && index === 0 ? 'ml-8' : '',
                 displayNoticeList.length === 1 && 'flex-center'
               )}
             >


### PR DESCRIPTION
## 작업 개요

게스트 페이지의 모바일/렌더링 UX를 개선하고, 일부 프리뷰 컴포넌트의 간격 및 알림 동작을 보정했습니다.

## 작업 내용

- [x] 게스트 페이지 전체 폭을 `min 375px / max 430px` 구조로 통일
- [x] 게스트 렌더러 내부 `max-w-[375px]` 제한 제거
- [x] 메인 포스터가 게스트 컨테이너 폭에 맞게 꽉 차도록 Fabric canvas 크기/스케일 조정
- [x] 메인 포스터의 border-radius 제거
- [x] BGM 버튼 안내문 추가
- [x] 메인 포스터 렌더 완료 후 BGM 안내문이 페이드인되도록 처리
- [x] BGM 안내문 5초 후 페이드아웃 및 제거
- [x] 웨딩 가족소개 셀렉터 직접입력 값 중앙정렬 적용
- [x] 웨딩 가족소개 프리뷰의 위아래 패딩 복구
- [x] 인터뷰/공지사항 캐러셀 카드 간격 및 초기 시작 여백 조정
- [x] 계좌번호 복사 성공 알림 추가
- [x] 계좌번호 복사 알림 페이드아웃 적용
- [x] 모바일 Clipboard API 실패 대응 fallback 복사 로직 추가
- [x] 복사 알림을 portal로 렌더링해 모바일에서도 표시되도록 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx eslint` pre-push hook 통과
- `npx jest --runTestsByPath "app/guest/[id]/guestPage.test.tsx" --runInBand` 통과
- 게스트 페이지 테스트 5개 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배경음악 재생 시 도움말 힌트 추가
  * 계정 정보 클립보드 복사 기능 구현

* **개선사항**
  * 반응형 캔버스 렌더링으로 다양한 화면 크기 지원
  * 캐러셀 및 슬라이드 간격 조정으로 더 나은 시각적 배치
  * 최소 너비 제약으로 레이아웃 안정성 향상
  * 입력 필드 텍스트 정렬 개선

* **테스트**
  * 반응형 레이아웃 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->