### PR TITLE
[fix] 저장 및 재편집 실패 에러 수정

### DIFF
--- a/app/api/drive/_lib/ensureThumbnailFile.ts
+++ b/app/api/drive/_lib/ensureThumbnailFile.ts
@@ -63,7 +63,7 @@ export async function ensureThumbnailFile(
 
   if (!searchRes.ok) {
     throw new DriveHttpError(
-      'invitation-thumbnail.json search failed',
+      'invitation-thumbnail.png search failed',
       searchRes.status,
       searchData
     );

--- a/app/api/drive/thumbnail/route.ts
+++ b/app/api/drive/thumbnail/route.ts
@@ -11,7 +11,7 @@ import {
 } from '@/app/api/drive/_lib/ensureThumbnailFile';
 import { DriveHttpError } from '@/app/api/drive/_lib/ensureWorkspace';
 import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
-import { publishPermissionWithRetry } from '@/app/api/drive/_lib/publishPermissionWithRetry';
+// import { publishPermissionWithRetry } from '@/app/api/drive/_lib/publishPermissionWithRetry';
 
 /**
  * POST: 초대장 썸네일 데이터를 invitation-thumbnail.png에 저장합니다.
@@ -51,8 +51,8 @@ export async function POST(req: Request) {
       await deleteThumbnailFile(thumbnailFileId);
     }
 
-    // 3) 공개 권한 설정
-    await publishPermissionWithRetry(finalFileId);
+    // // 3) 공개 권한 설정
+    // await publishPermissionWithRetry(finalFileId);
 
     const publicUrl = `https://drive.google.com/uc?export=download&id=${finalFileId}`;
 

--- a/app/api/drive/updateInvitation/route.ts
+++ b/app/api/drive/updateInvitation/route.ts
@@ -87,7 +87,7 @@ export async function GET(
       }
 
       // // 2. JSON 파일인 경우: 설정값(Config)으로 파싱해서 저장
-      else if (file.mimeType?.includes('json')) {
+      else if (file.mimeType?.includes('json') && file.name?.toLowerCase() === 'data.json') {
         const fileContent = await downloadFiles(file.id!);
         // 데이터 호환성 처리 (block vs blocks)
         if (fileContent) {

--- a/app/dashboard/components/carousel/item/CarouselItem.tsx
+++ b/app/dashboard/components/carousel/item/CarouselItem.tsx
@@ -188,6 +188,7 @@ function CarouselItem({
               alt={item.alt}
               fill
               sizes="260px"
+              unoptimized
               draggable={false}
               className="object-cover"
             />

--- a/app/editor/[id]/hooks/useInitData.ts
+++ b/app/editor/[id]/hooks/useInitData.ts
@@ -90,6 +90,14 @@ export const useInitData = ({
     }
     if (shareUrl) {
       setShareUrl(shareUrl);
+      const shareFiles = [
+        ...(shareUrl.images ?? []),
+        ...(shareUrl.urlImage ?? []),
+      ].filter((f): f is File => f instanceof File);
+
+      if (shareFiles.length > 0) {
+        updateImage('shareUrl', shareFiles);
+      }
     }
     selectedBlock('mainPoster');
   }, [

--- a/app/editor/[id]/hooks/useSavedData.ts
+++ b/app/editor/[id]/hooks/useSavedData.ts
@@ -25,6 +25,18 @@ const normalizePersistedBlocks = (blocks: unknown): PersistedEditorBlock[] => {
   );
 };
 
+const setAudioFile = async (
+  audioFile: { id: string; name: string; mimeType: string }[] | null,
+  signal: AbortSignal
+) => {
+  if (audioFile && audioFile.length > 0) {
+    const audioFiles = await fetchAudioFiles(audioFile, signal);
+    return audioFiles.length > 0 ? audioFiles[0].file : null;
+  } else {
+    return null;
+  }
+};
+
 export const useSavedData = (folderId: string): UseSavedDataReturn => {
   const [savedData, setSavedData] = useState<SavedData | null>(null);
   const [loading, setLoading] = useState(false);
@@ -33,51 +45,6 @@ export const useSavedData = (folderId: string): UseSavedDataReturn => {
   // 이전 요청 취소용
   const abortRef = useRef<AbortController | null>(null);
 
-  const setImageFile = async (
-    blocks: PersistedEditorBlock[],
-    imageFile: { id: string; name: string; mimeType: string }[] | null,
-    signal: AbortSignal
-  ) => {
-    if (!imageFile || imageFile.length === 0) return blocks;
-
-    const imageFiles = await fetchImageFiles(imageFile, signal);
-    const idToFileMap = new Map<string, File>();
-    imageFiles.forEach(item => idToFileMap.set(item.id, item.file));
-
-    const mapIdsToFiles = (obj: unknown): unknown => {
-      if (typeof obj === 'string') {
-        return idToFileMap.get(obj) || obj;
-      }
-      if (Array.isArray(obj)) {
-        return obj.map(mapIdsToFiles);
-      }
-      if (obj !== null && typeof obj === 'object') {
-        const newObj: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(obj)) {
-          newObj[key] = mapIdsToFiles(value);
-        }
-        return newObj;
-      }
-      return obj;
-    };
-
-    return blocks.map(block => ({
-      ...block,
-      props: mapIdsToFiles(block.props) as typeof block.props,
-    }));
-  };
-
-  const setAudioFile = async (
-    audioFile: { id: string; name: string; mimeType: string }[],
-    signal: AbortSignal
-  ) => {
-    if (audioFile && audioFile.length > 0) {
-      const audioFiles = await fetchAudioFiles(audioFile, signal);
-      return audioFiles.length > 0 ? audioFiles[0].file : null;
-    } else {
-      return null;
-    }
-  };
   useEffect(() => {
     if (!folderId) return;
 
@@ -116,11 +83,39 @@ export const useSavedData = (folderId: string): UseSavedDataReturn => {
           bodyData: BODY_BULK_DATA,
           isZoom: false,
         };
-        const updatedBlocksWithImages = await setImageFile(
-          updatedBlocks,
-          data.images.files ?? null,
-          controller.signal
-        );
+
+        // 이미지 파일 다운로드 및 ID -> File 객체 맵핑 생성
+        const imageFiles = data.images.files && data.images.files.length > 0
+          ? await fetchImageFiles(data.images.files, controller.signal)
+          : [];
+        const idToFileMap = new Map<string, File>();
+        imageFiles.forEach(item => idToFileMap.set(item.id, item.file));
+
+        const mapIdsToFiles = (obj: unknown): unknown => {
+          if (typeof obj === 'string') {
+            return idToFileMap.get(obj) || obj;
+          }
+          if (Array.isArray(obj)) {
+            return obj.map(mapIdsToFiles);
+          }
+          if (obj !== null && typeof obj === 'object') {
+            const newObj: Record<string, unknown> = {};
+            for (const [key, value] of Object.entries(obj)) {
+              newObj[key] = mapIdsToFiles(value);
+            }
+            return newObj;
+          }
+          return obj;
+        };
+
+        const updatedBlocksWithImages = updatedBlocks.map(block => ({
+          ...block,
+          props: mapIdsToFiles(block.props) as typeof block.props,
+        }));
+
+        const updatedShareUrl = data.config.shareUrl
+          ? (mapIdsToFiles(data.config.shareUrl) as typeof data.config.shareUrl)
+          : createDefaultShareUrlState();
 
         const audioFiles = await setAudioFile(
           data.audios.files ?? null,
@@ -134,7 +129,7 @@ export const useSavedData = (folderId: string): UseSavedDataReturn => {
             bgmInfo: data.config.bgm,
             bgmFile: audioFiles,
           },
-          shareUrl: data.config.shareUrl ?? createDefaultShareUrlState(),
+          shareUrl: updatedShareUrl,
           imageFolderId: data.imageFolderId,
           audioFolderId: data.audioFolderId,
           invitationImage: data.config.invitationImage,

--- a/widgets/editor/preview/hooks/useInvitationUpload.ts
+++ b/widgets/editor/preview/hooks/useInvitationUpload.ts
@@ -56,9 +56,18 @@ export const useInvitationUpload = () => {
     try {
       setIsLoading(true);
       setIsFail(false);
-      const task = editorData.images.flatMap(item =>
-        item.file.map(file => ({ id: item.id, file }))
-      );
+      const task = editorData.images.flatMap(item => {
+        const fileData = item.file as unknown;
+        if (Array.isArray(fileData)) {
+          return fileData
+            .filter((file): file is File => file instanceof File)
+            .map(file => ({ id: item.id, file }));
+        }
+        if (fileData instanceof File) {
+          return [{ id: item.id, file: fileData }];
+        }
+        return [];
+      });
 
       const bgmData = {
         selectedBgmId: selectedBgmId ?? null,


### PR DESCRIPTION
## 작업 개요
저장 및 재편집 실패 에러 수정


## 작업 내용
- 포스터 재편집시 썸네일 저장 오류 : json 파일 범위를 좁혀 불필요한 json 탐색 방지
- 포스터 썸네일 업로드시 권한 로직 삭제
- 대시보드 썸네일 로드시 개발단의 무한루프 오류 해결
- 공유썸네일 재편집시 파일아이디만 불러와져 이미지가 깨지는 현상 수정 및  이미지 스토어에 등록
- 단일 파일객체 저장시 발생하는 타입에러 수정
