### PR TITLE
[feat] 플레이스, 신랑신부소개 컴포넌트 ui 폴리싱

### DIFF
--- a/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
@@ -109,14 +109,14 @@ function CoupleIntroductionPreview({
       koTitleDefault="신랑・신부 소개"
       {...rest}
     >
-      <div className="flex flex-row gap-4.5">
+      <div className="flex w-full flex-row gap-4.5">
         {profileItems.map(profile => (
           <div
             key={profile.key}
-            className="w-40 flex flex-col justify-center items-center gap-4"
+            className="flex min-w-0 flex-1 flex-col items-center justify-center gap-4"
           >
             {profile.imageSrc ? (
-              <div className="relative size-40 rounded-3xl overflow-hidden">
+              <div className="relative aspect-square w-full overflow-hidden rounded-3xl">
                 <Image
                   src={profile.imageSrc}
                   alt={`${profile.label} 사진`}
@@ -125,7 +125,7 @@ function CoupleIntroductionPreview({
                 />
               </div>
             ) : (
-              <div className="size-40 rounded-3xl bg-border-neutral flex justify-center items-center">
+              <div className="flex aspect-square w-full items-center justify-center rounded-3xl bg-border-neutral">
                 <p>사진을 추가해 주세요.</p>
               </div>
             )}

--- a/components/organisms/place/Navigation.tsx
+++ b/components/organisms/place/Navigation.tsx
@@ -39,7 +39,7 @@ export function Navigation({ lat, lng, name }: Props) {
         <Button
           variant="bordered"
           size="sm"
-          className="w-26.5 shadow-btn-drop-black"
+          className="h-auto w-26.5 shadow-btn-drop-black"
           onClick={() => handleNavigation('naver')}
         >
           <MapIcon />
@@ -48,7 +48,7 @@ export function Navigation({ lat, lng, name }: Props) {
         <Button
           variant="bordered"
           size="sm"
-          className="w-26.5 shadow-btn-drop-black"
+          className="h-auto w-26.5 shadow-btn-drop-black"
           onClick={() => handleNavigation('kakao')}
         >
           <MapIcon />
@@ -57,7 +57,7 @@ export function Navigation({ lat, lng, name }: Props) {
         <Button
           variant="bordered"
           size="sm"
-          className="w-26.5 shadow-btn-drop-black"
+          className="h-auto w-26.5 shadow-btn-drop-black"
           onClick={() => handleNavigation('tmap')}
         >
           <MapIcon />

--- a/components/organisms/place/PlacePreview.tsx
+++ b/components/organisms/place/PlacePreview.tsx
@@ -36,6 +36,7 @@ export const PlacePreview = ({
   return (
     <MiddlePreviewWrapper
       className={className}
+      childClassName="gap-6"
       titleClassName={titleClassName}
       checkedEnglishTitle={checkedEnglishTitle}
       enTitle={englishTitle}
@@ -49,9 +50,9 @@ export const PlacePreview = ({
         <p className="font-semibold text-[16px]">
           {placeName} {placeDetail}
         </p>
-        <p className="font-semibold pb-2.5 text-sm">{placeAddress}</p>
+        <p className="font-semibold text-sm">{placeAddress}</p>
       </section>
-      <p className="font-normal text-text-tertiary pb-2.5">
+      <p className="font-normal text-text-tertiary">
         TEL. {formatPhoneNumber(placeTel)}
       </p>
 


### PR DESCRIPTION
## 작업 개요

플레이스 프리뷰와 신랑・신부 소개 프리뷰의 레이아웃 간격 및 이미지 반응형 처리를 조정했습니다.

## 작업 내용

- [x] 플레이스 프리뷰 각 요소 간격을 24px로 조정
- [x] 플레이스 프리뷰 주소/TEL 텍스트의 하단 패딩 제거
- [x] 길안내 버튼 높이를 패딩 기반 38px로 조정
- [x] 신랑・신부 소개 프리뷰 사진 영역을 가변 너비 정사각형으로 변경
- [x] 신랑・신부 사진 사이 간격은 기존 18px 유지

## 관련 이슈

Closes #

## 테스트 결과 보고

`npx tsc --noEmit` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 프로필 미리보기의 레이아웃을 유연한 크기 조정으로 개선했습니다.
  * 네비게이션 버튼의 높이를 최적화했습니다.
  * 장소 정보의 여백과 간격을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->