### PR TITLE
[feat] 대시보드 삭제 버튼 연결 및 예외처리

### DIFF
--- a/app/dashboard/components/carousel/CarouselBase.tsx
+++ b/app/dashboard/components/carousel/CarouselBase.tsx
@@ -16,11 +16,13 @@ type CarouselBaseProps = {
   showCenterActions?: boolean;
   stageHeight?: string;
   selectedLift?: string;
+  onDelete?: (folderId: string) => void | Promise<void>;
   onUpdate?: (folderId: string, uuid?: string) => void;
   onPublish?: (folderId: string) => void;
   onCopyUrl?: (folderId: string) => void;
   onShare?: (folderId: string) => Promise<void>;
   getPublishedUrl?: (folderId: string) => string | null;
+  isDeleting?: (folderId: string) => boolean;
   isSharing?: (folderId: string) => boolean;
   isPublishing?: (folderId: string) => boolean;
 };
@@ -33,11 +35,13 @@ function CarouselBase({
   showCenterActions = false,
   stageHeight = dashboardCarouselLayout.stageHeight,
   selectedLift,
+  onDelete,
   onUpdate,
   onPublish,
   onCopyUrl,
   onShare,
   getPublishedUrl,
+  isDeleting,
   isSharing,
   isPublishing,
 }: CarouselBaseProps) {
@@ -128,11 +132,13 @@ function CarouselBase({
         showCenterActions={showCenterActions}
         selectedLift={selectedLift}
         onSelect={handleSelect}
+        onDelete={onDelete}
         onUpdate={onUpdate}
         onPublish={onPublish}
         onCopyUrl={onCopyUrl}
         onShare={onShare}
         getPublishedUrl={getPublishedUrl}
+        isDeleting={isDeleting}
         isSharing={isSharing}
         isPublishing={isPublishing}
       />

--- a/app/dashboard/components/carousel/CarouselTrack.tsx
+++ b/app/dashboard/components/carousel/CarouselTrack.tsx
@@ -1,4 +1,7 @@
-import { dashboardCarouselLayout, dashboardCarouselVars } from './carouselLayout';
+import {
+  dashboardCarouselLayout,
+  dashboardCarouselVars,
+} from './carouselLayout';
 import { CarouselCardItem } from './carouselTypes';
 import CarouselItem from './item/CarouselItem';
 
@@ -12,11 +15,13 @@ type CarouselTrackProps = {
   showCenterActions?: boolean;
   selectedLift?: string;
   onSelect: (index: number) => void;
+  onDelete?: (folderId: string) => void | Promise<void>;
   onUpdate?: (folderId: string, uuid?: string) => void;
   onPublish?: (folderId: string) => void;
   onCopyUrl?: (folderId: string) => void;
   onShare?: (folderId: string) => Promise<void>;
   getPublishedUrl?: (folderId: string) => string | null;
+  isDeleting?: (folderId: string) => boolean;
   isSharing?: (folderId: string) => boolean;
   isPublishing?: (folderId: string) => boolean;
 };
@@ -31,11 +36,13 @@ function CarouselTrack({
   showCenterActions = false,
   selectedLift,
   onSelect,
+  onDelete,
   onUpdate,
   onPublish,
   onCopyUrl,
   onShare,
   getPublishedUrl,
+  isDeleting,
   isSharing,
   isPublishing,
 }: CarouselTrackProps) {
@@ -69,6 +76,7 @@ function CarouselTrack({
             showCenterActions={showCenterActions}
             selectedLift={selectedLift}
             onSelect={onSelect}
+            onDelete={onDelete}
             onUpdate={onUpdate}
             onPublish={onPublish}
             onCopyUrl={onCopyUrl}
@@ -77,6 +85,11 @@ function CarouselTrack({
               item.invite && getPublishedUrl
                 ? getPublishedUrl(item.invite.folderId)
                 : null
+            }
+            isDeleting={
+              item.invite && isDeleting
+                ? isDeleting(item.invite.folderId)
+                : false
             }
             isSharing={
               item.invite && isSharing ? isSharing(item.invite.folderId) : false

--- a/app/dashboard/components/carousel/CarouselWrapper.tsx
+++ b/app/dashboard/components/carousel/CarouselWrapper.tsx
@@ -23,17 +23,20 @@ function CarouselWrapper({
   const {
     invites,
     loading,
+    handleDelete,
     handleUpdate,
     handlePublish,
     handleCopyPublishedUrl,
     handleShare,
     getPublishedUrl,
+    isDeleting,
     isSharing,
     isPublishing,
   } = useDashboardInvitations(initialInvites, { loadOnMount });
+  const orderedInvites = useMemo(() => [...invites].reverse(), [invites]);
   const items: CarouselCardItem[] = useMemo(
     () =>
-      invites.map(invite => {
+      orderedInvites.map(invite => {
         const showcaseItem = getInvitationShowcaseItem(invite.folderId);
 
         return {
@@ -46,7 +49,7 @@ function CarouselWrapper({
           invite,
         };
       }),
-    [invites]
+    [orderedInvites]
   );
 
   if (loading) {
@@ -56,17 +59,19 @@ function CarouselWrapper({
   return (
     <CarouselBase
       items={items}
-      startIndex={Math.max(invites.length - 1, 0)}
+      startIndex={Math.max(orderedInvites.length - 1, 0)}
       stageHeight={dashboardCarouselLayout.dashboardStageHeight}
       selectedLift={dashboardCarouselLayout.dashboardSelectedLift}
       showHeader
       showSideActions
       showCenterActions
+      onDelete={handleDelete}
       onUpdate={handleUpdate}
       onPublish={handlePublish}
       onCopyUrl={handleCopyPublishedUrl}
       onShare={handleShare}
       getPublishedUrl={getPublishedUrl}
+      isDeleting={isDeleting}
       isSharing={isSharing}
       isPublishing={isPublishing}
     />

--- a/app/dashboard/components/carousel/item/CarouselItem.tsx
+++ b/app/dashboard/components/carousel/item/CarouselItem.tsx
@@ -20,11 +20,13 @@ type CarouselItemProps = {
   showCenterActions?: boolean;
   selectedLift?: string;
   onSelect: (index: number) => void;
+  onDelete?: (folderId: string) => void | Promise<void>;
   onUpdate?: (folderId: string, uuid?: string) => void;
   onPublish?: (folderId: string) => void;
   onCopyUrl?: (folderId: string) => void;
   onShare?: (folderId: string) => Promise<void>;
   publishedUrl: string | null;
+  isDeleting: boolean;
   isSharing: boolean;
   isPublishing: boolean;
 };
@@ -38,28 +40,28 @@ function CarouselItem({
   showCenterActions = false,
   selectedLift: selectedLiftProp = dashboardCarouselLayout.selectedLift,
   onSelect,
+  onDelete,
   onUpdate,
   onPublish,
   onCopyUrl,
   onShare,
   publishedUrl,
+  isDeleting,
   isSharing,
   isPublishing,
 }: CarouselItemProps) {
   const [isHovered, setIsHovered] = useState(false);
   const invite = item.invite;
-  const showSelectedOverlay = showHeader || showSideActions || showCenterActions;
+  const canShare = Boolean(invite?.hasKakaoShareData);
+  const showSelectedOverlay =
+    showHeader || showSideActions || showCenterActions;
   const hoverLift = showHeader
     ? `calc(${selectedLiftProp} - ${dashboardCarouselLayout.headerHeight})`
     : selectedLiftProp;
   const selectedLift = showHeader
     ? `calc(${selectedLiftProp} + ${dashboardCarouselLayout.headerHeight})`
     : selectedLiftProp;
-  const translateY = isSelected
-    ? selectedLift
-    : isHovered
-      ? hoverLift
-      : null;
+  const translateY = isSelected ? selectedLift : isHovered ? hoverLift : null;
 
   const handleActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -95,7 +97,9 @@ function CarouselItem({
         className="relative overflow-visible transition-transform"
         style={{
           transitionDuration: `${dashboardCarouselLayout.cardLiftDurationMs}ms`,
-          transform: translateY ? `translateY(calc(-1 * ${translateY}))` : undefined,
+          transform: translateY
+            ? `translateY(calc(-1 * ${translateY}))`
+            : undefined,
           height:
             isSelected && showHeader
               ? dashboardCarouselLayout.selectedVisualHeight
@@ -109,28 +113,39 @@ function CarouselItem({
               top: dashboardCarouselLayout.actionTop,
               right: dashboardCarouselLayout.actionRight,
               gap: dashboardCarouselLayout.sideActionGap,
+              minHeight: `calc(${dashboardCarouselLayout.sideActionSize} * 2 + ${dashboardCarouselLayout.sideActionGap})`,
             }}
           >
             <button
               type="button"
-              onClick={handleActionClick}
-              className="cursor-pointer"
+              disabled={isDeleting}
+              onClick={event => {
+                handleActionClick(event);
+                if (isDeleting) return;
+                void onDelete?.(invite.folderId);
+              }}
+              className={
+                isDeleting ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+              }
+              aria-disabled={isDeleting}
             >
               <DeleteButton />
             </button>
-            <button
-              type="button"
-              disabled={isSharing}
-              onClick={event => {
-                handleActionClick(event);
-                if (isSharing) return;
-                void onShare?.(invite.folderId);
-              }}
-              className={isSharing ? 'cursor-not-allowed' : 'cursor-pointer'}
-              aria-disabled={isSharing}
-            >
-              <ShareButton disabled={isSharing} />
-            </button>
+            {canShare && (
+              <button
+                type="button"
+                disabled={isSharing}
+                onClick={event => {
+                  handleActionClick(event);
+                  if (isSharing) return;
+                  void onShare?.(invite.folderId);
+                }}
+                className={isSharing ? 'cursor-not-allowed' : 'cursor-pointer'}
+                aria-disabled={isSharing}
+              >
+                <ShareButton disabled={isSharing} />
+              </button>
+            )}
           </div>
         )}
 

--- a/app/dashboard/server/loadDashboardInvitations.ts
+++ b/app/dashboard/server/loadDashboardInvitations.ts
@@ -1,10 +1,10 @@
 import 'server-only';
 
+import { ensureShareUrlFile } from '@/app/api/drive/_lib/ensureShareUrlFile';
 import {
   THUMBNAIL_KIND,
   THUMBNAIL_NAME,
 } from '@/app/api/drive/_lib/ensureThumbnailFile';
-import { ensureShareUrlFile } from '@/app/api/drive/_lib/ensureShareUrlFile';
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { escapeDriveQueryValue } from '@/app/api/drive/_lib/escapeQueryValue';
 import { findWorkspaceFolderId } from '@/app/api/drive/_lib/findWorkspaceFolderId';

--- a/app/dashboard/server/loadDashboardInvitations.ts
+++ b/app/dashboard/server/loadDashboardInvitations.ts
@@ -4,6 +4,7 @@ import {
   THUMBNAIL_KIND,
   THUMBNAIL_NAME,
 } from '@/app/api/drive/_lib/ensureThumbnailFile';
+import { ensureShareUrlFile } from '@/app/api/drive/_lib/ensureShareUrlFile';
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { escapeDriveQueryValue } from '@/app/api/drive/_lib/escapeQueryValue';
 import { findWorkspaceFolderId } from '@/app/api/drive/_lib/findWorkspaceFolderId';
@@ -167,6 +168,15 @@ async function loadThumbnailUrl(
   }
 }
 
+async function hasKakaoShareData(invitationFolderId: string): Promise<boolean> {
+  try {
+    const { shareUrlFileId } = await ensureShareUrlFile(invitationFolderId);
+    return Boolean(shareUrlFileId);
+  } catch {
+    return false;
+  }
+}
+
 export async function loadDashboardInvitations(): Promise<LoadInvitationResponse> {
   const workspaceFolderId = await findWorkspaceFolderId();
 
@@ -221,14 +231,16 @@ export async function loadDashboardInvitations(): Promise<LoadInvitationResponse
 
   const invites = await Promise.all(
     invitationFolders.map(async invite => {
-      const [publishedUrl, thumbnailUrl] = await Promise.all([
+      const [publishedUrl, thumbnailUrl, hasShareData] = await Promise.all([
         loadPublishedUrl(invite.folderId),
         loadThumbnailUrl(invite.folderId),
+        hasKakaoShareData(invite.folderId),
       ]);
       return {
         ...invite,
         publishedUrl,
         thumbnailUrl,
+        hasKakaoShareData: hasShareData,
       };
     })
   );

--- a/app/dashboard/types.ts
+++ b/app/dashboard/types.ts
@@ -5,6 +5,7 @@ export type InviteListItem = {
   invitationUuid?: string;
   publishedUrl?: string | null;
   thumbnailUrl?: string | null;
+  hasKakaoShareData?: boolean;
 };
 
 export type KakaoShareData = {


### PR DESCRIPTION
## 작업 개요

대시보드 초대장 카드의 액션 동작과 표시 조건을 정리했습니다.

## 작업 내용

- [x] 삭제 버튼 클릭 시 실제 삭제 로직이 호출되도록 연결
- [x] 초대장 표시 순서 reverse 처리
- [x] `kakao-share.json`이 없는 초대장은 카카오톡 공유 버튼 미노출 처리

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npm run lint` 통과
- `npm run build` 통과
- `npm test -- --runTestsByPath app/dashboard/hooks/useDashboardInvitations.test.tsx` 통과
