### PR TITLE
[feat] 게스트 페이지 bgm 요청 개선

### DIFF
--- a/app/api/drive/guestBgm/route.ts
+++ b/app/api/drive/guestBgm/route.ts
@@ -47,10 +47,16 @@ export async function GET(req: NextRequest) {
 
   const headers = new Headers();
   headers.set('Content-Type', contentType);
-  headers.set('Cache-Control', 'private, no-store');
+  headers.set('Cache-Control', 'private, max-age=31536000, immutable');
 
   const contentLength = driveRes.headers.get('content-length');
   if (contentLength) headers.set('Content-Length', contentLength);
+
+  const etag = driveRes.headers.get('etag');
+  if (etag) headers.set('ETag', etag);
+
+  const lastModified = driveRes.headers.get('last-modified');
+  if (lastModified) headers.set('Last-Modified', lastModified);
 
   const acceptRanges = driveRes.headers.get('accept-ranges');
   if (acceptRanges) headers.set('Accept-Ranges', acceptRanges);

--- a/app/guest/[id]/components/GuestBgm.tsx
+++ b/app/guest/[id]/components/GuestBgm.tsx
@@ -15,6 +15,10 @@ interface GuestBgmProps {
 
 const USER_BGM_ID = 'user-bgm';
 
+function driveAudioUrl(fileId: string) {
+  return `https://drive.usercontent.google.com/download?id=${encodeURIComponent(fileId)}&export=download`;
+}
+
 function proxyAudioUrl(fileId: string) {
   return `/api/drive/guestBgm?fileId=${encodeURIComponent(fileId)}`;
 }
@@ -58,17 +62,52 @@ function GuestBgm({ bgm }: GuestBgmProps) {
   const [isOn, setIsOn] = useState(false);
   const [isHintDismissed, setIsHintDismissed] = useState(false);
   const [isPosterReady, setIsPosterReady] = useState(false);
+  const [directFailedUserBgmFileId, setDirectFailedUserBgmFileId] = useState<
+    string | null
+  >(null);
+  const [requestedAudioKey, setRequestedAudioKey] = useState<string | null>(
+    null
+  );
 
-  const src = useMemo(() => {
+  const isUserBgm = bgm.selectedBgmId === USER_BGM_ID;
+  const shouldUseProxyForUserBgm =
+    isUserBgm &&
+    bgm.userBgmFileId !== null &&
+    directFailedUserBgmFileId === bgm.userBgmFileId;
+
+  const selectedAudioKey = useMemo(() => {
     if (!bgm.selectedBgmId) return null;
 
-    if (bgm.selectedBgmId === USER_BGM_ID) {
+    if (isUserBgm) {
       if (!bgm.userBgmFileId) return null;
-      return proxyAudioUrl(bgm.userBgmFileId);
+      return `${USER_BGM_ID}:${bgm.userBgmFileId}`;
+    }
+
+    return bgm.selectedBgmId;
+  }, [bgm.selectedBgmId, bgm.userBgmFileId, isUserBgm]);
+
+  const selectedAudioSrc = useMemo(() => {
+    if (!bgm.selectedBgmId) return null;
+
+    if (isUserBgm) {
+      if (!bgm.userBgmFileId) return null;
+      return shouldUseProxyForUserBgm
+        ? proxyAudioUrl(bgm.userBgmFileId)
+        : driveAudioUrl(bgm.userBgmFileId);
     }
 
     return BGM_LIST.find(item => item.id === bgm.selectedBgmId)?.src ?? null;
-  }, [bgm.selectedBgmId, bgm.userBgmFileId]);
+  }, [
+    bgm.selectedBgmId,
+    bgm.userBgmFileId,
+    isUserBgm,
+    shouldUseProxyForUserBgm,
+  ]);
+
+  const src =
+    selectedAudioKey !== null && requestedAudioKey === selectedAudioKey
+      ? selectedAudioSrc
+      : null;
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -84,8 +123,10 @@ function GuestBgm({ bgm }: GuestBgmProps) {
 
     if (!src) {
       audio.pause();
-      audio.removeAttribute('src');
-      audio.load();
+      if (audio.hasAttribute('src')) {
+        audio.removeAttribute('src');
+        audio.load();
+      }
       return;
     }
 
@@ -93,6 +134,26 @@ function GuestBgm({ bgm }: GuestBgmProps) {
     audio.src = src;
     audio.load();
   }, [src]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const handleError = () => {
+      if (isUserBgm && bgm.userBgmFileId && !shouldUseProxyForUserBgm) {
+        setDirectFailedUserBgmFileId(bgm.userBgmFileId);
+        return;
+      }
+
+      setIsOn(false);
+    };
+
+    audio.addEventListener('error', handleError);
+
+    return () => {
+      audio.removeEventListener('error', handleError);
+    };
+  }, [bgm.userBgmFileId, isUserBgm, shouldUseProxyForUserBgm]);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -138,14 +199,17 @@ function GuestBgm({ bgm }: GuestBgmProps) {
   }, []);
 
   const handleToggle = () => {
+    if (!selectedAudioKey) return;
+
     setIsHintDismissed(true);
+    setRequestedAudioKey(selectedAudioKey);
     setIsOn(prev => !prev);
   };
 
   return (
     <>
       <audio ref={audioRef} preload="none" />
-      {src && (
+      {selectedAudioSrc && (
         <>
           {isPosterReady && <BgmPlaybackHint isDismissed={isHintDismissed} />}
           <BgmToggleButton isOn={isOn} onToggle={handleToggle} />


### PR DESCRIPTION
## 작업 개요

게스트 페이지의 사용자 업로드 BGM 요청 부하를 줄이고, Google Drive 직접 재생 실패 시에도 안정적으로 재생되도록 개선했습니다.

## 작업 내용

- [x] BGM 요청을 페이지 진입 시점이 아니라 첫 재생 버튼 클릭 시점에만 발생하도록 변경
- [x] 사용자 업로드 BGM은 Google Drive 직접 URL을 먼저 시도하고, 실패 시 기존 프록시 API로 fallback
- [x] `/api/drive/guestBgm` 응답에 브라우저 장기 캐시 적용
- [x] BGM 파일 ID가 바뀌면 새 음원 URL로 인식되도록 기존 fileId 기반 캐시 구조 유지

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx eslint app/api/drive/guestBgm/route.ts app/guest/[id]/components/GuestBgm.tsx` 통과
- `npx tsc --noEmit --pretty false` 통과
- Google Drive 직접 오디오 요청은 브라우저 cross-site audio 요청에서 403이 발생하여 프록시 fallback 유지
- 첫 버튼 클릭 전에는 BGM 네트워크 요청이 발생하지 않도록 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자 배경음악 재생 실패 시 대체 프록시 엔드포인트로 자동 전환

* **버그 수정**
  * Google Drive 오디오 파일 로드 오류 처리 개선
  * 장기 캐싱 메타데이터 추가로 오디오 콘텐츠 로딩 성능 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bread-Barbershop/frontend/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->