### PR TITLE
[feat] 헤더 디자인 수정

### DIFF
--- a/app/editor/layout.tsx
+++ b/app/editor/layout.tsx
@@ -7,5 +7,5 @@ export default function EditorLayout({
 }: Readonly<{
   children: ReactNode;
 }>) {
-  return <DashboardShell>{children}</DashboardShell>;
+  return <DashboardShell variant="editor">{children}</DashboardShell>;
 }

--- a/features/session/components/DashboardShell.tsx
+++ b/features/session/components/DashboardShell.tsx
@@ -14,17 +14,26 @@ const HEADER_NAV_LINK_CLASS =
 
 export default async function DashboardShell({
   children,
+  variant = 'default',
 }: Readonly<{
   children: ReactNode;
+  variant?: 'default' | 'editor';
 }>) {
   const session = await getAuthSession();
+  const isEditor = variant === 'editor';
 
   return (
     <div
-      className="min-h-dvh grid grid-rows-[auto_1fr_auto] bg-center bg-cover bg-no-repeat"
-      style={{ backgroundImage: `url(${homeBackgroundImage.src})` }}
+      className={`min-h-dvh grid grid-rows-[auto_1fr_auto] ${
+        isEditor ? 'bg-[#E7E9EB]' : 'bg-center bg-cover bg-no-repeat'
+      }`}
+      style={
+        isEditor
+          ? undefined
+          : { backgroundImage: `url(${homeBackgroundImage.src})` }
+      }
     >
-      <header className="h-15.5 bg-white flex items-center justify-between px-10">
+      <header className="h-14 bg-transparent flex items-center justify-between px-10">
         <div className="flex h-full items-center gap-8">
           <HomeButton />
 

--- a/features/session/components/HeaderPrivacyNoticeButton.tsx
+++ b/features/session/components/HeaderPrivacyNoticeButton.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react';
 import PrivacyNoticeModal from './PrivacyNoticeModal';
 
 const HEADER_PRIVACY_BUTTON_CLASS =
-  'h-full px-2 flex items-center text-[16px] font-semibold text-[#121212] cursor-pointer';
+  'h-full px-2 flex items-center text-[14px] font-semibold text-[#121212] cursor-pointer';
 
 function HeaderPrivacyNoticeButton() {
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
## 작업 개요

헤더 스타일을 정리하고 에디터 페이지 배경색을 통일했습니다.

## 작업 내용

- [x] 헤더 높이 `56px` 적용
- [x] 헤더 배경 투명 처리
- [x] `개인정보 걱정 없어요.` 문구 크기 `14px` 적용
- [x] 에디터 헤더 부모 배경을 메인 색상(`#E7E9EB`)으로 통일

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx tsc --noEmit` 통과
- `npm run lint` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 에디터 페이지와 기본 페이지의 배경 및 레이아웃을 구분하여 각각에 맞게 적용했습니다.
  * 헤더 영역의 고정 높이와 투명 배경 스타일을 최적화했습니다.
  * 프라이버시 알림 버튼의 텍스트 크기를 조정하여 시각적 균형을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->