### PR TITLE
[refactor] 초대장 발행 로직 개선 및 에러처리 보강

### DIFF
--- a/app/api/drive/_lib/ensureDataJsonFile.ts
+++ b/app/api/drive/_lib/ensureDataJsonFile.ts
@@ -2,6 +2,7 @@
 
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+import { BODY_BULK_DATA, TITLE_BULK_DATA } from '@/shared/data/sample/bulkData';
 import { createDefaultShareUrlState } from '@/shared/utils/shareUrlDefaults';
 
 import { escapeDriveQueryValue } from './escapeQueryValue';
@@ -23,6 +24,12 @@ const DATA_JSON_NAME = 'data.json';
 const DATA_JSON_KIND = 'invitation_data_json';
 
 const DEFAULT_DATA_JSON_PAYLOAD = {
+  bulkData: {
+    backgroundColor: '#FFFFFF',
+    titleData: TITLE_BULK_DATA,
+    bodyData: BODY_BULK_DATA,
+    isZoom: false,
+  },
   blocks: [],
   shareUrl: createDefaultShareUrlState(),
   bgm: {
@@ -37,6 +44,7 @@ const DEFAULT_DATA_JSON_PAYLOAD = {
     version: '7.1.0',
     objects: [],
   },
+  invitationImage: [],
 };
 
 // "invitation 폴더 내에 단일 data.json 초대 파일이 존재하는지 확인합니다. 파일이 없는 경우, 파일을 생성하고 유효한 기본 페이로드(payload)로 초기화합니다."

--- a/app/api/drive/_lib/guestReadiness.ts
+++ b/app/api/drive/_lib/guestReadiness.ts
@@ -1,0 +1,100 @@
+import 'server-only';
+
+import { isGuestPayload } from '@/app/guest/[id]/utils/guestBlockTypeGuards';
+
+export type ProbeFailureReason =
+  | 'fetch_failed'
+  | 'http_not_ok'
+  | 'json_parse_failed'
+  | 'invalid_schema';
+
+export type ProbeResult =
+  | { ok: true; status: number }
+  | {
+      ok: false;
+      status: number;
+      reason: ProbeFailureReason;
+      error?: string;
+      rawPreview?: string;
+    };
+
+export type ReadinessResult =
+  | { ok: true; attempt: number }
+  | { ok: false; attempts: number; lastProbe: ProbeResult | null };
+
+export const guestPath = (dataJsonFileId: string) =>
+  `/guest/${dataJsonFileId}`;
+
+const guestDataUrl = (dataJsonFileId: string) =>
+  `https://drive.google.com/uc?export=download&id=${encodeURIComponent(
+    dataJsonFileId
+  )}`;
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+export async function probeGuestData(
+  dataJsonFileId: string
+): Promise<ProbeResult> {
+  let res: Response;
+  try {
+    res = await fetch(guestDataUrl(dataJsonFileId), { cache: 'no-store' });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      reason: 'fetch_failed',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!res.ok) {
+    return { ok: false, status: res.status, reason: 'http_not_ok' };
+  }
+
+  const raw = await res.text();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      status: res.status,
+      reason: 'json_parse_failed',
+      rawPreview: raw.slice(0, 200),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!isGuestPayload(parsed)) {
+    return { ok: false, status: res.status, reason: 'invalid_schema' };
+  }
+
+  return { ok: true, status: res.status };
+}
+
+export async function waitUntilGuestReady(
+  dataJsonFileId: string,
+  options: { maxAttempts: number; delayMs: number }
+): Promise<ReadinessResult> {
+  const { maxAttempts, delayMs } = options;
+  let lastProbe: ProbeResult | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const probe = await probeGuestData(dataJsonFileId);
+    if (probe.ok) {
+      return { ok: true, attempt };
+    }
+
+    lastProbe = probe;
+
+    if (attempt < maxAttempts) {
+      await sleep(delayMs);
+    }
+  }
+
+  return { ok: false, attempts: maxAttempts, lastProbe };
+}

--- a/app/api/drive/_lib/guestReadiness.ts
+++ b/app/api/drive/_lib/guestReadiness.ts
@@ -4,6 +4,7 @@ import { isGuestPayload } from '@/app/guest/[id]/utils/guestBlockTypeGuards';
 
 export type ProbeFailureReason =
   | 'fetch_failed'
+  | 'fetch_timeout'
   | 'http_not_ok'
   | 'json_parse_failed'
   | 'invalid_schema';
@@ -30,24 +31,40 @@ const guestDataUrl = (dataJsonFileId: string) =>
     dataJsonFileId
   )}`;
 
+const PROBE_FETCH_TIMEOUT_MS = 3000;
+
 const sleep = (ms: number) =>
   new Promise<void>(resolve => {
     setTimeout(resolve, ms);
   });
 
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 export async function probeGuestData(
   dataJsonFileId: string
 ): Promise<ProbeResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, PROBE_FETCH_TIMEOUT_MS);
+
   let res: Response;
   try {
-    res = await fetch(guestDataUrl(dataJsonFileId), { cache: 'no-store' });
+    res = await fetch(guestDataUrl(dataJsonFileId), {
+      cache: 'no-store',
+      signal: controller.signal,
+    });
   } catch (error) {
     return {
       ok: false,
       status: 0,
-      reason: 'fetch_failed',
+      reason: isAbortError(error) ? 'fetch_timeout' : 'fetch_failed',
       error: error instanceof Error ? error.message : String(error),
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   if (!res.ok) {

--- a/app/api/drive/publishInvitation/readiness/route.test.ts
+++ b/app/api/drive/publishInvitation/readiness/route.test.ts
@@ -49,7 +49,12 @@ global.fetch = mockFetch as unknown as typeof fetch;
 describe('publishInvitation readiness Route Handler 테스트', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.useRealTimers();
     global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('dataJsonFileId가 없으면 400을 반환한다', async () => {
@@ -123,6 +128,46 @@ describe('publishInvitation readiness Route Handler 테스트', () => {
         ok: false,
         status: 404,
         reason: 'http_not_ok',
+      },
+    });
+  });
+
+  it('guest 데이터 확인 요청이 오래 걸리면 timeout pending을 반환한다', async () => {
+    jest.useFakeTimers();
+
+    mockFetch.mockImplementation(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        })
+    );
+
+    const req = new Request(
+      'http://localhost/api/drive/publishInvitation/readiness?dataJsonFileId=data-json-file-id-timeout'
+    );
+
+    const responsePromise = GET(req);
+
+    await jest.advanceTimersByTimeAsync(3000);
+
+    const res = await responsePromise;
+    const json = await res.json();
+
+    expect(res.status).toBe(202);
+    expect(json).toMatchObject({
+      ok: true,
+      published: true,
+      ready: false,
+      guestUrl: '/guest/data-json-file-id-timeout',
+      dataJsonFileId: 'data-json-file-id-timeout',
+      warning: 'guest_not_ready',
+      status: 202,
+      details: {
+        ok: false,
+        status: 0,
+        reason: 'fetch_timeout',
       },
     });
   });

--- a/app/api/drive/publishInvitation/readiness/route.test.ts
+++ b/app/api/drive/publishInvitation/readiness/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/drive/publishInvitation/readiness/route';
+
+const validGuestPayload = {
+  bulkData: {
+    backgroundColor: '#ffffff',
+    titleData: {
+      font: 'font-maruburi',
+      fontSize: '20px',
+      color: '#FA7564',
+      bold: false,
+      italic: false,
+      align: 'center',
+      isDefault: false,
+    },
+    bodyData: {
+      font: 'font-maruburi',
+      fontSize: '16px',
+      color: '#222222',
+      bold: false,
+      italic: false,
+      align: 'left',
+      isDefault: false,
+    },
+    isZoom: false,
+  },
+  blocks: [],
+  bgm: {
+    selectedBgmId: null,
+    isLoop: false,
+    volume: 0.2,
+    userBgmTitle: null,
+    userBgmDuration: null,
+    userBgmFileId: null,
+  },
+  mainPoster: {
+    version: '7.1.0',
+    objects: [],
+  },
+};
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('publishInvitation readiness Route Handler 테스트', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it('dataJsonFileId가 없으면 400을 반환한다', async () => {
+    const req = new Request(
+      'http://localhost/api/drive/publishInvitation/readiness'
+    );
+
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json).toEqual({
+      ok: false,
+      error: 'dataJsonFileId required',
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('guest 데이터가 준비되어 있으면 ready true를 반환한다', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue(JSON.stringify(validGuestPayload)),
+    });
+
+    const req = new Request(
+      'http://localhost/api/drive/publishInvitation/readiness?dataJsonFileId=data-json-file-id-1'
+    );
+
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      ok: true,
+      published: true,
+      ready: true,
+      guestUrl: '/guest/data-json-file-id-1',
+      dataJsonFileId: 'data-json-file-id-1',
+      details: {
+        ok: true,
+        status: 200,
+      },
+    });
+  });
+
+  it('guest 데이터가 아직 준비되지 않았으면 202 pending을 반환한다', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: jest.fn().mockResolvedValue('not found'),
+    });
+
+    const req = new Request(
+      'http://localhost/api/drive/publishInvitation/readiness?dataJsonFileId=data-json-file-id-2'
+    );
+
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(202);
+    expect(json).toEqual({
+      ok: true,
+      published: true,
+      ready: false,
+      guestUrl: '/guest/data-json-file-id-2',
+      dataJsonFileId: 'data-json-file-id-2',
+      warning: 'guest_not_ready',
+      status: 202,
+      details: {
+        ok: false,
+        status: 404,
+        reason: 'http_not_ok',
+      },
+    });
+  });
+});

--- a/app/api/drive/publishInvitation/readiness/route.ts
+++ b/app/api/drive/publishInvitation/readiness/route.ts
@@ -1,0 +1,47 @@
+import 'server-only';
+import { NextResponse } from 'next/server';
+
+import {
+  guestPath,
+  probeGuestData,
+} from '@/app/api/drive/_lib/guestReadiness';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const dataJsonFileId = searchParams.get('dataJsonFileId');
+
+  if (!dataJsonFileId) {
+    return NextResponse.json(
+      { ok: false, error: 'dataJsonFileId required' },
+      { status: 400 }
+    );
+  }
+
+  const guestUrl = guestPath(dataJsonFileId);
+  const probe = await probeGuestData(dataJsonFileId);
+
+  if (probe.ok) {
+    return NextResponse.json({
+      ok: true,
+      published: true,
+      ready: true,
+      guestUrl,
+      dataJsonFileId,
+      details: probe,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      published: true,
+      ready: false,
+      guestUrl,
+      dataJsonFileId,
+      warning: 'guest_not_ready',
+      status: 202,
+      details: probe,
+    },
+    { status: 202 }
+  );
+}

--- a/app/api/drive/publishInvitation/route.test.ts
+++ b/app/api/drive/publishInvitation/route.test.ts
@@ -210,6 +210,8 @@ describe('publishInvitation Route Handler 테스트', () => {
     expect(res.status).toBe(200);
     expect(json).toEqual({
       ok: true,
+      published: true,
+      ready: true,
       guestUrl: '/guest/data-json-file-id-1',
       dataJsonFileId: 'data-json-file-id-1',
     });
@@ -270,6 +272,8 @@ describe('publishInvitation Route Handler 테스트', () => {
     expect(res.status).toBe(200);
     expect(json).toEqual({
       ok: true,
+      published: true,
+      ready: true,
       guestUrl: '/guest/data-json-file-id-3',
       dataJsonFileId: 'data-json-file-id-3',
       ignored: 'already_public',
@@ -399,14 +403,68 @@ describe('publishInvitation Route Handler 테스트', () => {
     const res = await responsePromise;
     const json = await res.json();
 
-    expect(res.status).toBe(502);
-    expect(json.ok).toBe(false);
-    expect(json.error).toBe('guest_not_ready_after_publish');
+    expect(res.status).toBe(202);
+    expect(json.ok).toBe(true);
+    expect(json.published).toBe(true);
+    expect(json.ready).toBe(false);
+    expect(json.warning).toBe('guest_not_ready_after_publish');
+    expect(json.status).toBe(202);
     expect(json.guestUrl).toBe('/guest/data-json-file-id-2');
     expect(json.dataJsonFileId).toBe('data-json-file-id-2');
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(ensureDataJsonFile).toHaveBeenCalledWith('folder-999');
     expect(publishPermissionWithRetry).toHaveBeenCalledWith('folder-999');
+  });
+
+  it('guest readiness fetch 자체가 실패해도 발행 완료 상태는 유지한다', async () => {
+    jest.useFakeTimers();
+
+    (ensureDataJsonFile as jest.Mock).mockResolvedValue({
+      dataJsonFileId: 'data-json-file-id-fetch-error',
+    });
+
+    (publishPermissionWithRetry as jest.Mock).mockResolvedValue({
+      ok: true,
+      attempt: 1,
+    });
+
+    mockFetch.mockRejectedValue(new Error('network unavailable'));
+
+    const req = new Request('http://localhost/api/drive/publishInvitation', {
+      method: 'POST',
+      body: JSON.stringify({
+        invitationFolderId: 'folder-fetch-error',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const responsePromise = POST(req);
+
+    await jest.advanceTimersByTimeAsync(1000);
+
+    const res = await responsePromise;
+    const json = await res.json();
+
+    expect(res.status).toBe(202);
+    expect(json).toMatchObject({
+      ok: true,
+      published: true,
+      ready: false,
+      warning: 'guest_not_ready_after_publish',
+      guestUrl: '/guest/data-json-file-id-fetch-error',
+      dataJsonFileId: 'data-json-file-id-fetch-error',
+      status: 202,
+    });
+    expect(json.details.lastProbe).toMatchObject({
+      ok: false,
+      status: 0,
+      reason: 'fetch_failed',
+      error: 'network unavailable',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/app/api/drive/publishInvitation/route.test.ts
+++ b/app/api/drive/publishInvitation/route.test.ts
@@ -221,7 +221,7 @@ describe('publishInvitation Route Handler 테스트', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
       'https://drive.google.com/uc?export=download&id=data-json-file-id-1',
-      { cache: 'no-store' }
+      { cache: 'no-store', signal: expect.any(AbortSignal) }
     );
   });
 

--- a/app/api/drive/publishInvitation/route.ts
+++ b/app/api/drive/publishInvitation/route.ts
@@ -3,50 +3,20 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 
 import { ensureDataJsonFile } from '@/app/api/drive/_lib/ensureDataJsonFile';
+import {
+  guestPath,
+  ReadinessResult,
+  waitUntilGuestReady,
+} from '@/app/api/drive/_lib/guestReadiness';
 import { publishPermissionWithRetry } from '@/app/api/drive/_lib/publishPermissionWithRetry';
-import { isGuestPayload } from '@/app/guest/[id]/utils/guestBlockTypeGuards';
 
 import { ensurePublishedJsonFile } from '../_lib/ensurePublishedJsonFile';
 
 // publish API 요청 본문
 type Body = { invitationFolderId: string };
 
-// 단일 probe 실패 사유
-type ProbeFailureReason =
-  | 'http_not_ok'
-  | 'json_parse_failed'
-  | 'invalid_schema';
-
-// 단일 probe 결과
-type ProbeResult =
-  | { ok: true; status: number }
-  | {
-      ok: false;
-      status: number;
-      reason: ProbeFailureReason;
-      error?: string;
-      rawPreview?: string;
-    };
-
-// 재시도 전체 결과
-type ReadinessResult =
-  | { ok: true; attempt: number }
-  | { ok: false; attempts: number; lastProbe: ProbeResult | null };
-
 const VERIFY_MAX_ATTEMPTS = 3;
 const VERIFY_DELAY_MS = 350;
-
-const guestPath = (dataJsonFileId: string) => `/guest/${dataJsonFileId}`;
-
-const guestDataUrl = (dataJsonFileId: string) =>
-  `https://drive.google.com/uc?export=download&id=${encodeURIComponent(
-    dataJsonFileId
-  )}`;
-
-const sleep = (ms: number) =>
-  new Promise<void>(resolve => {
-    setTimeout(resolve, ms);
-  });
 
 // 게스트 페이지/태그 캐시를 함께 무효화
 function revalidateGuestCaches(dataJsonFileId: string) {
@@ -56,76 +26,28 @@ function revalidateGuestCaches(dataJsonFileId: string) {
   revalidatePath(guestPath(dataJsonFileId));
 }
 
-// 공개 data.json URL을 1회 조회하고 파싱/스키마까지 검증
-async function probeGuestData(dataJsonFileId: string): Promise<ProbeResult> {
-  const res = await fetch(guestDataUrl(dataJsonFileId), { cache: 'no-store' });
-
-  if (!res.ok) {
-    return { ok: false, status: res.status, reason: 'http_not_ok' };
-  }
-
-  const raw = await res.text();
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    return {
-      ok: false,
-      status: res.status,
-      reason: 'json_parse_failed',
-      rawPreview: raw.slice(0, 200),
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-
-  if (!isGuestPayload(parsed)) {
-    return { ok: false, status: res.status, reason: 'invalid_schema' };
-  }
-
-  return { ok: true, status: res.status };
-}
-
-// guest 데이터가 준비될 때까지 짧게 재시도
-async function waitUntilGuestReady(
-  dataJsonFileId: string
-): Promise<ReadinessResult> {
-  let lastProbe: ProbeResult | null = null;
-
-  for (let attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt += 1) {
-    const probe = await probeGuestData(dataJsonFileId);
-    if (probe.ok) {
-      return { ok: true, attempt };
-    }
-
-    lastProbe = probe;
-
-    if (attempt < VERIFY_MAX_ATTEMPTS) {
-      await sleep(VERIFY_DELAY_MS);
-    }
-  }
-
-  return { ok: false, attempts: VERIFY_MAX_ATTEMPTS, lastProbe };
-}
-
-// "게스트 미준비" 공통 실패 응답
-function notReadyResponse(params: {
+// 발행은 완료됐지만 공개 데이터 읽기 검증이 아직 안정화되지 않은 응답
+function readinessPendingResponse(params: {
   guestUrl: string;
   dataJsonFileId: string;
   verification: ReadinessResult;
+  ignored?: string;
 }) {
-  const { guestUrl, dataJsonFileId, verification } = params;
+  const { guestUrl, dataJsonFileId, verification, ignored } = params;
 
   return NextResponse.json(
     {
-      ok: false,
+      ok: true,
+      published: true,
+      ready: false,
       guestUrl,
       dataJsonFileId,
-      error: 'guest_not_ready_after_publish',
-      status: 502,
+      warning: 'guest_not_ready_after_publish',
+      status: 202,
       details: verification,
+      ...(ignored ? { ignored } : {}),
     },
-    { status: 502 }
+    { status: 202 }
   );
 }
 
@@ -139,15 +61,23 @@ async function buildPublishSuccessResponse(params: {
 
   revalidateGuestCaches(dataJsonFileId);
 
-  // 공개된 JSON 엔드포인트가 안정적으로 읽히는 것이 확인된 이후에만
-  // 게스트 URL을 외부에 노출한다.
-  const verification = await waitUntilGuestReady(dataJsonFileId);
+  const verification = await waitUntilGuestReady(dataJsonFileId, {
+    maxAttempts: VERIFY_MAX_ATTEMPTS,
+    delayMs: VERIFY_DELAY_MS,
+  });
   if (!verification.ok) {
-    return notReadyResponse({ guestUrl, dataJsonFileId, verification });
+    return readinessPendingResponse({
+      guestUrl,
+      dataJsonFileId,
+      verification,
+      ignored,
+    });
   }
 
   return NextResponse.json({
     ok: true,
+    published: true,
+    ready: true,
     guestUrl,
     dataJsonFileId,
     ...(ignored ? { ignored } : {}),

--- a/app/dashboard/components/carousel/CarouselBase.tsx
+++ b/app/dashboard/components/carousel/CarouselBase.tsx
@@ -25,6 +25,8 @@ type CarouselBaseProps = {
   isDeleting?: (folderId: string) => boolean;
   isSharing?: (folderId: string) => boolean;
   isPublishing?: (folderId: string) => boolean;
+  isPublishReadinessPolling?: (folderId: string) => boolean;
+  isPublishReadyPending?: (folderId: string) => boolean;
 };
 
 function CarouselBase({
@@ -44,6 +46,8 @@ function CarouselBase({
   isDeleting,
   isSharing,
   isPublishing,
+  isPublishReadinessPolling,
+  isPublishReadyPending,
 }: CarouselBaseProps) {
   const [selectedIndex, setSelectedIndex] = useState(startIndex);
   const hasHandledInitialLayoutRef = useRef(false);
@@ -141,6 +145,8 @@ function CarouselBase({
         isDeleting={isDeleting}
         isSharing={isSharing}
         isPublishing={isPublishing}
+        isPublishReadinessPolling={isPublishReadinessPolling}
+        isPublishReadyPending={isPublishReadyPending}
       />
       <div className="absolute inset-x-0 bottom-0 z-10">
         <CarouselController onMove={handleMove} />

--- a/app/dashboard/components/carousel/CarouselTrack.tsx
+++ b/app/dashboard/components/carousel/CarouselTrack.tsx
@@ -24,6 +24,8 @@ type CarouselTrackProps = {
   isDeleting?: (folderId: string) => boolean;
   isSharing?: (folderId: string) => boolean;
   isPublishing?: (folderId: string) => boolean;
+  isPublishReadinessPolling?: (folderId: string) => boolean;
+  isPublishReadyPending?: (folderId: string) => boolean;
 };
 
 function CarouselTrack({
@@ -45,6 +47,8 @@ function CarouselTrack({
   isDeleting,
   isSharing,
   isPublishing,
+  isPublishReadinessPolling,
+  isPublishReadyPending,
 }: CarouselTrackProps) {
   return (
     <div
@@ -97,6 +101,16 @@ function CarouselTrack({
             isPublishing={
               item.invite && isPublishing
                 ? isPublishing(item.invite.folderId)
+                : false
+            }
+            isPublishReadinessPolling={
+              item.invite && isPublishReadinessPolling
+                ? isPublishReadinessPolling(item.invite.folderId)
+                : false
+            }
+            isPublishReadyPending={
+              item.invite && isPublishReadyPending
+                ? isPublishReadyPending(item.invite.folderId)
                 : false
             }
           />

--- a/app/dashboard/components/carousel/CarouselWrapper.tsx
+++ b/app/dashboard/components/carousel/CarouselWrapper.tsx
@@ -32,6 +32,8 @@ function CarouselWrapper({
     isDeleting,
     isSharing,
     isPublishing,
+    isPublishReadinessPolling,
+    isPublishReadyPending,
   } = useDashboardInvitations(initialInvites, { loadOnMount });
   const orderedInvites = useMemo(() => [...invites].reverse(), [invites]);
   const items: CarouselCardItem[] = useMemo(
@@ -74,6 +76,8 @@ function CarouselWrapper({
       isDeleting={isDeleting}
       isSharing={isSharing}
       isPublishing={isPublishing}
+      isPublishReadinessPolling={isPublishReadinessPolling}
+      isPublishReadyPending={isPublishReadyPending}
     />
   );
 }

--- a/app/dashboard/components/carousel/item/CarouselItem.tsx
+++ b/app/dashboard/components/carousel/item/CarouselItem.tsx
@@ -29,6 +29,8 @@ type CarouselItemProps = {
   isDeleting: boolean;
   isSharing: boolean;
   isPublishing: boolean;
+  isPublishReadinessPolling: boolean;
+  isPublishReadyPending: boolean;
 };
 
 function CarouselItem({
@@ -49,6 +51,8 @@ function CarouselItem({
   isDeleting,
   isSharing,
   isPublishing,
+  isPublishReadinessPolling,
+  isPublishReadyPending,
 }: CarouselItemProps) {
   const [isHovered, setIsHovered] = useState(false);
   const invite = item.invite;
@@ -206,6 +210,8 @@ function CarouselItem({
                 <PublishButton
                   isPublished={Boolean(publishedUrl)}
                   isPublishing={isPublishing}
+                  isReadinessPolling={isPublishReadinessPolling}
+                  isReadyPending={isPublishReadyPending}
                   onPublish={() => onPublish?.(invite.folderId)}
                 />
                 <button

--- a/app/dashboard/components/carousel/item/actions/PublishButton.tsx
+++ b/app/dashboard/components/carousel/item/actions/PublishButton.tsx
@@ -3,22 +3,41 @@ import { dashboardCarouselLayout } from '../../carouselLayout';
 type PublishButtonProps = {
   isPublished: boolean;
   isPublishing: boolean;
+  isReadinessPolling: boolean;
+  isReadyPending: boolean;
   onPublish: () => void;
 };
 
 function PublishButton({
   isPublished,
   isPublishing,
+  isReadinessPolling,
+  isReadyPending,
   onPublish,
 }: PublishButtonProps) {
+  const isBusy = isPublishing || isReadinessPolling;
+  const label = isPublishing
+    ? '발행 중...'
+    : isReadinessPolling
+      ? '반영 확인 중...'
+      : isReadyPending
+        ? '반영 지연 중'
+        : isPublished
+          ? '재발행하기'
+          : 'URL 발행하기';
+
   return (
     <button
       type="button"
+      disabled={isBusy}
       onClick={event => {
         event.stopPropagation();
+        if (isBusy) return;
         onPublish();
       }}
-      className="flex cursor-pointer select-none items-center justify-center rounded-lg bg-white text-[13px] font-semibold text-primary transition-colors hover:bg-[#E5E7EB]"
+      className={`flex select-none items-center justify-center rounded-lg bg-white text-[13px] font-semibold text-primary transition-colors hover:bg-[#E5E7EB] ${
+        isBusy ? 'cursor-not-allowed opacity-80' : 'cursor-pointer'
+      }`}
       style={{
         flex: '0 0 auto',
         width: dashboardCarouselLayout.primaryActionWidth,
@@ -27,11 +46,7 @@ function PublishButton({
         height: dashboardCarouselLayout.primaryActionHeight,
       }}
     >
-      {isPublishing
-        ? '발행 중...'
-        : isPublished
-          ? '재발행하기'
-          : 'URL 발행하기'}
+      {label}
     </button>
   );
 }

--- a/app/dashboard/hooks/useDashboardInvitations.test.tsx
+++ b/app/dashboard/hooks/useDashboardInvitations.test.tsx
@@ -172,7 +172,11 @@ describe('useDashboardInvitations', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch).toHaveBeenLastCalledWith(
       '/api/drive/publishInvitation/readiness?dataJsonFileId=data-json-file-id-1',
-      { method: 'GET', cache: 'no-store' }
+      {
+        method: 'GET',
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }
     );
   });
 });

--- a/app/dashboard/hooks/useDashboardInvitations.test.tsx
+++ b/app/dashboard/hooks/useDashboardInvitations.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import useDashboardInvitations from '@/app/dashboard/hooks/useDashboardInvitations';
 
@@ -23,7 +23,12 @@ describe('useDashboardInvitations', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.useRealTimers();
     global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('redirects home when loadInvitation returns an invalid request error', async () => {
@@ -100,5 +105,74 @@ describe('useDashboardInvitations', () => {
       'http://localhost/guest/data-json-file-id-1'
     );
     expect(result.current.getPublishedUrl('folder-2')).toBeNull();
+  });
+
+  it('polls publish readiness until the guest page is ready', async () => {
+    jest.useFakeTimers();
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        json: jest.fn().mockResolvedValue({
+          ok: true,
+          published: true,
+          ready: false,
+          guestUrl: '/guest/data-json-file-id-1',
+          dataJsonFileId: 'data-json-file-id-1',
+          warning: 'guest_not_ready_after_publish',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+          ok: true,
+          published: true,
+          ready: true,
+          guestUrl: '/guest/data-json-file-id-1',
+          dataJsonFileId: 'data-json-file-id-1',
+        }),
+      });
+
+    const { result } = renderHook(() =>
+      useDashboardInvitations(
+        [
+          {
+            folderId: 'folder-1',
+            name: 'Invitation 1',
+            invitationUuid: 'uuid-1',
+          },
+        ],
+        { loadOnMount: false }
+      )
+    );
+
+    await act(async () => {
+      await result.current.handlePublish('folder-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPublishReadyPending('folder-1')).toBe(true);
+      expect(result.current.isPublishReadinessPolling('folder-1')).toBe(true);
+    });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPublishReadinessPolling('folder-1')).toBe(false);
+      expect(result.current.isPublishReadyPending('folder-1')).toBe(false);
+    });
+
+    expect(result.current.getPublishedUrl('folder-1')).toBe(
+      'http://localhost/guest/data-json-file-id-1'
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      '/api/drive/publishInvitation/readiness?dataJsonFileId=data-json-file-id-1',
+      { method: 'GET', cache: 'no-store' }
+    );
   });
 });

--- a/app/dashboard/hooks/useDashboardInvitations.ts
+++ b/app/dashboard/hooks/useDashboardInvitations.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   DeleteInvitationResponse,
@@ -34,10 +34,28 @@ type ShareUrlResponse = {
 
 const READINESS_POLL_DELAYS_MS = [1000, 1500, 2500, 4000, 6000];
 
-const sleep = (ms: number) =>
-  new Promise<void>(resolve => {
-    setTimeout(resolve, ms);
+const sleep = (ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener('abort', onAbort, { once: true });
   });
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
 
 function resolveShareImageUrl(imageFileId?: string, origin?: string) {
   return imageFileId
@@ -170,51 +188,73 @@ function useDashboardInvitations(
   const [publishResults, setPublishResults] = useState<PublishResultMap>(
     createInitialPublishResults(initialInvites)
   );
+  const readinessAbortControllersRef = useRef(
+    new Map<string, AbortController>()
+  );
+
+  const abortReadinessPolling = useCallback((folderId: string) => {
+    const controller = readinessAbortControllersRef.current.get(folderId);
+    controller?.abort();
+    readinessAbortControllersRef.current.delete(folderId);
+  }, []);
+
+  const abortAllReadinessPolling = useCallback(() => {
+    readinessAbortControllersRef.current.forEach(controller => {
+      controller.abort();
+    });
+    readinessAbortControllersRef.current.clear();
+  }, []);
 
   const resetPublishState = useCallback(() => {
+    abortAllReadinessPolling();
     setPublishBusy({});
     setPublishErrors({});
     setReadinessPolling({});
     setPublishResults({});
-  }, []);
+  }, [abortAllReadinessPolling]);
 
-  const clearInvitationTransientState = useCallback((folderId: string) => {
-    setDeleteBusy(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setDeleteErrors(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setPublishBusy(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setPublishErrors(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setReadinessPolling(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setShareBusy(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-    setPublishResults(prev => {
-      const next = { ...prev };
-      delete next[folderId];
-      return next;
-    });
-  }, []);
+  const clearInvitationTransientState = useCallback(
+    (folderId: string) => {
+      abortReadinessPolling(folderId);
+
+      setDeleteBusy(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setDeleteErrors(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setPublishBusy(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setPublishErrors(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setReadinessPolling(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setShareBusy(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+      setPublishResults(prev => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+    },
+    [abortReadinessPolling]
+  );
 
   const loadInvitations = useCallback(async () => {
     setLoading(true);
@@ -254,6 +294,7 @@ function useDashboardInvitations(
       setDeleteErrors({});
       setPublishBusy({});
       setPublishErrors({});
+      abortAllReadinessPolling();
       setReadinessPolling({});
       setPublishResults(createInitialPublishResults(loadedInvites));
     } catch (err) {
@@ -268,7 +309,13 @@ function useDashboardInvitations(
     } finally {
       setLoading(false);
     }
-  }, [resetPublishState, router]);
+  }, [abortAllReadinessPolling, resetPublishState, router]);
+
+  useEffect(() => {
+    return () => {
+      abortAllReadinessPolling();
+    };
+  }, [abortAllReadinessPolling]);
 
   useEffect(() => {
     if (!loadOnMount) {
@@ -287,20 +334,27 @@ function useDashboardInvitations(
       const dataJsonFileId = initialResult.dataJsonFileId;
       if (!dataJsonFileId) return;
 
+      abortReadinessPolling(folderId);
+      const controller = new AbortController();
+      readinessAbortControllersRef.current.set(folderId, controller);
+      const { signal } = controller;
+
       setReadinessPolling(prev => ({ ...prev, [folderId]: true }));
 
       let latestResult = initialResult;
 
       try {
         for (const delayMs of READINESS_POLL_DELAYS_MS) {
-          await sleep(delayMs);
+          await sleep(delayMs, signal);
+          if (signal.aborted) break;
 
           const res = await fetch(
             `/api/drive/publishInvitation/readiness?dataJsonFileId=${encodeURIComponent(
               dataJsonFileId
             )}`,
-            { method: 'GET', cache: 'no-store' }
+            { method: 'GET', cache: 'no-store', signal }
           );
+          if (signal.aborted) break;
 
           const json = (await res.json().catch(() => ({}))) as PublishResult;
           latestResult = {
@@ -317,12 +371,20 @@ function useDashboardInvitations(
           }
         }
       } catch (err) {
-        console.error('Guest readiness polling failed:', err);
+        if (!isAbortError(err)) {
+          console.error('Guest readiness polling failed:', err);
+        }
       } finally {
-        setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+        if (readinessAbortControllersRef.current.get(folderId) === controller) {
+          readinessAbortControllersRef.current.delete(folderId);
+        }
+
+        if (!signal.aborted) {
+          setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+        }
       }
     },
-    []
+    [abortReadinessPolling]
   );
 
   const handlePublish = useCallback(async (invitationFolderId: string) => {
@@ -331,6 +393,7 @@ function useDashboardInvitations(
     setPublishErrors(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishResults(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishBusy(prev => ({ ...prev, [invitationFolderId]: true }));
+    abortReadinessPolling(invitationFolderId);
     setReadinessPolling(prev => ({ ...prev, [invitationFolderId]: false }));
 
     try {
@@ -367,7 +430,7 @@ function useDashboardInvitations(
     } finally {
       setPublishBusy(prev => ({ ...prev, [invitationFolderId]: false }));
     }
-  }, [pollGuestReadiness]);
+  }, [abortReadinessPolling, pollGuestReadiness]);
 
   const handleDelete = useCallback(
     async (folderId: string) => {

--- a/app/dashboard/hooks/useDashboardInvitations.ts
+++ b/app/dashboard/hooks/useDashboardInvitations.ts
@@ -32,6 +32,13 @@ type ShareUrlResponse = {
   error?: string;
 };
 
+const READINESS_POLL_DELAYS_MS = [1000, 1500, 2500, 4000, 6000];
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
 function resolveShareImageUrl(imageFileId?: string, origin?: string) {
   return imageFileId
     ? `https://lh3.googleusercontent.com/d/${imageFileId}`
@@ -135,6 +142,8 @@ function createInitialPublishResults(
 
     acc[invite.folderId] = {
       ok: true,
+      published: true,
+      ready: true,
       guestUrl: invite.publishedUrl,
     };
     return acc;
@@ -156,6 +165,7 @@ function useDashboardInvitations(
   const [deleteErrors, setDeleteErrors] = useState<DeleteErrorMap>({});
   const [publishBusy, setPublishBusy] = useState<PublishStateMap>({});
   const [publishErrors, setPublishErrors] = useState<PublishErrorMap>({});
+  const [readinessPolling, setReadinessPolling] = useState<PublishStateMap>({});
   const [shareBusy, setShareBusy] = useState<ShareStateMap>({});
   const [publishResults, setPublishResults] = useState<PublishResultMap>(
     createInitialPublishResults(initialInvites)
@@ -164,6 +174,7 @@ function useDashboardInvitations(
   const resetPublishState = useCallback(() => {
     setPublishBusy({});
     setPublishErrors({});
+    setReadinessPolling({});
     setPublishResults({});
   }, []);
 
@@ -184,6 +195,11 @@ function useDashboardInvitations(
       return next;
     });
     setPublishErrors(prev => {
+      const next = { ...prev };
+      delete next[folderId];
+      return next;
+    });
+    setReadinessPolling(prev => {
       const next = { ...prev };
       delete next[folderId];
       return next;
@@ -238,6 +254,7 @@ function useDashboardInvitations(
       setDeleteErrors({});
       setPublishBusy({});
       setPublishErrors({});
+      setReadinessPolling({});
       setPublishResults(createInitialPublishResults(loadedInvites));
     } catch (err) {
       console.error(err);
@@ -265,12 +282,56 @@ function useDashboardInvitations(
     setOrigin(window.location.origin);
   }, []);
 
+  const pollGuestReadiness = useCallback(
+    async (folderId: string, initialResult: PublishResult) => {
+      const dataJsonFileId = initialResult.dataJsonFileId;
+      if (!dataJsonFileId) return;
+
+      setReadinessPolling(prev => ({ ...prev, [folderId]: true }));
+
+      let latestResult = initialResult;
+
+      try {
+        for (const delayMs of READINESS_POLL_DELAYS_MS) {
+          await sleep(delayMs);
+
+          const res = await fetch(
+            `/api/drive/publishInvitation/readiness?dataJsonFileId=${encodeURIComponent(
+              dataJsonFileId
+            )}`,
+            { method: 'GET', cache: 'no-store' }
+          );
+
+          const json = (await res.json().catch(() => ({}))) as PublishResult;
+          latestResult = {
+            ...latestResult,
+            ...json,
+            guestUrl: json.guestUrl ?? latestResult.guestUrl,
+            dataJsonFileId: json.dataJsonFileId ?? dataJsonFileId,
+          };
+
+          setPublishResults(prev => ({ ...prev, [folderId]: latestResult }));
+
+          if (res.ok && json.ready === true) {
+            break;
+          }
+        }
+      } catch (err) {
+        console.error('Guest readiness polling failed:', err);
+      } finally {
+        setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+      }
+    },
+    []
+  );
+
   const handlePublish = useCallback(async (invitationFolderId: string) => {
     if (!invitationFolderId) return;
 
     setPublishErrors(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishResults(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishBusy(prev => ({ ...prev, [invitationFolderId]: true }));
+    setReadinessPolling(prev => ({ ...prev, [invitationFolderId]: false }));
 
     try {
       const res = await fetch('/api/drive/publishInvitation', {
@@ -293,6 +354,10 @@ function useDashboardInvitations(
       }
 
       setPublishResults(prev => ({ ...prev, [invitationFolderId]: json }));
+
+      if (json.ready === false) {
+        void pollGuestReadiness(invitationFolderId, json);
+      }
     } catch (err) {
       setPublishErrors(prev => ({
         ...prev,
@@ -302,7 +367,7 @@ function useDashboardInvitations(
     } finally {
       setPublishBusy(prev => ({ ...prev, [invitationFolderId]: false }));
     }
-  }, []);
+  }, [pollGuestReadiness]);
 
   const handleDelete = useCallback(
     async (folderId: string) => {
@@ -438,6 +503,17 @@ function useDashboardInvitations(
     [publishBusy]
   );
 
+  const isPublishReadinessPolling = useCallback(
+    (folderId: string) => Boolean(readinessPolling[folderId]),
+    [readinessPolling]
+  );
+
+  const isPublishReadyPending = useCallback(
+    (folderId: string) =>
+      !publishErrors[folderId] && publishResults[folderId]?.ready === false,
+    [publishErrors, publishResults]
+  );
+
   const isSharing = useCallback(
     (folderId: string) => Boolean(shareBusy[folderId]),
     [shareBusy]
@@ -472,6 +548,8 @@ function useDashboardInvitations(
     getPublishedUrl,
     isDeleting,
     isSharing,
+    isPublishReadinessPolling,
+    isPublishReadyPending,
     getDeleteError,
     isPublishing,
     getPublishError,

--- a/app/dashboard/types.ts
+++ b/app/dashboard/types.ts
@@ -30,9 +30,12 @@ export type LoadInvitationResponse = {
 
 export type PublishResult = {
   ok: boolean;
+  published?: boolean;
+  ready?: boolean;
   guestUrl?: string;
   dataJsonFileId?: string;
   ignored?: string;
+  warning?: string;
   error?: string;
   status?: number;
   details?: unknown;

--- a/widgets/editor/preview/components/SaveModal.tsx
+++ b/widgets/editor/preview/components/SaveModal.tsx
@@ -23,13 +23,16 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
       handlePublish,
       publishResults,
       publishBusy,
+      readinessPolling,
       publishErrors,
       isPublish,
     } = useInvitationPublish({ invitationFolderId });
 
     const result = publishResults[invitationFolderId];
     const busy = Boolean(publishBusy[invitationFolderId]);
+    const readinessBusy = Boolean(readinessPolling[invitationFolderId]);
     const error = publishErrors[invitationFolderId];
+    const isReadyPending = !error && result?.ready === false;
     const finalGuestUrl =
       result?.guestUrl && result.guestUrl.startsWith('http')
         ? result.guestUrl
@@ -41,7 +44,7 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
         <div
           className="fixed inset-0 z-40 bg-black/20"
           onMouseDown={e => {
-            if (isLoading || busy) {
+            if (isLoading || busy || readinessBusy) {
               e.stopPropagation();
             }
           }}
@@ -63,7 +66,11 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                         ? 'URL 발행중...'
                         : error
                           ? 'URL 발행에 실패하였습니다.'
-                          : '성공적으로 발행되었습니다!'}
+                          : readinessBusy
+                            ? 'URL 발행 완료, 반영 중입니다.'
+                            : isReadyPending
+                              ? 'URL 발행 완료, 반영 지연 중입니다.'
+                            : '성공적으로 발행되었습니다.'}
                     </p>
                   </div>
                   <div>
@@ -76,6 +83,8 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                         width={84}
                         height={84}
                       />
+                    ) : readinessBusy ? (
+                      <LoadingSpinner className="w-[84px] h-[84px] animate-spin" />
                     ) : (
                       <Image
                         src="/images/saveSuccess.png"
@@ -104,7 +113,11 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                     ) : (
                       <div className="px-2 font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[295px] h-[44px] gap-1">
                         {!finalGuestUrl || error ? (
-                          <button className="text-white truncate w-[215px] hover:bg-white/30 rounded-lg p-1">
+                          <button
+                            type="button"
+                            className="text-white truncate w-[215px] hover:bg-white/30 rounded-lg p-1"
+                            onClick={handlePublish}
+                          >
                             초대장 URL 다시 발행하기
                           </button>
                         ) : (
@@ -164,13 +177,19 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                   )}
 
                   <div>
-                    <button
-                      type="button"
-                      className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[295px] h-[44px]"
-                      onClick={handlePublish}
-                    >
-                      초대장 URL 발행하기
-                    </button>
+                    {isFail ? (
+                      <div className="font-semibold text-sm border border-white/12 rounded-lg bg-black/50 text-white/70 flex-center w-[295px] h-[44px]">
+                        저장 후 URL을 발행할 수 있습니다.
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[295px] h-[44px]"
+                        onClick={handlePublish}
+                      >
+                        초대장 URL 발행하기
+                      </button>
+                    )}
                   </div>
                 </>
               )}

--- a/widgets/editor/preview/components/SaveModal.tsx
+++ b/widgets/editor/preview/components/SaveModal.tsx
@@ -11,6 +11,7 @@ interface Props {
   isLoading: boolean;
   isFail: boolean;
 }
+
 export const SaveModal = forwardRef<HTMLDivElement, Props>(
   ({ isLoading, isFail }: Props, ref) => {
     const invitationFolderId = useEditorStore(
@@ -39,6 +40,15 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
         : result?.guestUrl && origin
           ? `${origin}${result.guestUrl}`
           : (result?.guestUrl ?? null);
+
+    const getStatusMessage = () => {
+      if (busy) return 'URL 발행중...';
+      if (error) return 'URL 발행에 실패했습니다.';
+      if (readinessBusy) return 'URL 발행 완료, 반영 중입니다.';
+      if (isReadyPending) return 'URL 발행 완료, 반영 지연 중입니다.';
+      return '성공적으로 발행되었습니다.';
+    };
+
     return createPortal(
       <>
         <div
@@ -62,21 +72,7 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                 <>
                   <div className="pt-5">
                     <p className="font-semibold text-base">
-                      {busy
-                        ? 'URL 발행중...'
-                        : error
-                          ? 'URL 발행에 실패하였습니다.'
-const getStatusMessage = () => {
-  if (busy) return 'URL 발행중...';
-  if (error) return 'URL 발행에 실패하였습니다.';
-  if (readinessBusy) return 'URL 발행 완료, 반영 중입니다.';
-  if (isReadyPending) return 'URL 발행 완료, 반영 지연 중입니다.';
-  return '성공적으로 발행되었습니다.';
-};
-
-<p className="font-semibold text-base">
-  {getStatusMessage()}
-</p>
+                      {getStatusMessage()}
                     </p>
                   </div>
                   <div>
@@ -143,7 +139,7 @@ const getStatusMessage = () => {
                             onClick={e => {
                               e.stopPropagation();
                               navigator.clipboard.writeText(finalGuestUrl);
-                              alert('복사되었습니다!');
+                              alert('복사되었습니다.');
                             }}
                           >
                             복사하기
@@ -158,7 +154,7 @@ const getStatusMessage = () => {
                   <div className="pt-5">
                     <p className="font-semibold text-base">
                       {isFail
-                        ? '파일 저장에 실패하였습니다.'
+                        ? '파일 저장에 실패했습니다.'
                         : '성공적으로 저장되었습니다!'}
                     </p>
                   </div>
@@ -207,4 +203,5 @@ const getStatusMessage = () => {
     );
   }
 );
+
 SaveModal.displayName = 'SaveModal';

--- a/widgets/editor/preview/components/SaveModal.tsx
+++ b/widgets/editor/preview/components/SaveModal.tsx
@@ -66,11 +66,17 @@ export const SaveModal = forwardRef<HTMLDivElement, Props>(
                         ? 'URL 발행중...'
                         : error
                           ? 'URL 발행에 실패하였습니다.'
-                          : readinessBusy
-                            ? 'URL 발행 완료, 반영 중입니다.'
-                            : isReadyPending
-                              ? 'URL 발행 완료, 반영 지연 중입니다.'
-                            : '성공적으로 발행되었습니다.'}
+const getStatusMessage = () => {
+  if (busy) return 'URL 발행중...';
+  if (error) return 'URL 발행에 실패하였습니다.';
+  if (readinessBusy) return 'URL 발행 완료, 반영 중입니다.';
+  if (isReadyPending) return 'URL 발행 완료, 반영 지연 중입니다.';
+  return '성공적으로 발행되었습니다.';
+};
+
+<p className="font-semibold text-base">
+  {getStatusMessage()}
+</p>
                     </p>
                   </div>
                   <div>

--- a/widgets/editor/preview/hooks/useInvitationPublish.ts
+++ b/widgets/editor/preview/hooks/useInvitationPublish.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type PublishResult = {
   ok: boolean;
@@ -15,10 +15,28 @@ type PublishResult = {
 
 const READINESS_POLL_DELAYS_MS = [1000, 1500, 2500, 4000, 6000];
 
-const sleep = (ms: number) =>
-  new Promise<void>(resolve => {
-    setTimeout(resolve, ms);
+const sleep = (ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener('abort', onAbort, { once: true });
   });
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
 
 export const useInvitationPublish = ({
   invitationFolderId,
@@ -36,6 +54,7 @@ export const useInvitationPublish = ({
   const [readinessPolling, setReadinessPolling] = useState<
     Record<string, boolean>
   >({});
+  const readinessAbortRef = useRef<AbortController | null>(null);
 
   const pollGuestReadiness = async (
     folderId: string,
@@ -44,20 +63,27 @@ export const useInvitationPublish = ({
     const dataJsonFileId = initialResult.dataJsonFileId;
     if (!dataJsonFileId) return;
 
+    readinessAbortRef.current?.abort();
+    const controller = new AbortController();
+    readinessAbortRef.current = controller;
+    const { signal } = controller;
+
     setReadinessPolling(prev => ({ ...prev, [folderId]: true }));
 
     let latestResult = initialResult;
 
     try {
       for (const delayMs of READINESS_POLL_DELAYS_MS) {
-        await sleep(delayMs);
+        await sleep(delayMs, signal);
+        if (signal.aborted) break;
 
         const res = await fetch(
           `/api/drive/publishInvitation/readiness?dataJsonFileId=${encodeURIComponent(
             dataJsonFileId
           )}`,
-          { method: 'GET', cache: 'no-store' }
+          { method: 'GET', cache: 'no-store', signal }
         );
+        if (signal.aborted) break;
 
         const json = (await res.json().catch(() => ({}))) as PublishResult;
         latestResult = {
@@ -74,16 +100,32 @@ export const useInvitationPublish = ({
         }
       }
     } catch (err) {
-      console.error('Guest readiness polling failed:', err);
+      if (!isAbortError(err)) {
+        console.error('Guest readiness polling failed:', err);
+      }
     } finally {
-      setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+      if (readinessAbortRef.current === controller) {
+        readinessAbortRef.current = null;
+      }
+
+      if (!signal.aborted) {
+        setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+      }
     }
   };
+
+  useEffect(() => {
+    return () => {
+      readinessAbortRef.current?.abort();
+    };
+  }, []);
 
   const handlePublish = async () => {
     if (!invitationFolderId) return;
     setIsPublish(true);
 
+    readinessAbortRef.current?.abort();
+    setReadinessPolling(prev => ({ ...prev, [invitationFolderId]: false }));
     setPublishErrors(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishResults(prev => ({ ...prev, [invitationFolderId]: null }));
     setPublishBusy(prev => ({ ...prev, [invitationFolderId]: true }));

--- a/widgets/editor/preview/hooks/useInvitationPublish.ts
+++ b/widgets/editor/preview/hooks/useInvitationPublish.ts
@@ -2,13 +2,23 @@ import { useState } from 'react';
 
 type PublishResult = {
   ok: boolean;
+  published?: boolean;
+  ready?: boolean;
   guestUrl?: string;
   dataJsonFileId?: string;
   ignored?: string;
+  warning?: string;
   error?: string;
   status?: number;
   details?: unknown;
 };
+
+const READINESS_POLL_DELAYS_MS = [1000, 1500, 2500, 4000, 6000];
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
 
 export const useInvitationPublish = ({
   invitationFolderId,
@@ -23,6 +33,52 @@ export const useInvitationPublish = ({
   const [publishResults, setPublishResults] = useState<
     Record<string, PublishResult | null>
   >({});
+  const [readinessPolling, setReadinessPolling] = useState<
+    Record<string, boolean>
+  >({});
+
+  const pollGuestReadiness = async (
+    folderId: string,
+    initialResult: PublishResult
+  ) => {
+    const dataJsonFileId = initialResult.dataJsonFileId;
+    if (!dataJsonFileId) return;
+
+    setReadinessPolling(prev => ({ ...prev, [folderId]: true }));
+
+    let latestResult = initialResult;
+
+    try {
+      for (const delayMs of READINESS_POLL_DELAYS_MS) {
+        await sleep(delayMs);
+
+        const res = await fetch(
+          `/api/drive/publishInvitation/readiness?dataJsonFileId=${encodeURIComponent(
+            dataJsonFileId
+          )}`,
+          { method: 'GET', cache: 'no-store' }
+        );
+
+        const json = (await res.json().catch(() => ({}))) as PublishResult;
+        latestResult = {
+          ...latestResult,
+          ...json,
+          guestUrl: json.guestUrl ?? latestResult.guestUrl,
+          dataJsonFileId: json.dataJsonFileId ?? dataJsonFileId,
+        };
+
+        setPublishResults(prev => ({ ...prev, [folderId]: latestResult }));
+
+        if (res.ok && json.ready === true) {
+          break;
+        }
+      }
+    } catch (err) {
+      console.error('Guest readiness polling failed:', err);
+    } finally {
+      setReadinessPolling(prev => ({ ...prev, [folderId]: false }));
+    }
+  };
 
   const handlePublish = async () => {
     if (!invitationFolderId) return;
@@ -53,6 +109,10 @@ export const useInvitationPublish = ({
       }
 
       setPublishResults(prev => ({ ...prev, [invitationFolderId]: json }));
+
+      if (json.ready === false) {
+        void pollGuestReadiness(invitationFolderId, json);
+      }
     } catch (err) {
       setPublishErrors(prev => ({
         ...prev,
@@ -67,6 +127,7 @@ export const useInvitationPublish = ({
     handlePublish,
     publishResults,
     publishBusy,
+    readinessPolling,
     publishErrors,
     isPublish,
   };

--- a/widgets/editor/preview/hooks/useInvitationUpload.ts
+++ b/widgets/editor/preview/hooks/useInvitationUpload.ts
@@ -37,9 +37,24 @@ export const useInvitationUpload = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isFail, setIsFail] = useState(false);
 
+  const applySaveResult = (
+    saveResult: Awaited<ReturnType<typeof saveInvitationFlow>>
+  ) => {
+    if (!saveResult.success) {
+      console.error('Invitation save failed:', saveResult.results);
+      throw new Error('Invitation save failed.');
+    }
+
+    editorData.setInvitationUuid(saveResult.invitationUuid);
+    editorData.setImageFolderId(saveResult.folders.imageFolderId);
+    editorData.setAudioFolderId(saveResult.folders.audioFolderId);
+    editorData.setInvitationFolderId(saveResult.folders.invitationFolderId);
+  };
+
   const handleUpload = async () => {
     try {
       setIsLoading(true);
+      setIsFail(false);
       const task = editorData.images.flatMap(item =>
         item.file.map(file => ({ id: item.id, file }))
       );
@@ -84,10 +99,7 @@ export const useInvitationUpload = () => {
           mainPoster,
           invitationThumbnail,
         });
-        editorData.setInvitationUuid(saveResult.invitationUuid);
-        editorData.setImageFolderId(saveResult.folders.imageFolderId);
-        editorData.setAudioFolderId(saveResult.folders.audioFolderId);
-        editorData.setInvitationFolderId(saveResult.folders.invitationFolderId);
+        applySaveResult(saveResult);
       } else {
         const result = await trashFolder();
         //실패 토스트 알람 표시
@@ -107,10 +119,7 @@ export const useInvitationUpload = () => {
           invitationThumbnail,
           invitationUuid: editorData.invitationUuid,
         });
-        editorData.setInvitationUuid(saveResult.invitationUuid);
-        editorData.setImageFolderId(saveResult.folders.imageFolderId);
-        editorData.setAudioFolderId(saveResult.folders.audioFolderId);
-        editorData.setInvitationFolderId(saveResult.folders.invitationFolderId);
+        applySaveResult(saveResult);
       }
     } catch (error) {
       console.error('저장 중 오류 발생:', error);


### PR DESCRIPTION
## 작업 개요

Google Drive 기반 초대장 저장/발행 흐름에서 발행 성공과 게스트 페이지 반영 지연을 분리하고, 저장 실패가 발행 단계로 이어지지 않도록 에러 처리 안정성을 개선했습니다.

## 작업 내용

- [x] `data.json` 기본 payload를 실제 저장 구조와 맞게 보강
- [x] 저장 결과 `success:false` 감지 및 저장 실패 시 발행 차단
- [x] 발행 성공과 guest readiness 지연 상태 분리
- [x] 발행 후 readiness 확인 API 추가
- [x] 에딧 페이지 발행 pending/polling UI 상태 반영
- [x] 대시보드 발행 pending/polling UI 상태 반영
- [x] 관련 API 및 훅 테스트 추가/수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `publishInvitation` API 테스트 통과
- `publishInvitation/readiness` API 테스트 통과
- guest payload schema guard 테스트 통과
- 대시보드 발행 readiness polling 훅 테스트 통과
- 관련 파일 ESLint 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새 기능**
  * 초대장 발행 후 게스트 페이지 준비 상태를 자동으로 확인하는 기능 추가
  * 발행 버튼과 저장 모달에 준비 상태 확인 진행 중 표시
  * 발행 완료 후 게스트 준비 상태를 별도로 추적하는 폴링 메커니즘

* **개선사항**
  * 발행 프로세스에 명시적인 "준비됨/준비 안됨" 상태 피드백 추가
  * 사용자에게 초대장 준비 상태에 대한 더 나은 시각적 피드백 제공

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bread-Barbershop/frontend/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->