### PR TITLE
[Feat] UI polishing (헤더, 개인정보 모달, 컬러픽커, 안내문구, 순서패널, 텍스트에디터)

### DIFF
--- a/app/editor/[id]/components/EditorUpdate.tsx
+++ b/app/editor/[id]/components/EditorUpdate.tsx
@@ -46,7 +46,7 @@ function EditorUpdate({ folderId, uuid }: Props) {
   if (error) notFound();
   if (loading || !savedData) {
     return (
-      <div className="w-screen h-full flex justify-center items-center bg-[#E7E9EB]">
+      <div className="w-full h-full flex justify-center items-center bg-[#E7E9EB]">
         <LoadingSpinner className="w-20 h-20 animate-spin" />
       </div>
     );
@@ -54,7 +54,7 @@ function EditorUpdate({ folderId, uuid }: Props) {
 
   return (
     <FabricProvider initialData={savedData?.mainPoster}>
-      <div className="w-screen h-full bg-[#E7E9EB] flex flex-col gap-13 justify-center overflow-hidden">
+      <div className="w-full h-full bg-[#E7E9EB] flex flex-col gap-13 justify-center overflow-hidden">
         <div className="min-w-[1340px] flex justify-between items-center">
           <LeftPanel />
           <div className="flex gap-[clamp(20px,calc(20px+(32-20)*((100vw-1340px)/(1920-1340))),32px)] items-center">

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -5,7 +5,7 @@ import MainContentsArea from './components/MainContentsArea';
 const EditorPage = () => {
   return (
     <FabricProvider>
-      <div className="w-screen h-full bg-[#E7E9EB] flex flex-col gap-13 justify-center overflow-x-auto">
+      <div className="w-full h-full bg-[#E7E9EB] flex flex-col gap-13 justify-center overflow-x-auto overflow-y-hidden">
         <MainContentsArea />
       </div>
     </FabricProvider>

--- a/components/atoms/button/ImageUploadButton.tsx
+++ b/components/atoms/button/ImageUploadButton.tsx
@@ -16,8 +16,9 @@ export const ImageUploadButton = forwardRef<HTMLInputElement, Props>(
         style={{ width: size, height: size }}
         onClick={onButtonClick}
       >
-        <p className="font-semibold text-base">
-          이곳을 클릭하여 사진을 추가해주세요.
+        <p className="text-base font-[500] text-black">
+          <span className="font-[600] text-[#1F72EF]">이곳</span>을
+          클릭하여 사진을 추가해주세요.
         </p>
         <input
           type="file"

--- a/components/molecules/color-picker/ColorPickerBase.tsx
+++ b/components/molecules/color-picker/ColorPickerBase.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { hexToHsva, hsvaToHex, validHex } from '@uiw/color-convert';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ColorConverterSection } from './components/ColorConverterSection';
 import { ColorHistorySection } from './components/ColorHistorySection';
@@ -47,6 +47,8 @@ function ColorPickerBase({
     resolvedDefaultValue ?? { h: 0, s: 0, v: 68, a: 1 };
   const [internalHsva, setInternalHsva] = useState<PickerHsva>(initialHsva);
   const [inputMode, setInputMode] = useState<InputMode>('hex');
+  const hsvaRef = useRef<PickerHsva>(initialHsva);
+  const removePointerEndListenersRef = useRef<(() => void) | null>(null);
   const colorHistory = useColorHistoryStore(state => state.colorHistory);
   const addColorHistory = useColorHistoryStore(state => state.addColorHistory);
   const controlledHsva = resolvedControlledValue;
@@ -55,6 +57,8 @@ function ColorPickerBase({
   const hex = hsvaToHex(hsva).toUpperCase();
 
   const applyHsva = (nextHsva: PickerHsva) => {
+    hsvaRef.current = nextHsva;
+
     if (!controlledHsva) {
       setInternalHsva(nextHsva);
     }
@@ -70,14 +74,37 @@ function ColorPickerBase({
   };
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      addColorHistory(hex, maxHistoryCount);
-    }, 250);
+    hsvaRef.current = hsva;
+  }, [hsva]);
 
-    return () => {
-      window.clearTimeout(timeoutId);
+  const commitColorHistory = useCallback(() => {
+    addColorHistory(hsvaToHex(hsvaRef.current).toUpperCase(), maxHistoryCount);
+  }, [addColorHistory, maxHistoryCount]);
+
+  const clearPointerEndListeners = useCallback(() => {
+    removePointerEndListenersRef.current?.();
+    removePointerEndListenersRef.current = null;
+  }, []);
+
+  const handleColorControlPointerDown = useCallback(() => {
+    if (typeof window === 'undefined') return;
+
+    clearPointerEndListeners();
+
+    const handlePointerEnd = () => {
+      commitColorHistory();
+      clearPointerEndListeners();
     };
-  }, [addColorHistory, hex, maxHistoryCount]);
+
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    removePointerEndListenersRef.current = () => {
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    };
+  }, [clearPointerEndListeners, commitColorHistory]);
+
+  useEffect(() => clearPointerEndListeners, [clearPointerEndListeners]);
 
   return (
     <>
@@ -85,6 +112,7 @@ function ColorPickerBase({
         hsva={hsva}
         className={paletteClassName}
         pointerSize={pointerSize}
+        onPointerDown={handleColorControlPointerDown}
         onChange={nextColor => {
           mergeHsva(nextColor);
         }}
@@ -93,6 +121,7 @@ function ColorPickerBase({
       <ColorSlideSection
         hue={hsva.h}
         pointerSize={pointerSize}
+        onPointerDown={handleColorControlPointerDown}
         onChange={hue => {
           mergeHsva({ h: hue });
         }}
@@ -102,6 +131,7 @@ function ColorPickerBase({
         hsva={hsva}
         transparencyPercent={transparencyPercent}
         pointerSize={pointerSize}
+        onPointerDown={handleColorControlPointerDown}
         onChange={alpha => {
           mergeHsva({ a: alpha });
         }}

--- a/components/molecules/color-picker/components/ColorPaletteSection.tsx
+++ b/components/molecules/color-picker/components/ColorPaletteSection.tsx
@@ -7,6 +7,7 @@ import { GlassPointer } from './GlassPointer';
 
 import type { PickerHsva } from './colorPicker.types';
 import type { GlassPointerSize } from './GlassPointer';
+import type { PointerEventHandler } from 'react';
 
 /**
  * 채도와 명도를 동시에 조절하는 메인 컬러 팔레트 영역입니다.
@@ -19,14 +20,16 @@ export function ColorPaletteSection({
   className = 'aspect-square w-full',
   pointerSize,
   onChange,
+  onPointerDown,
 }: {
   hsva: PickerHsva;
   className?: string;
   pointerSize?: GlassPointerSize;
   onChange: (nextColor: Partial<PickerHsva>) => void;
+  onPointerDown?: PointerEventHandler<HTMLDivElement>;
 }) {
   return (
-    <div className={`${className} overflow-visible`}>
+    <div className={`${className} overflow-visible`} onPointerDown={onPointerDown}>
       <Saturation
         hsva={hsva}
         radius={12}

--- a/components/molecules/color-picker/components/ColorSlideSection.tsx
+++ b/components/molecules/color-picker/components/ColorSlideSection.tsx
@@ -6,6 +6,7 @@ import Hue from '@uiw/react-color-hue';
 import { GlassPointer } from './GlassPointer';
 
 import type { GlassPointerSize } from './GlassPointer';
+import type { PointerEventHandler } from 'react';
 
 /**
  * 색상환 기준의 Hue 값을 조절하는 슬라이더입니다.
@@ -17,13 +18,15 @@ export function ColorSlideSection({
   hue,
   pointerSize,
   onChange,
+  onPointerDown,
 }: {
   hue: number;
   pointerSize?: GlassPointerSize;
   onChange: (hue: number) => void;
+  onPointerDown?: PointerEventHandler<HTMLDivElement>;
 }) {
   return (
-    <div className="w-full">
+    <div className="w-full" onPointerDown={onPointerDown}>
       <Hue
         hue={hue}
         width="100%"

--- a/components/molecules/color-picker/components/ToneControlSection.tsx
+++ b/components/molecules/color-picker/components/ToneControlSection.tsx
@@ -7,6 +7,7 @@ import { GlassPointer } from './GlassPointer';
 
 import type { PickerHsva } from './colorPicker.types';
 import type { GlassPointerSize } from './GlassPointer';
+import type { PointerEventHandler } from 'react';
 
 /**
  * 투명도 값을 조절하는 슬라이더 영역입니다.
@@ -19,14 +20,16 @@ export function ToneControlSection({
   transparencyPercent,
   pointerSize,
   onChange,
+  onPointerDown,
 }: {
   hsva: PickerHsva;
   transparencyPercent: number;
   pointerSize?: GlassPointerSize;
   onChange: (alpha: number) => void;
+  onPointerDown?: PointerEventHandler<HTMLDivElement>;
 }) {
   return (
-    <div className="flex items-center gap-5">
+    <div className="flex items-center gap-5" onPointerDown={onPointerDown}>
       <div className="flex h-8 w-13.5 shrink-0 items-center justify-center rounded-md border border-gray-200 bg-[#f5f5f5] text-[14px] font-medium text-gray-700">
         {transparencyPercent}%
       </div>

--- a/components/molecules/color-picker/store/useColorHistoryStore.ts
+++ b/components/molecules/color-picker/store/useColorHistoryStore.ts
@@ -5,8 +5,10 @@ type ColorHistoryState = {
   addColorHistory: (hex: string, maxCount: number) => void;
 };
 
+const DEFAULT_COLOR_HISTORY = ['#000000', '#FFFFFF'];
+
 export const useColorHistoryStore = create<ColorHistoryState>(set => ({
-  colorHistory: [],
+  colorHistory: DEFAULT_COLOR_HISTORY,
   addColorHistory: (hex, maxCount) =>
     set(state => ({
       colorHistory: [

--- a/components/molecules/editor-notice/EditorNoticeList.tsx
+++ b/components/molecules/editor-notice/EditorNoticeList.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/shared/utils/cn';
+
+export type EditorNoticeItem = {
+  id: string | number;
+  text: string;
+  colorClass?: string;
+};
+
+type EditorNoticeListProps = {
+  notices: EditorNoticeItem[];
+  className?: string;
+};
+
+function EditorNoticeList({ notices, className }: EditorNoticeListProps) {
+  if (notices.length === 0) return null;
+
+  return (
+    <div className={cn('flex w-full flex-col gap-1', className)}>
+      {notices.map(({ id, text, colorClass = 'text-[#838383]' }) => {
+        const isBlueNotice =
+          colorClass.includes('#1F72EF') || colorClass.includes('blue');
+
+        return (
+          <p
+            key={id}
+            className={cn(
+              'grid grid-cols-[auto_1fr] gap-x-2 break-keep text-[13px]',
+              isBlueNotice ? 'font-medium' : 'font-normal',
+              colorClass,
+            )}
+          >
+            <span aria-hidden="true">·</span>
+            <span>{text}</span>
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
+export default EditorNoticeList;

--- a/components/molecules/editor-notice/EditorNoticeList.tsx
+++ b/components/molecules/editor-notice/EditorNoticeList.tsx
@@ -17,8 +17,10 @@ function EditorNoticeList({ notices, className }: EditorNoticeListProps) {
   return (
     <div className={cn('flex w-full flex-col gap-1', className)}>
       {notices.map(({ id, text, colorClass = 'text-[#838383]' }) => {
+        const normalizedColorClass = colorClass.toLowerCase();
         const isBlueNotice =
-          colorClass.includes('#1F72EF') || colorClass.includes('blue');
+          normalizedColorClass.includes('#1f72ef') ||
+          normalizedColorClass.includes('blue');
 
         return (
           <p

--- a/components/molecules/editor-notice/index.ts
+++ b/components/molecules/editor-notice/index.ts
@@ -1,0 +1,2 @@
+export { default as EditorNoticeList } from './EditorNoticeList';
+export type { EditorNoticeItem } from './EditorNoticeList';

--- a/components/molecules/preview-text-editor/TextEditorPreview.tsx
+++ b/components/molecules/preview-text-editor/TextEditorPreview.tsx
@@ -179,7 +179,7 @@ export function TextEditorPreview({
             }}
           />
 
-          <div className="flex h-8 items-center rounded-md bg-[#f3f3f3] p-px">
+          <div className="flex h-8 items-center gap-1 rounded-md bg-[#f3f3f3] p-px">
             {TEXT_ALIGN_OPTIONS.map(option => {
               const active = textAlignSelected.value === option.value;
 

--- a/components/molecules/preview-text-editor/components/ColorPicker.tsx
+++ b/components/molecules/preview-text-editor/components/ColorPicker.tsx
@@ -11,11 +11,17 @@ import {
 import { createPortal } from 'react-dom';
 
 import SmallColorPicker from '@/components/molecules/color-picker/SmallColorPicker';
+import {
+  clampFloatingValue,
+  resolveFloatingTop,
+  type FloatingPlacementMode,
+} from '@/shared/utils/floatingPosition';
 
 interface Props {
   initialHex?: string;
   onClose?: () => void;
   containerRef?: RefObject<HTMLElement | null>;
+  placementMode?: FloatingPlacementMode;
   onChange: (hex: string) => void;
 }
 
@@ -24,13 +30,11 @@ const TRIGGER_GAP = 8;
 const PANEL_GAP = 12;
 const LEFT_PANEL_SELECTOR = '[data-editor-left-panel]';
 
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(Math.max(value, min), Math.max(min, max));
-
 export default function BulkColorPicker({
   initialHex = '#FF4D6D',
   onClose,
   containerRef,
+  placementMode = 'center',
   onChange,
 }: Props) {
   const pickerRef = useRef<HTMLDivElement>(null);
@@ -65,24 +69,16 @@ export default function BulkColorPicker({
         : triggerRect
           ? triggerRect.right - pickerWidth
           : (window.innerWidth - pickerWidth) / 2;
-      const left = clamp(preferredLeft, VIEWPORT_GAP, maxLeft);
-
-      const maxTop = window.innerHeight - pickerHeight - VIEWPORT_GAP;
-      const preferredTop = triggerRect
-        ? triggerRect.top
-        : panelRect
-          ? panelRect.top + (panelRect.height - pickerHeight) / 2
-          : (window.innerHeight - pickerHeight) / 2;
-      const top = triggerRect
-        ? preferredTop + pickerHeight <= window.innerHeight - VIEWPORT_GAP ||
-          triggerRect.top - pickerHeight - TRIGGER_GAP < VIEWPORT_GAP
-          ? clamp(preferredTop, VIEWPORT_GAP, maxTop)
-          : clamp(
-              triggerRect.top - pickerHeight - TRIGGER_GAP,
-              VIEWPORT_GAP,
-              maxTop
-            )
-        : clamp(preferredTop, VIEWPORT_GAP, maxTop);
+      const left = clampFloatingValue(preferredLeft, VIEWPORT_GAP, maxLeft);
+      const top = resolveFloatingTop({
+        mode: placementMode,
+        floatingHeight: pickerHeight,
+        triggerRect,
+        containerRect: panelRect,
+        viewportGap: VIEWPORT_GAP,
+        triggerGap: TRIGGER_GAP,
+        flipSticky: true,
+      });
 
       setPopoverStyle({
         position: 'fixed',
@@ -111,7 +107,7 @@ export default function BulkColorPicker({
       window.removeEventListener('scroll', updatePosition, true);
       resizeObserver.disconnect();
     };
-  }, [containerRef]);
+  }, [containerRef, placementMode]);
 
   if (typeof document === 'undefined') return null;
 

--- a/components/molecules/selector/Selector.tsx
+++ b/components/molecules/selector/Selector.tsx
@@ -3,6 +3,7 @@ import {
   useState,
   useRef,
   useEffect,
+  useCallback,
   ChangeEvent,
   useId,
   CSSProperties,
@@ -39,6 +40,11 @@ interface SelectorProps<T extends Option> {
   searchable?: boolean;
 }
 
+const VIEWPORT_GAP = 12;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), Math.max(min, max));
+
 export const Selector = <T extends Option>({
   type = 'editor',
   options,
@@ -70,16 +76,31 @@ export const Selector = <T extends Option>({
   // 실제 값이 있는지 확인 (객체 내부의 value나 label 체크)
   const hasValue = !!(selected?.value || selected?.label);
 
-  const updatePopoverPosition = () => {
-    if (containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect();
-      setPopoverPos({
-        top: rect.bottom + window.scrollY,
-        left: rect.left + window.scrollX,
-        width: rect.width,
-      });
-    }
-  };
+  const updatePopoverPosition = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || typeof window === 'undefined') return;
+
+    const rect = container.getBoundingClientRect();
+    const width = rect.width + addPopWidth;
+    const popoverHeight = popoverRef.current?.offsetHeight ?? 0;
+    const maxLeft = window.innerWidth - width - VIEWPORT_GAP;
+    const left = clamp(rect.left, VIEWPORT_GAP, maxLeft);
+    const belowTop = rect.bottom;
+    const aboveTop = rect.top - popoverHeight;
+    const maxTop = window.innerHeight - popoverHeight - VIEWPORT_GAP;
+    const preferredTop =
+      popoverHeight > 0 &&
+      belowTop + popoverHeight > window.innerHeight - VIEWPORT_GAP &&
+      aboveTop >= VIEWPORT_GAP
+        ? aboveTop
+        : belowTop;
+
+    setPopoverPos({
+      top: clamp(preferredTop, VIEWPORT_GAP, maxTop),
+      left,
+      width: rect.width,
+    });
+  }, [addPopWidth]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     onInputChange?.(e.target.value);
@@ -99,6 +120,7 @@ export const Selector = <T extends Option>({
       setIsOpen(true);
       updatePopoverPosition();
       popoverRef.current?.showPopover();
+      window.requestAnimationFrame(updatePopoverPosition);
     }
   };
 
@@ -130,7 +152,31 @@ export const Selector = <T extends Option>({
 
     el.addEventListener('toggle', handleToggleEvent);
     return () => el.removeEventListener('toggle', handleToggleEvent);
-  }, []);
+  }, [updatePopoverPosition]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (typeof window === 'undefined') return;
+
+    updatePopoverPosition();
+    const animationFrameId = window.requestAnimationFrame(
+      updatePopoverPosition
+    );
+
+    window.addEventListener('resize', updatePopoverPosition);
+    window.addEventListener('scroll', updatePopoverPosition, true);
+
+    const resizeObserver = new ResizeObserver(updatePopoverPosition);
+    if (containerRef.current) resizeObserver.observe(containerRef.current);
+    if (popoverRef.current) resizeObserver.observe(popoverRef.current);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', updatePopoverPosition);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      resizeObserver.disconnect();
+    };
+  }, [isOpen, updatePopoverPosition]);
 
   const filteredOptions = searchable
     ? options.filter(opt => {

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -335,7 +335,7 @@ export function TextEditor({
             onClick={handleUnderlineToggle}
           />
 
-          <div className="flex h-8 items-center rounded-md bg-[#f3f3f3] p-px">
+          <div className="flex h-8 items-center gap-1 rounded-md bg-[#f3f3f3] p-px">
             {TEXT_ALIGN_OPTIONS.map(option => {
               const active = textAlignSelected.value === option.value;
 

--- a/components/molecules/text-editor/components/TextEditorColorPickerPopover.tsx
+++ b/components/molecules/text-editor/components/TextEditorColorPickerPopover.tsx
@@ -13,6 +13,11 @@ import {
 import { createPortal } from 'react-dom';
 
 import SmallColorPicker from '@/components/molecules/color-picker/SmallColorPicker';
+import {
+  clampFloatingValue,
+  resolveFloatingTop,
+  type FloatingPlacementMode,
+} from '@/shared/utils/floatingPosition';
 
 import type { Editor } from '@tiptap/react';
 
@@ -23,6 +28,7 @@ interface Props {
   onClose?: () => void;
   onColorChange?: (color: string) => void;
   containerRef?: RefObject<HTMLElement | null>;
+  placementMode?: FloatingPlacementMode;
 }
 
 const VIEWPORT_GAP = 12;
@@ -36,6 +42,7 @@ export default function TextEditorColorPickerPopover({
   onClose,
   onColorChange,
   containerRef,
+  placementMode = 'center',
 }: Props) {
   const pickerRef = useRef<HTMLDivElement>(null);
   const [popoverStyle, setPopoverStyle] = useState<CSSProperties>({
@@ -65,13 +72,14 @@ export default function TextEditorColorPickerPopover({
       const preferredLeft = panelRect
         ? panelRect.right + PANEL_GAP
         : triggerRect.right - pickerWidth;
-      const left = Math.min(Math.max(preferredLeft, VIEWPORT_GAP), maxLeft);
-      const preferredTop = triggerRect.top;
-      const maxTop = window.innerHeight - pickerHeight - VIEWPORT_GAP;
-      const top = Math.max(
-        VIEWPORT_GAP,
-        Math.min(preferredTop, Math.max(VIEWPORT_GAP, maxTop))
-      );
+      const left = clampFloatingValue(preferredLeft, VIEWPORT_GAP, maxLeft);
+      const top = resolveFloatingTop({
+        mode: placementMode,
+        floatingHeight: pickerHeight,
+        triggerRect,
+        containerRect: panelRect,
+        viewportGap: VIEWPORT_GAP,
+      });
 
       setPopoverStyle({
         position: 'fixed',
@@ -98,7 +106,7 @@ export default function TextEditorColorPickerPopover({
       window.removeEventListener('scroll', updatePosition, true);
       resizeObserver.disconnect();
     };
-  }, [containerRef, isOpen]);
+  }, [containerRef, isOpen, placementMode]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/components/organisms/calendar/Calendar.tsx
+++ b/components/organisms/calendar/Calendar.tsx
@@ -6,6 +6,7 @@ import React, { useCallback } from 'react';
 import { Divider } from '@/components/atoms/divider';
 import { Label } from '@/components/atoms/label';
 import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { TextEditor } from '@/components/molecules/text-editor';
 import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
@@ -202,6 +203,15 @@ export function Calendar({ blockInfo, id }: Props) {
             </div>
           </div>
         </div>
+        <EditorNoticeList
+          notices={[
+            {
+              id: 'calendar-dday',
+              text: '디데이 버튼 클릭 시 (D-Day)가 추가되며, (D-Day)에 남은 일수가 표시됩니다.',
+              colorClass: 'text-[#1F72EF]',
+            },
+          ]}
+        />
       </div>
     </LeftEditorWrapper>
   );

--- a/components/organisms/interview/Interview.tsx
+++ b/components/organisms/interview/Interview.tsx
@@ -6,6 +6,7 @@ import { UtilityButton } from '@/components/atoms/button';
 import { Divider } from '@/components/atoms/divider/Divider';
 import { Label } from '@/components/atoms/label/Label';
 import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
 import { TextField } from '@/components/molecules/text-field';
@@ -198,6 +199,19 @@ export const Interview = ({ blockInfo, id }: Props) => {
           </div>
         ))}
       </div>
+      <EditorNoticeList
+        notices={[
+          {
+            id: 'interview-default-image',
+            text: '배너사진을 추가하지 않으실 경우, 기본 이미지로 제공됩니다.',
+            colorClass: 'text-[#1F72EF]',
+          },
+          {
+            id: 'interview-animation',
+            text: '항목이 2개 이상일 경우, 애니메이션 효과가 적용됩니다.',
+          },
+        ]}
+      />
 
       {isQuestionListOpen && (
         <PopupOptions

--- a/components/organisms/notice/Notice.tsx
+++ b/components/organisms/notice/Notice.tsx
@@ -5,6 +5,7 @@ import { UtilityButton } from '@/components/atoms/button';
 import { Divider } from '@/components/atoms/divider';
 import { Label } from '@/components/atoms/label/Label';
 import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
 import { TextField } from '@/components/molecules/text-field';
@@ -199,6 +200,19 @@ export const Notice = ({ blockInfo, id }: Props) => {
           </div>
         ))}
       </div>
+      <EditorNoticeList
+        notices={[
+          {
+            id: 'notice-default-image',
+            text: '배너사진을 추가하지 않으실 경우, 기본 이미지로 제공됩니다.',
+            colorClass: 'text-[#1F72EF]',
+          },
+          {
+            id: 'notice-animation',
+            text: '항목이 2개 이상일 경우, 애니메이션 효과가 적용됩니다.',
+          },
+        ]}
+      />
 
       {isNoticeListOpen && (
         <PopupOptions

--- a/components/organisms/popup/Popup.tsx
+++ b/components/organisms/popup/Popup.tsx
@@ -15,6 +15,11 @@ import { createPortal } from 'react-dom';
 import { UtilityButton } from '@/components/atoms/button';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { cn } from '@/shared/utils/cn';
+import {
+  clampFloatingValue,
+  resolveFloatingTop,
+  type FloatingPlacementMode,
+} from '@/shared/utils/floatingPosition';
 
 interface Props {
   children: ReactNode;
@@ -26,14 +31,12 @@ interface Props {
   contentClassName?: string;
   hideCloseButton?: boolean;
   triggerRef?: RefObject<HTMLElement | null>;
+  placementMode?: FloatingPlacementMode;
 }
 
 const VIEWPORT_GAP = 12;
 const PANEL_GAP = 12;
 const LEFT_PANEL_SELECTOR = '[data-editor-left-panel]';
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(Math.max(value, min), Math.max(min, max));
 
 export const Popup = ({
   children,
@@ -45,6 +48,7 @@ export const Popup = ({
   contentClassName,
   hideCloseButton = false,
   triggerRef,
+  placementMode = 'sticky',
 }: Props) => {
   const popupRef = useRef<HTMLDivElement>(null);
   const [popupStyle, setPopupStyle] = useState<CSSProperties>({
@@ -76,23 +80,22 @@ export const Popup = ({
       const popupWidth = popup.offsetWidth;
       const popupHeight = popup.offsetHeight;
       const maxLeft = window.innerWidth - popupWidth - VIEWPORT_GAP;
-      const maxTop = window.innerHeight - popupHeight - VIEWPORT_GAP;
 
       const preferredLeft = panelRect
         ? panelRect.right + PANEL_GAP
         : triggerRect
           ? triggerRect.right + PANEL_GAP
           : (window.innerWidth - popupWidth) / 2;
-      const preferredTop = triggerRect
-        ? triggerRect.top
-        : panelRect
-          ? panelRect.top
-          : (window.innerHeight - popupHeight) / 2;
-
       setPopupStyle({
         position: 'fixed',
-        left: clamp(preferredLeft, VIEWPORT_GAP, maxLeft),
-        top: clamp(preferredTop, VIEWPORT_GAP, maxTop),
+        left: clampFloatingValue(preferredLeft, VIEWPORT_GAP, maxLeft),
+        top: resolveFloatingTop({
+          mode: placementMode,
+          floatingHeight: popupHeight,
+          triggerRect,
+          containerRect: panelRect,
+          viewportGap: VIEWPORT_GAP,
+        }),
         visibility: 'visible',
         zIndex: 1000,
       });
@@ -116,7 +119,7 @@ export const Popup = ({
       window.removeEventListener('scroll', updatePosition, true);
       resizeObserver.disconnect();
     };
-  }, [triggerRef, variant]);
+  }, [placementMode, triggerRef, variant]);
 
   useEffect(() => {
     const handlePointerDown = (event: PointerEvent) => {

--- a/components/organisms/share-url/ShareUrl.tsx
+++ b/components/organisms/share-url/ShareUrl.tsx
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/shallow';
 import { MultiRowInput } from '@/components/atoms/input/MultiRowInput';
 import { Label } from '@/components/atoms/label';
 import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { Picture } from '@/components/molecules/picture/Picture';
 import { TextField } from '@/components/molecules/text-field';
@@ -166,11 +167,7 @@ function ShareUrl() {
             </div>
           </div>
         )}
-        {SHARE_NOTICES.map(({ id, text, colorClass }) => (
-          <p key={id} className={`text-xs ${colorClass} break-keep`}>
-            {text}
-          </p>
-        ))}
+        <EditorNoticeList notices={SHARE_NOTICES} />
       </div>
     </LeftEditorWrapper>
   );

--- a/components/organisms/share-url/constants/share.ts
+++ b/components/organisms/share-url/constants/share.ts
@@ -2,7 +2,7 @@ export const SHARE_NOTICES = [
   {
     id: 1,
     text: '* 해당 초대장을 공유 시 반영되는 기능입니다.',
-    colorClass: 'text-blue-500',
+    colorClass: 'text-[#1F72EF]',
   },
   {
     id: 2,

--- a/components/organisms/speakerInformation/SpeakerInformation.tsx
+++ b/components/organisms/speakerInformation/SpeakerInformation.tsx
@@ -6,6 +6,7 @@ import { UtilityButton } from '@/components/atoms/button';
 import { Divider } from '@/components/atoms/divider/Divider';
 import { Label } from '@/components/atoms/label/Label';
 import { Checkbox } from '@/components/molecules/checkbox/Checkbox';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
 import { TextField } from '@/components/molecules/text-field';
@@ -201,6 +202,14 @@ export const SpeakerInformation = ({ blockInfo, id }: Props) => {
           영문 제목 추가
         </Checkbox>
       </section>
+      <EditorNoticeList
+        notices={[
+          {
+            id: 'speaker-animation',
+            text: '항목이 2개 이상일 경우, 애니메이션 효과가 적용됩니다.',
+          },
+        ]}
+      />
     </LeftEditorWrapper>
   );
 };

--- a/features/session/components/DashboardShell.tsx
+++ b/features/session/components/DashboardShell.tsx
@@ -6,6 +6,7 @@ import { DASHBOARD_SHELL_NAV_MENU } from '@/features/session/config/dashboardShe
 import homeBackgroundImage from '@/shared/assets/images/home/home-background.png';
 
 import HeaderAuthControl from './HeaderAuthControl';
+import HeaderPrivacyNoticeButton from './HeaderPrivacyNoticeButton';
 import HomeButton from './HomeButton';
 
 const HEADER_NAV_LINK_CLASS =
@@ -42,9 +43,7 @@ export default async function DashboardShell({
           </nav>
         </div>
 
-        <div className="h-full px-2 flex items-center text-[16px] font-semibold text-[#121212]">
-          개인정보 걱정 없어요.
-        </div>
+        <HeaderPrivacyNoticeButton />
       </header>
 
       <main className="relative max-w-480 w-full mx-auto min-h-0 flex flex-col justify-end">

--- a/features/session/components/HeaderPrivacyNoticeButton.tsx
+++ b/features/session/components/HeaderPrivacyNoticeButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+
+import PrivacyNoticeModal from './PrivacyNoticeModal';
+
+const HEADER_PRIVACY_BUTTON_CLASS =
+  'h-full px-2 flex items-center text-[16px] font-semibold text-[#121212] cursor-pointer';
+
+function HeaderPrivacyNoticeButton() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={HEADER_PRIVACY_BUTTON_CLASS}
+      >
+        개인정보 걱정 없어요.
+      </button>
+      <PrivacyNoticeModal open={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}
+
+export default HeaderPrivacyNoticeButton;

--- a/features/session/components/HeaderPrivacyNoticeButton.tsx
+++ b/features/session/components/HeaderPrivacyNoticeButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import PrivacyNoticeModal from './PrivacyNoticeModal';
 
@@ -9,6 +9,9 @@ const HEADER_PRIVACY_BUTTON_CLASS =
 
 function HeaderPrivacyNoticeButton() {
   const [isOpen, setIsOpen] = useState(false);
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
 
   return (
     <>
@@ -19,7 +22,7 @@ function HeaderPrivacyNoticeButton() {
       >
         개인정보 걱정 없어요.
       </button>
-      <PrivacyNoticeModal open={isOpen} onClose={() => setIsOpen(false)} />
+      <PrivacyNoticeModal open={isOpen} onClose={handleClose} />
     </>
   );
 }

--- a/features/session/components/PrivacyNoticeModal.tsx
+++ b/features/session/components/PrivacyNoticeModal.tsx
@@ -60,7 +60,7 @@ function PrivacyNoticeModal({ open, onClose }: PrivacyNoticeModalProps) {
       }}
     >
       <div
-        className={`max-w-[calc(100vw-40px)] rounded-xl border border-white/22 bg-white/72 p-5 shadow-[0_24px_60px_-20px_rgb(0_0_0_/_12%),0_8px_24px_-8px_rgb(0_0_0_/_18%),0_1px_8px_-2px_rgb(255_255_255_/_35%)] backdrop-blur-xl transition-all duration-200 ${
+        className={`max-w-[calc(100vw-40px)] rounded-xl border border-black/5 bg-white p-5 shadow-[0_24px_60px_-20px_rgb(0_0_0_/_12%),0_8px_24px_-8px_rgb(0_0_0_/_18%)] transition-all duration-200 ${
           isClosing ? 'scale-[0.98] opacity-0' : 'scale-100 opacity-100'
         }`}
       >

--- a/features/session/components/PrivacyNoticeModal.tsx
+++ b/features/session/components/PrivacyNoticeModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type PrivacyNoticeModalProps = {
   open: boolean;
@@ -10,34 +10,59 @@ type PrivacyNoticeModalProps = {
 const FADE_OUT_MS = 180;
 
 function PrivacyNoticeModal({ open, onClose }: PrivacyNoticeModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const [isClosing, setIsClosing] = useState(false);
 
-  const closeWithFade = () => {
+  const closeWithFade = useCallback(() => {
     if (isClosing) return;
 
     setIsClosing(true);
     window.setTimeout(() => {
+      if (dialogRef.current?.open) {
+        dialogRef.current.close();
+      }
       onClose();
       setIsClosing(false);
     }, FADE_OUT_MS);
-  };
+  }, [isClosing, onClose]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+      return;
+    }
+
+    if (!open && !isClosing && dialog.open) {
+      dialog.close();
+    }
+  }, [open, isClosing]);
 
   if (!open && !isClosing) return null;
 
   return (
-    <div
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-[rgb(0_0_0_/_8%)] transition-opacity duration-200 ${
-        isClosing ? 'opacity-0' : 'opacity-100'
+    <dialog
+      ref={dialogRef}
+      className={`m-auto max-w-[calc(100vw-40px)] border-0 bg-transparent p-0 text-left outline-none backdrop:bg-[rgb(0_0_0_/_8%)] backdrop:transition-opacity backdrop:duration-200 ${
+        isClosing ? 'backdrop:opacity-0' : 'backdrop:opacity-100'
       }`}
-      onClick={closeWithFade}
-      role="dialog"
       aria-modal="true"
+      onCancel={e => {
+        e.preventDefault();
+        closeWithFade();
+      }}
+      onClick={e => {
+        if (e.target === e.currentTarget) {
+          closeWithFade();
+        }
+      }}
     >
       <div
         className={`max-w-[calc(100vw-40px)] rounded-xl border border-white/22 bg-white/72 p-5 shadow-[0_24px_60px_-20px_rgb(0_0_0_/_12%),0_8px_24px_-8px_rgb(0_0_0_/_18%),0_1px_8px_-2px_rgb(255_255_255_/_35%)] backdrop-blur-xl transition-all duration-200 ${
           isClosing ? 'scale-[0.98] opacity-0' : 'scale-100 opacity-100'
         }`}
-        onClick={e => e.stopPropagation()}
       >
         <div className="p-10 text-[14px] font-semibold leading-[1.65] text-[#121212]">
           이 사이트는 초대장을 확인하는 과정에서 사용자의 이름, 연락처,
@@ -49,7 +74,7 @@ function PrivacyNoticeModal({ open, onClose }: PrivacyNoticeModalProps) {
           사용자의 개인정보를 광고, 마케팅, 분석 목적으로 이용하지 않습니다.
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/shared/utils/floatingPosition.ts
+++ b/shared/utils/floatingPosition.ts
@@ -1,0 +1,60 @@
+export type FloatingPlacementMode = 'sticky' | 'center';
+
+type ResolveFloatingTopOptions = {
+  mode: FloatingPlacementMode;
+  floatingHeight: number;
+  triggerRect?: DOMRect | null;
+  containerRect?: DOMRect | null;
+  viewportHeight?: number;
+  viewportGap?: number;
+  triggerGap?: number;
+  flipSticky?: boolean;
+};
+
+export const clampFloatingValue = (
+  value: number,
+  min: number,
+  max: number
+) => Math.min(Math.max(value, min), Math.max(min, max));
+
+export function resolveFloatingTop({
+  mode,
+  floatingHeight,
+  triggerRect,
+  containerRect,
+  viewportHeight = window.innerHeight,
+  viewportGap = 12,
+  triggerGap = 8,
+  flipSticky = false,
+}: ResolveFloatingTopOptions) {
+  const maxTop = viewportHeight - floatingHeight - viewportGap;
+
+  if (mode === 'center') {
+    const preferredTop = containerRect
+      ? containerRect.top + (containerRect.height - floatingHeight) / 2
+      : (viewportHeight - floatingHeight) / 2;
+
+    return clampFloatingValue(preferredTop, viewportGap, maxTop);
+  }
+
+  const preferredTop = triggerRect
+    ? triggerRect.top
+    : containerRect
+      ? containerRect.top
+      : (viewportHeight - floatingHeight) / 2;
+
+  if (
+    flipSticky &&
+    triggerRect &&
+    preferredTop + floatingHeight > viewportHeight - viewportGap &&
+    triggerRect.top - floatingHeight - triggerGap >= viewportGap
+  ) {
+    return clampFloatingValue(
+      triggerRect.top - floatingHeight - triggerGap,
+      viewportGap,
+      maxTop
+    );
+  }
+
+  return clampFloatingValue(preferredTop, viewportGap, maxTop);
+}

--- a/widgets/editor/leftPanel/components/BulkEdit.tsx
+++ b/widgets/editor/leftPanel/components/BulkEdit.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import type { BulkColorPickerId } from '@/components/molecules/preview-text-editor/types';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 
@@ -30,6 +31,15 @@ function BulkEdit() {
           onActiveColorPickerChange={setActiveColorPickerId}
         />
         <ZoomEdit />
+        <EditorNoticeList
+          notices={[
+            {
+              id: 'bulk-edit',
+              text: '초대장의 모든 폰트를 일괄 변경하거나 배경 색상을 변경하실 수 있습니다.',
+              colorClass: 'text-[#1F72EF]',
+            },
+          ]}
+        />
       </LeftEditorWrapper>
     </div>
   );

--- a/widgets/editor/preview/Preview.tsx
+++ b/widgets/editor/preview/Preview.tsx
@@ -55,7 +55,13 @@ function Preview() {
             </div>
           )}
           <div className="flex flex-col min-h-full font-lineseed">
-            <MainPosterPreview />
+            <div
+              ref={el => {
+                blockRefs.current.mainPoster = el;
+              }}
+            >
+              <MainPosterPreview />
+            </div>
             {block.map(comp => {
               const registryItem = blockRegistry[comp.component];
 

--- a/widgets/editor/preview/components/OrderPanel.tsx
+++ b/widgets/editor/preview/components/OrderPanel.tsx
@@ -140,7 +140,7 @@ function OrderPanel() {
           >
             <button
               type="button"
-              className={`flex-center px-3 py-2 w-24 rounded-sm ${selectedId === 'mainPoster' ? 'bg-[#DBE8FC]' : ''}`}
+              className={`flex-center px-3 py-2 w-24 cursor-pointer rounded-sm ${selectedId === 'mainPoster' ? 'bg-[#DBE8FC]' : ''}`}
               onPointerDown={() => handleSelect('mainPoster')}
             >
               포스터

--- a/widgets/mainPoster/components/image/ImagePanel.tsx
+++ b/widgets/mainPoster/components/image/ImagePanel.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 
 import { ImageUploadButton } from '@/components/atoms/button/ImageUploadButton';
+import { EditorNoticeList } from '@/components/molecules/editor-notice';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
@@ -164,6 +165,15 @@ export const ImagePanel = () => {
         )}
       </div>
       <AspectRatioSelector startCrop={handleStartCrop} />
+      <EditorNoticeList
+        notices={[
+          {
+            id: 'poster-image-crop',
+            text: '자르기 실행 후 원하는 형태로 자르기 하신 뒤 아무곳이나 클릭하시면 적용됩니다.',
+            colorClass: 'text-[#1F72EF]',
+          },
+        ]}
+      />
     </LeftEditorWrapper>
   );
 };

--- a/widgets/mainPoster/components/richtext/FontColor.tsx
+++ b/widgets/mainPoster/components/richtext/FontColor.tsx
@@ -1,7 +1,13 @@
 import { hsvaToHex } from '@uiw/color-convert';
 import { Textbox } from 'fabric';
 import { ChevronDown } from 'lucide-react';
-import React, { useEffect, useId, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   ColorPickerValue,
@@ -9,9 +15,17 @@ import {
 } from '@/components/molecules/color-picker/components/colorPicker.types';
 import SmallColorPicker from '@/components/molecules/color-picker/SmallColorPicker';
 import { cn } from '@/shared/utils/cn';
+import {
+  clampFloatingValue,
+  resolveFloatingTop,
+} from '@/shared/utils/floatingPosition';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 import { convertFabricColor } from '../../utils/fabricUtils';
+
+const VIEWPORT_GAP = 12;
+const PANEL_GAP = 12;
+const LEFT_PANEL_SELECTOR = '[data-editor-left-panel]';
 
 const ColorIcon = ({ color }: { color: string }) => (
   <svg
@@ -46,15 +60,31 @@ function FontColor() {
   const baseId = useId();
   const popoverId = `color-picker-${baseId}`;
 
-  const updatePopoverPosition = () => {
-    if (containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect();
-      setPopoverPos({
-        top: rect.bottom + window.scrollY,
-        left: rect.left + window.scrollX,
-      });
-    }
-  };
+  const updatePopoverPosition = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || typeof window === 'undefined') return;
+
+    const triggerRect = container.getBoundingClientRect();
+    const panel = container.closest(LEFT_PANEL_SELECTOR);
+    const panelRect = panel?.getBoundingClientRect();
+    const popoverWidth = popoverRef.current?.offsetWidth ?? 0;
+    const popoverHeight = popoverRef.current?.offsetHeight ?? 0;
+    const maxLeft = window.innerWidth - popoverWidth - VIEWPORT_GAP;
+    const preferredLeft = panelRect
+      ? panelRect.right + PANEL_GAP
+      : triggerRect.right - popoverWidth;
+
+    setPopoverPos({
+      top: resolveFloatingTop({
+        mode: 'center',
+        floatingHeight: popoverHeight,
+        triggerRect,
+        containerRect: panelRect,
+        viewportGap: VIEWPORT_GAP,
+      }),
+      left: clampFloatingValue(preferredLeft, VIEWPORT_GAP, maxLeft),
+    });
+  }, []);
 
   const handleColorPickerToggle = () => {
     if (openFontColor) {
@@ -62,6 +92,7 @@ function FontColor() {
     } else {
       updatePopoverPosition();
       popoverRef.current?.showPopover();
+      window.requestAnimationFrame(updatePopoverPosition);
     }
   };
 
@@ -89,7 +120,33 @@ function FontColor() {
 
     el.addEventListener('toggle', handleToggleEvent);
     return () => el.removeEventListener('toggle', handleToggleEvent);
-  }, []);
+  }, [updatePopoverPosition]);
+
+  useEffect(() => {
+    if (!openFontColor) return;
+    if (typeof window === 'undefined') return;
+
+    updatePopoverPosition();
+    const animationFrameId = window.requestAnimationFrame(
+      updatePopoverPosition
+    );
+
+    window.addEventListener('resize', updatePopoverPosition);
+    window.addEventListener('scroll', updatePopoverPosition, true);
+
+    const resizeObserver = new ResizeObserver(updatePopoverPosition);
+    const panel = document.querySelector(LEFT_PANEL_SELECTOR);
+    if (containerRef.current) resizeObserver.observe(containerRef.current);
+    if (popoverRef.current) resizeObserver.observe(popoverRef.current);
+    if (panel) resizeObserver.observe(panel);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', updatePopoverPosition);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      resizeObserver.disconnect();
+    };
+  }, [openFontColor, updatePopoverPosition]);
 
   useEffect(() => {
     if (!activeObject) {
@@ -154,7 +211,7 @@ function FontColor() {
         popover="auto"
         className="z-9999 border-none p-0 m-0 fixed bg-transparent overflow-visible"
         style={{
-          top: `${popoverPos.top + 4}px`,
+          top: `${popoverPos.top}px`,
           left: `${popoverPos.left}px`,
           inset: 'auto',
           touchAction: 'none',


### PR DESCRIPTION
## 작업 개요

에디터 페이지의 팝업/스크롤 위치 안정화, 개인정보 모달 개선, 컬러픽커 동작 개선, 안내 문구 공통화 및 일부 UI 간격 조정을 진행했습니다.

## 작업 내용

- [x] 헤더 개인정보 문구 클릭 시 native dialog 기반 개인정보 모달 노출
- [x] 개인정보 모달 배경을 글래스모피즘에서 흰색 배경으로 변경
- [x] 텍스트 에디터/포스터 텍스트 컬러픽커 위치 계산 방식 개선
- [x] 컬러 히스토리 기본값 추가 및 등록 시점을 pointer 종료 시점으로 변경
- [x] 셀렉터 fixed 좌표 계산 안정화
- [x] 에디터 페이지 `w-screen`으로 인한 수평 overflow 후보 수정
- [x] 안내 문구 공통 컴포넌트 추가 및 주요 편집 컴포넌트에 적용
- [x] 안내 문구 불릿/줄바꿈/폰트 크기/굵기 스타일 정리
- [x] 포스터 사진 탭에 자르기 안내 문구 추가
- [x] 텍스트 에디터 정렬 버튼 간격을 4px로 조정
- [x] 순서 패널에서 포스터 클릭 시 프리뷰 상단으로 스크롤되도록 수정
- [x] 순서 패널 포스터 버튼에 cursor pointer 적용

## 관련 이슈

Closes #

## 테스트 결과 보고

- 관련 수정 파일 단위로 ESLint 확인 완료
- 일부 기존 컴포넌트에서 React Hook dependency warning이 있었으나, 이번 작업 범위와 무관하여 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 각 편집 섹션별 안내 메시지 추가
  * 컬러 피커 색상 이력 기본값 추가 및 포인터 이벤트 기반 저장 방식 개선
  * 프라이버시 공지 모달로 개선

* **Bug Fixes**
  * 에디터 레이아웃 너비 계산 개선
  * 플로팅 요소 위치 계산 및 뷰포트 경계 처리 개선

* **Style**
  * 버튼 간 간격 조정
  * 텍스트 색상 스타일 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bread-Barbershop/frontend/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->