### PR TITLE
[feat] 계좌번호 프리뷰 디자인 조정

### DIFF
--- a/components/organisms/account/preview/AccountsPerGroupPreview.tsx
+++ b/components/organisms/account/preview/AccountsPerGroupPreview.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 
 import { openAccountApp } from '@/app/api/account/openAccountApp';
 import { Button } from '@/components/atoms/button';
-import { ToastBar } from '@/components/molecules/toast/ToastBar';
 import CopyIcon from '@/shared/assets/icons/copy.svg';
 import KakaoIcon from '@/shared/assets/icons/kakao.svg';
 
@@ -74,10 +73,11 @@ export const AccountsPerGroupPreview = ({
       setCopyToastKey(prev => prev + 1);
       return true;
     } catch (error) {
-      console.error('복사 실패:', error);
+      console.error('copy failed:', error);
       return false;
     }
   };
+
   const handleOpenKakao = () => {
     openAccountApp();
   };
@@ -86,11 +86,13 @@ export const AccountsPerGroupPreview = ({
     showCopyToast && typeof document !== 'undefined'
       ? createPortal(
           <div
-            className={`fixed left-1/2 top-[calc(env(safe-area-inset-top)+16px)] z-[9999] w-[calc(100%-32px)] max-w-[375px] -translate-x-1/2 transition-opacity duration-500 ${
+            className={`fixed left-1/2 top-[calc(env(safe-area-inset-top)+16px)] z-[9999] -translate-x-1/2 transition-opacity duration-500 ${
               isCopyToastVisible ? 'opacity-100' : 'opacity-0'
             }`}
           >
-            <ToastBar variant="success" message="복사되었습니다." />
+            <div className="w-fit whitespace-nowrap rounded-xl bg-white p-5 text-center text-sm font-semibold text-text-primary shadow-[0_8px_24px_-8px_rgba(0,0,0,0.18),0_24px_60px_-20px_rgba(0,0,0,0.12)]">
+              복사가 완료되었어요!
+            </div>
           </div>,
           document.body
         )
@@ -99,21 +101,14 @@ export const AccountsPerGroupPreview = ({
   return (
     <>
       {copyToast}
-      <div className="flex flex-col gap-3">
-        {isOpenAccount &&
-          accountList.map((account: Account, j: number) => (
-            <div key={j} className="flex items-center gap-2 w-full">
-              <Button
-                type="button"
-                variant="borderless"
-                className="w-8 h-8 flex-center"
-                onClick={() =>
-                  handleCopyAccount(account.bank, account.account)
-                }
-              >
-                <CopyIcon />
-              </Button>
-              <div className="flex flex-col w-full justify-center text-start h-[50px]">
+      {isOpenAccount && (
+        <div className="flex flex-col gap-2 pb-[11px] pt-2">
+          {accountList.map((account: Account, j: number) => (
+            <div
+              key={j}
+              className="flex min-h-13 w-full shrink-0 items-center gap-2 pl-3 pr-2"
+            >
+              <div className="flex h-full w-full flex-col justify-center text-start">
                 <p className="text-[13px] text-start font-semibold text-border-liner">
                   {account.name}
                 </p>
@@ -124,25 +119,38 @@ export const AccountsPerGroupPreview = ({
                   {account.account}
                 </p>
               </div>
-              {account.kakao === true && (
+              <div className="flex shrink-0 items-center justify-start gap-0.5">
                 <Button
                   type="button"
                   variant="borderless"
-                  className="w-10"
-                  onClick={async () => {
-                    const success = await handleCopyAccount(
-                      account.bank,
-                      account.account
-                    );
-                    if (success) handleOpenKakao();
-                  }}
+                  className="size-11 flex-center"
+                  onClick={() =>
+                    handleCopyAccount(account.bank, account.account)
+                  }
                 >
-                  <KakaoIcon />
+                  <CopyIcon />
                 </Button>
-              )}
+                {account.kakao === true && (
+                  <Button
+                    type="button"
+                    variant="borderless"
+                    className="size-11 flex-center"
+                    onClick={async () => {
+                      const success = await handleCopyAccount(
+                        account.bank,
+                        account.account
+                      );
+                      if (success) handleOpenKakao();
+                    }}
+                  >
+                    <KakaoIcon width={36} height={36} />
+                  </Button>
+                )}
+              </div>
             </div>
           ))}
-      </div>
+        </div>
+      )}
     </>
   );
 };

--- a/components/organisms/account/preview/GroupPreview.tsx
+++ b/components/organisms/account/preview/GroupPreview.tsx
@@ -16,9 +16,9 @@ export const GroupPreview = ({
     setIsOpenAccount(prev => !prev);
   };
   return (
-    <div className="relative flex flex-col px-1 py-2 justify-center w-66 border border-border-button rounded-lg shadow-btn-drop-black">
+    <div className="relative flex w-70 flex-col justify-center overflow-hidden rounded-lg border border-border-button shadow-btn-drop-black">
       <Button
-        className="text-sm text-text-secondary w-full border-none"
+        className="h-[43px] w-full border-none py-2 text-sm text-text-secondary font-bold"
         type="button"
         onClick={handleOpenAccount}
       >


### PR DESCRIPTION
## 작업 개요

계좌번호 프리뷰의 버튼 배치와 복사 완료 알림 UI를 개선했습니다.

## 작업 내용

- [x] 계좌번호 프리뷰 디자인 조정
- [x] 복사 완료 알림창 디자인 교체

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npm run lint` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선사항**
  * 계정 복사 알림 UI를 개선하여 더 나은 사용자 경험 제공
  * 계정 행 레이아웃 및 스타일링을 재조정
  * 카카오 버튼 동작을 개선하여 복사 완료 후에만 앱이 열리도록 변경
  * 그룹 미리보기 컨테이너 및 버튼 스타일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->