### PR TITLE
feat: 컴포넌트 프리뷰 스타일 및 에디터 UI 폴리싱

### DIFF
--- a/components/organisms/account/Account.tsx
+++ b/components/organisms/account/Account.tsx
@@ -11,6 +11,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { Popup } from '../popup/Popup';
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
@@ -129,7 +130,10 @@ export const Account = ({ blockInfo, id }: Props) => {
             placeholder: 'ACCOUNT',
             value: englishTitle === 'ACCOUNT' ? '' : englishTitle,
             onChange: e =>
-              handleUpdateBlock('englishTitle', e.target.value || 'ACCOUNT'),
+              handleUpdateBlock(
+                'englishTitle',
+                sanitizeEnglishTitleInput(e.target) || 'ACCOUNT'
+              ),
           }}
           className="text-center w-full pt-3"
         />

--- a/components/organisms/calendar/Calendar.tsx
+++ b/components/organisms/calendar/Calendar.tsx
@@ -14,6 +14,7 @@ import { TextField } from '@/components/molecules/text-field';
 import { TimeSelector } from '@/components/molecules/time-selector';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -91,8 +92,8 @@ export function Calendar({ blockInfo, id }: Props) {
     [id, updateBlock]
   );
   const handleEnglishTitleChange = useCallback(
-    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-      updateBlock(id, { englishTitle: value });
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      updateBlock(id, { englishTitle: sanitizeEnglishTitleInput(target) });
     },
     [id, updateBlock]
   );

--- a/components/organisms/calendar/CalendarPreview.tsx
+++ b/components/organisms/calendar/CalendarPreview.tsx
@@ -3,6 +3,7 @@
 import { PreviewTitle } from '@/components/atoms/preview-title/PreviewTitle';
 import { tiptapJsonToHtmlUniversal } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
 import LoadingSpinner from '@/shared/assets/icons/loadingSpinner.svg';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import { EditorBlock } from '@/shared/types/block';
 import { cn } from '@/shared/utils/cn';
 
@@ -52,6 +53,7 @@ export function CalendarPreview({
   } = useCalendarData({ date, time, language, template });
 
   const isDateIncomplete = !date || date.length < 10;
+  const bodyFontFamily = useBodyFontFamily();
 
   const TemplateComponent =
     CalendarTemplates[template as string] || CalendarTemplates['calendarType1'];
@@ -78,7 +80,10 @@ export function CalendarPreview({
 
       {/* String Date Display */}
       {showStringDate && (
-        <div className="flex flex-col items-center tracking-[-0.01rem] leading-[1.2] text-base font-normal text-text-primary min-h-[40px] justify-center">
+        <div
+          className="flex flex-col items-center tracking-[-0.01rem] leading-[1.2] text-base font-normal text-text-primary min-h-[40px] justify-center"
+          style={{ fontFamily: bodyFontFamily }}
+        >
           {isDateIncomplete ? (
             <div className="flex items-center gap-2">
               <LoadingSpinner className="w-5 h-5 animate-spin text-gray-300" />

--- a/components/organisms/couple-introduction/CoupleIntroduction.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroduction.tsx
@@ -11,6 +11,7 @@ import { TextField } from '@/components/molecules/text-field';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import type { JSONContent } from '@tiptap/core';
 
@@ -96,7 +97,7 @@ function CoupleIntroduction({ blockInfo, id }: Props) {
   };
 
   const handleEnglishTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const nextEnglishTitle = e.target.value;
+    const nextEnglishTitle = sanitizeEnglishTitleInput(e.target);
     updateBlock(id, {
       englishTitle:
         nextEnglishTitle || DEFAULT_COUPLE_INTRODUCTION_ENGLISH_TITLE,

--- a/components/organisms/gallery/Gallery.tsx
+++ b/components/organisms/gallery/Gallery.tsx
@@ -11,6 +11,7 @@ import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrap
 import { useToast } from '@/shared/hooks/useToast';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { ASPECT_RATIO_OPTIONS } from './constants/AspectRatio';
 
@@ -38,7 +39,9 @@ function Gallery({ blockInfo, id }: Props) {
     updateBlock(id, { title: e.target.value || '갤러리' });
   };
   const handleOnChangeEngTitle = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { enTitle: e.target.value || 'GALLERY' });
+    updateBlock(id, {
+      enTitle: sanitizeEnglishTitleInput(e.target) || 'GALLERY',
+    });
   };
 
   const handlePictureChange = (file: (File | string)[]) => {

--- a/components/organisms/greeting/Greeting.tsx
+++ b/components/organisms/greeting/Greeting.tsx
@@ -9,6 +9,7 @@ import { TextField } from '@/components/molecules/text-field';
 import { LeftEditorWrapper } from '@/components/organisms/wrapper/LeftEditorWrapper';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import type { JSONContent } from '@tiptap/react';
 
@@ -46,7 +47,7 @@ function Greeting({ blockInfo, id }: Props) {
   };
 
   const handleEnglishTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const nextEnglishTitle = e.target.value;
+    const nextEnglishTitle = sanitizeEnglishTitleInput(e.target);
     updateBlock(id, {
       englishTitle: nextEnglishTitle || DEFAULT_GREETING_ENGLISH_TITLE,
     });

--- a/components/organisms/interview/Interview.tsx
+++ b/components/organisms/interview/Interview.tsx
@@ -12,6 +12,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import type { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import PopupOptions from '../popup/PopupOptions';
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
@@ -158,7 +159,10 @@ export const Interview = ({ blockInfo, id }: Props) => {
             placeholder: 'INTERVIEW',
             value: englishTitle === 'INTERVIEW' ? '' : englishTitle,
             onChange: e =>
-              handleUpdateBlock('englishTitle', e.target.value || 'INTERVIEW'),
+              handleUpdateBlock(
+                'englishTitle',
+                sanitizeEnglishTitleInput(e.target) || 'INTERVIEW'
+              ),
           }}
           className="w-full py-1.5 text-center"
         />

--- a/components/organisms/interview/InterviewPreviewItem.tsx
+++ b/components/organisms/interview/InterviewPreviewItem.tsx
@@ -1,5 +1,6 @@
 import { Image } from '@/components/atoms/image';
 import { previewTextClassName } from '@/components/molecules/text-editor/utils/previewTextClassName';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import { useResolvedImageSource } from '@/shared/hooks/useResolvedImageSource';
 import { cn } from '@/shared/utils/cn';
 
@@ -24,6 +25,7 @@ export const InterviewPreviewItem = ({
 }) => {
   const customPreview = useResolvedImageSource(image?.[0]);
   const preview = customPreview ?? defaultImage;
+  const bodyFontFamily = useBodyFontFamily();
   const hasAnswer =
     answerHtml
       .replace(/<[^>]*>/g, '')
@@ -52,7 +54,10 @@ export const InterviewPreviewItem = ({
           />
         </div>
       )}
-      <p className="text-sm text-center font-semibold select-text">
+      <p
+        className="text-sm text-center font-semibold select-text"
+        style={{ fontFamily: bodyFontFamily }}
+      >
         {question}
       </p>
       <div

--- a/components/organisms/myChild/MyChild.tsx
+++ b/components/organisms/myChild/MyChild.tsx
@@ -12,6 +12,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -44,7 +45,9 @@ export const MyChild = ({ blockInfo, id }: Props) => {
   ) => {
     updateBlock(id, {
       [type]:
-        type === 'englishTitle' ? e.target.value || 'MY CHILD' : e.target.value,
+        type === 'englishTitle'
+          ? sanitizeEnglishTitleInput(e.target) || 'MY CHILD'
+          : e.target.value,
     });
   };
 

--- a/components/organisms/myFamily/MemberPreview.tsx
+++ b/components/organisms/myFamily/MemberPreview.tsx
@@ -2,6 +2,8 @@ import { Image } from '@/components/atoms/image';
 import Flower from '@/shared/assets/icons/flower.svg';
 import { useResolvedImageSource } from '@/shared/hooks/useResolvedImageSource';
 
+import type { CSSProperties } from 'react';
+
 interface Props {
   member: {
     relation: string;
@@ -9,9 +11,10 @@ interface Props {
     image: (File | string)[];
     flower: boolean;
   };
+  fontFamily?: CSSProperties['fontFamily'];
 }
 
-export const MemberPreview = ({ member }: Props) => {
+export const MemberPreview = ({ member, fontFamily }: Props) => {
   const { image, relation, name, flower } = member;
   const preview = useResolvedImageSource(
     image && image.length > 0 ? image[0] : null
@@ -23,7 +26,10 @@ export const MemberPreview = ({ member }: Props) => {
           <Image src={preview} alt="가족 사진" fill className="object-cover" />
         </div>
       )}
-      <p className="flex items-center gap-1 text-[16px] font-semibold text-center">
+      <p
+        className="flex items-center gap-1 text-[16px] font-semibold text-center"
+        style={{ fontFamily }}
+      >
         {relation} {flower ? <Flower /> : ''} {name}
       </p>
     </>

--- a/components/organisms/myFamily/MyFamily.tsx
+++ b/components/organisms/myFamily/MyFamily.tsx
@@ -11,6 +11,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field/TextField';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -46,7 +47,9 @@ export const MyFamily = ({ blockInfo, id }: Props) => {
   };
 
   const handleEnglishTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { englishTitle: e.target.value || 'MY FAMILY' });
+    updateBlock(id, {
+      englishTitle: sanitizeEnglishTitleInput(e.target) || 'MY FAMILY',
+    });
   };
 
   const handleRelationChange = (index: number, value: string) => {

--- a/components/organisms/myFamily/MyFamilyPreview.tsx
+++ b/components/organisms/myFamily/MyFamilyPreview.tsx
@@ -1,5 +1,6 @@
 import { previewTextClassName } from '@/components/molecules/text-editor/utils/previewTextClassName';
 import { tiptapJsonToHtmlUniversal } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import type { EditorBlock } from '@/shared/types/block';
 
 import { MiddlePreviewWrapper } from '../wrapper/MiddlePreviewWrapper';
@@ -28,6 +29,7 @@ export const MyFamilyPreview = ({
   } = blockInfo.props;
   const html =
     messageHtml ?? tiptapJsonToHtmlUniversal(messageJson ?? undefined);
+  const bodyFontFamily = useBodyFontFamily();
 
   return (
     <MiddlePreviewWrapper
@@ -47,12 +49,13 @@ export const MyFamilyPreview = ({
             key={index}
             className="flex flex-col items-center gap-4.5 w-[calc(50%-9px)] max-w-[158.5px]"
           >
-            <MemberPreview member={member} />
+            <MemberPreview member={member} fontFamily={bodyFontFamily} />
           </div>
         ))}
       </div>
       <div
         className={`text-sm ${previewTextClassName}`}
+        style={{ fontFamily: bodyFontFamily }}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </MiddlePreviewWrapper>

--- a/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
+++ b/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
@@ -1,4 +1,5 @@
 import Flower from '@/shared/assets/icons/flower.svg';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import type { EditorBlock } from '@/shared/types/block';
 
 import { MiddlePreviewWrapper } from '../wrapper/MiddlePreviewWrapper';
@@ -16,6 +17,7 @@ export const MyFamilyWeddingPreview = ({
   ...rest
 }: Props) => {
   const { brideFamily, groomFamily } = blockInfo.props;
+  const bodyFontFamily = useBodyFontFamily();
 
   return (
     <MiddlePreviewWrapper
@@ -26,7 +28,10 @@ export const MyFamilyWeddingPreview = ({
       childClassName="w-full flex flex-col gap-1"
       {...rest}
     >
-      <div className="flex flex-row items-center gap-1">
+      <div
+        className="flex flex-row items-center gap-1"
+        style={{ fontFamily: bodyFontFamily }}
+      >
         {brideFamily?.map((member, index) => (
           <p key={index} className="flex items-center">
             {brideFamily.length > 1 && index !== 0 && '•'}
@@ -36,7 +41,10 @@ export const MyFamilyWeddingPreview = ({
         ))}
         <span>의 딸</span>
       </div>
-      <div className="flex flex-row items-center gap-1">
+      <div
+        className="flex flex-row items-center gap-1"
+        style={{ fontFamily: bodyFontFamily }}
+      >
         {groomFamily?.map((member, index) => (
           <p key={index} className="flex items-center">
             {groomFamily.length > 1 && index !== 0 && '•'}

--- a/components/organisms/notice/Notice.tsx
+++ b/components/organisms/notice/Notice.tsx
@@ -11,6 +11,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import type { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import PopupOptions from '../popup/PopupOptions';
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
@@ -160,7 +161,7 @@ export const Notice = ({ blockInfo, id }: Props) => {
             onChange: e =>
               handleUpdateBlock(
                 'englishTitle',
-                e.target.value || 'INFORMATION'
+                sanitizeEnglishTitleInput(e.target) || 'INFORMATION'
               ),
           }}
           className="w-full py-1.5 text-center"

--- a/components/organisms/notice/NoticePreviewItem.tsx
+++ b/components/organisms/notice/NoticePreviewItem.tsx
@@ -1,6 +1,7 @@
 import { Image } from '@/components/atoms/image';
 import { previewTextClassName } from '@/components/molecules/text-editor/utils/previewTextClassName';
 import { tiptapJsonToHtmlUniversal } from '@/components/molecules/text-editor/utils/tiptapJsonToHtml';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import { useResolvedImageSource } from '@/shared/hooks/useResolvedImageSource';
 import { cn } from '@/shared/utils/cn';
 
@@ -21,6 +22,7 @@ export const NoticePreviewItem = ({
     tiptapJsonToHtmlUniversal(notice.content.messageJson);
   const customPreview = useResolvedImageSource(notice.image?.[0]);
   const preview = customPreview ?? defaultImage;
+  const bodyFontFamily = useBodyFontFamily();
 
   return (
     <div className={cn('flex flex-col gap-6 overflow-hidden', className)}>
@@ -36,7 +38,10 @@ export const NoticePreviewItem = ({
         </div>
       )}
       <div className="flex flex-col gap-6">
-        <p className="text-sm text-center font-semibold select-none">
+        <p
+          className="text-sm text-center font-semibold select-none"
+          style={{ fontFamily: bodyFontFamily }}
+        >
           {notice.notice}
         </p>
         <div

--- a/components/organisms/organizerInfo/OrganizerInformation.tsx
+++ b/components/organisms/organizerInfo/OrganizerInformation.tsx
@@ -11,6 +11,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import type { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -87,7 +88,8 @@ export const OrganizerInformation = ({ blockInfo, id }: Props) => {
               handleValueChange(
                 'englishTitle',
                 undefined,
-                e.target.value || 'ORGANIZER INFORMATION'
+                sanitizeEnglishTitleInput(e.target) ||
+                  'ORGANIZER INFORMATION'
               ),
           }}
           className="text-center w-full"

--- a/components/organisms/picture/PictureBlock.tsx
+++ b/components/organisms/picture/PictureBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { JSONContent } from '@tiptap/core';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useEffect } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import { Label } from '@/components/atoms/label';
@@ -12,8 +12,11 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
+
+const DEFAULT_ENGLISH_TITLE = 'PICTURE';
 
 interface Props {
   blockInfo: EditorBlock<'picture'>;
@@ -21,12 +24,20 @@ interface Props {
 }
 
 function PictureBlock({ blockInfo, id }: Props) {
+  const englishTitle = blockInfo.props.enTitle || DEFAULT_ENGLISH_TITLE;
   const { updateBlock, updateImage } = useEditorStore(
     useShallow(state => ({
       updateBlock: state.updateBlock,
       updateImage: state.updateImage,
     }))
   );
+
+  useEffect(() => {
+    if (!blockInfo.props.enTitle) {
+      updateBlock(id, { enTitle: DEFAULT_ENGLISH_TITLE });
+    }
+  }, [blockInfo.props.enTitle, id, updateBlock]);
+
   const handlePictureChange = (file: (File | string)[]) => {
     updateBlock(id, { image: file });
     updateImage(id, file);
@@ -37,7 +48,8 @@ function PictureBlock({ blockInfo, id }: Props) {
   };
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { isTitle: e.target.checked });
+    const checked = e.target.checked;
+    updateBlock(id, { isTitle: checked, isEnglishTitle: checked });
   };
   const handleEngTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     updateBlock(id, { isEnglishTitle: e.target.checked });
@@ -50,7 +62,9 @@ function PictureBlock({ blockInfo, id }: Props) {
     updateBlock(id, { title: e.target.value || '사진' });
   };
   const handleOnChangeEngTitle = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { enTitle: e.target.value || 'PICTURE' });
+    updateBlock(id, {
+      enTitle: sanitizeEnglishTitleInput(e.target) || DEFAULT_ENGLISH_TITLE,
+    });
   };
   const handleEditorChange = (json: JSONContent) => {
     updateBlock(id, {
@@ -83,7 +97,7 @@ function PictureBlock({ blockInfo, id }: Props) {
             }}
           />
         )}
-        {blockInfo.props.isEnglishTitle && (
+        {blockInfo.props.isTitle && blockInfo.props.isEnglishTitle && (
           <TextField
             label="영문 제목"
             className="py-1.5 text-center"
@@ -91,9 +105,9 @@ function PictureBlock({ blockInfo, id }: Props) {
               placeholder: 'PICTURE',
               onChange: e => handleOnChangeEngTitle(e),
               value:
-                blockInfo.props.enTitle === 'PICTURE'
+                englishTitle === DEFAULT_ENGLISH_TITLE
                   ? ''
-                  : blockInfo.props.enTitle,
+                  : englishTitle,
             }}
           />
         )}
@@ -118,6 +132,7 @@ function PictureBlock({ blockInfo, id }: Props) {
               제목 추가
             </Checkbox>
             <Checkbox
+              className={!blockInfo.props.isTitle ? 'hidden' : undefined}
               checked={blockInfo.props.isEnglishTitle}
               onChange={handleEngTitleChange}
             >

--- a/components/organisms/picture/PictureBlockPreview.tsx
+++ b/components/organisms/picture/PictureBlockPreview.tsx
@@ -47,12 +47,12 @@ function PictureBlockPreview({ blockInfo, className, ...rest }: Props) {
           )}
         </div>
         {!preview && (
-          <div className="w-full aspect-square flex-center bg-border-neutral">
+          <div className="w-full aspect-square flex-center bg-border-neutral rounded-3xl">
             <p className="text-text-secondary text-sm">사진을 추가해주세요.</p>
           </div>
         )}
         {preview && (
-          <div className="relative w-full aspect-square">
+          <div className="relative w-full aspect-square rounded-3xl overflow-hidden">
             <Image
               src={preview}
               alt="사진 컴포넌트 이미지"

--- a/components/organisms/place/Place.tsx
+++ b/components/organisms/place/Place.tsx
@@ -21,6 +21,7 @@ import {
   getDefaultPlaceTitle,
   isDefaultPlaceTitle,
 } from '@/shared/utils/placeTitle';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { Popup } from '../popup/Popup';
 
@@ -110,7 +111,10 @@ export function Place({ blockInfo, id }: Props) {
               placeholder: 'LOCATION',
               value: englishTitle === 'LOCATION' ? '' : englishTitle,
               onChange: e =>
-                handleUpdateBlock('englishTitle', e.target.value || 'LOCATION'),
+                handleUpdateBlock(
+                  'englishTitle',
+                  sanitizeEnglishTitleInput(e.target) || 'LOCATION'
+                ),
             }}
             className="w-full py-1.5 text-center"
           />

--- a/components/organisms/place/PlacePreview.tsx
+++ b/components/organisms/place/PlacePreview.tsx
@@ -3,6 +3,7 @@
 import { HTMLAttributes, useState } from 'react';
 
 import { MiddlePreviewWrapper } from '@/components/organisms/wrapper/MiddlePreviewWrapper';
+import { useBodyFontFamily } from '@/shared/hooks/useBodyFontFamily';
 import type { EditorBlock } from '@/shared/types/block';
 import { formatPhoneNumber } from '@/shared/utils/phoneNumber';
 import {
@@ -38,6 +39,7 @@ export const PlacePreview = ({
     mapLocked,
   } = blockInfo.props;
   const defaultTitle = getDefaultPlaceTitle(blockInfo.type);
+  const bodyFontFamily = useBodyFontFamily();
 
   return (
     <MiddlePreviewWrapper
@@ -52,11 +54,14 @@ export const PlacePreview = ({
       {...rest}
     >
       <NaverMapScript onReady={() => setIsScriptLoaded(true)} />
-      <section className="flex flex-col justify-center items-center text-text-primary">
-        <p className="font-semibold text-[16px]">
+      <section
+        className="flex flex-col justify-center items-center text-text-primary"
+        style={{ fontFamily: bodyFontFamily }}
+      >
+        <p className="font-normal text-[16px]">
           {placeName} {placeDetail}
         </p>
-        <p className="font-semibold text-sm">{placeAddress}</p>
+        <p className="font-normal text-[16px]">{placeAddress}</p>
       </section>
       <p className="font-normal text-text-tertiary">
         TEL. {formatPhoneNumber(placeTel)}

--- a/components/organisms/speakerInformation/SpeakerInformation.tsx
+++ b/components/organisms/speakerInformation/SpeakerInformation.tsx
@@ -12,6 +12,7 @@ import { tiptapJsonToHtmlInBrowser } from '@/components/molecules/text-editor/ut
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -62,7 +63,12 @@ export const SpeakerInformation = ({ blockInfo, id }: Props) => {
     e: ChangeEvent<HTMLInputElement>
   ) => {
     const fallback = key === 'title' ? '연사정보' : 'SPEAKER INFORMATION';
-    updateBlock(id, { [key]: e.target.value || fallback });
+    const value =
+      key === 'englishTitle'
+        ? sanitizeEnglishTitleInput(e.target)
+        : e.target.value;
+
+    updateBlock(id, { [key]: value || fallback });
   };
 
   const handleCheckedChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/components/organisms/sponsorshipInfomation/SposorshipInfomation.tsx
+++ b/components/organisms/sponsorshipInfomation/SposorshipInfomation.tsx
@@ -8,6 +8,7 @@ import { Picture } from '@/components/molecules/picture';
 import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -48,7 +49,9 @@ function SponsorshipInfomation({ blockInfo, id }: Props) {
   };
 
   const handleOnchangeEnglishTitle = (e: ChangeEvent<HTMLInputElement>) => {
-    updateBlock(id, { englishTitle: e.target.value || 'OUR SPONSORS' });
+    updateBlock(id, {
+      englishTitle: sanitizeEnglishTitleInput(e.target) || 'OUR SPONSORS',
+    });
   };
   return (
     <LeftEditorWrapper ariaLabel="후원 정보">

--- a/components/organisms/video/Video.tsx
+++ b/components/organisms/video/Video.tsx
@@ -9,6 +9,7 @@ import { TextField } from '@/components/molecules/text-field';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { EditorBlock } from '@/shared/types/block';
 import { cn } from '@/shared/utils/cn';
+import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
 
 import { LeftEditorWrapper } from '../wrapper/LeftEditorWrapper';
 
@@ -58,7 +59,10 @@ export const Video = ({ blockInfo, id }: Props) => {
             placeholder: 'VIDEO',
             value: englishTitle === 'VIDEO' ? '' : englishTitle,
             onChange: e =>
-              handleUpdateBlock('englishTitle', e.target.value || 'VIDEO'),
+              handleUpdateBlock(
+                'englishTitle',
+                sanitizeEnglishTitleInput(e.target) || 'VIDEO'
+              ),
           }}
           className="w-full py-1.5 text-center"
         />

--- a/shared/hooks/useBodyFontFamily.ts
+++ b/shared/hooks/useBodyFontFamily.ts
@@ -1,0 +1,7 @@
+'use client';
+
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+import { toStyle } from '@/shared/utils/toStyle';
+
+export const useBodyFontFamily = () =>
+  useEditorStore(state => toStyle(state.bodyData, false).fontFamily);

--- a/shared/utils/stringUtils.ts
+++ b/shared/utils/stringUtils.ts
@@ -3,3 +3,16 @@ export const parseValue = (data: string, target: string, replace: string) => {
   const n = Number(cleaned);
   return Number.isFinite(n) ? n : null;
 };
+
+export const sanitizeEnglishTitle = (value: string) =>
+  value.replace(/[^A-Za-z ]/g, '');
+
+export const sanitizeEnglishTitleInput = (target: HTMLInputElement) => {
+  const sanitizedValue = sanitizeEnglishTitle(target.value);
+
+  if (target.value !== sanitizedValue) {
+    target.value = sanitizedValue;
+  }
+
+  return sanitizedValue;
+};

--- a/shared/utils/stringUtils.ts
+++ b/shared/utils/stringUtils.ts
@@ -14,5 +14,5 @@ export const sanitizeEnglishTitleInput = (target: HTMLInputElement) => {
     target.value = sanitizedValue;
   }
 
-  return sanitizedValue;
+  return sanitizedValue.trim();
 };

--- a/widgets/editor/preview/components/ComponentsPopup.tsx
+++ b/widgets/editor/preview/components/ComponentsPopup.tsx
@@ -2,6 +2,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { DESKTOP_CONTENT_MIN_WIDTH } from '@/shared/config/layout';
+
 import ContentsArea from './ContentsArea';
 import TabArea from './TabArea';
 
@@ -15,6 +17,20 @@ function ComponentsPopup({ onPopClose }: Props) {
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isManualScrolling = useRef(false);
+
+  useEffect(() => {
+    const closeIfViewportGuardActive = () => {
+      if (window.innerWidth < DESKTOP_CONTENT_MIN_WIDTH) {
+        onPopClose();
+      }
+    };
+
+    closeIfViewportGuardActive();
+    window.addEventListener('resize', closeIfViewportGuardActive);
+
+    return () =>
+      window.removeEventListener('resize', closeIfViewportGuardActive);
+  }, [onPopClose]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;

--- a/widgets/editor/preview/components/ComponentsPopup.tsx
+++ b/widgets/editor/preview/components/ComponentsPopup.tsx
@@ -60,9 +60,12 @@ function ComponentsPopup({ onPopClose }: Props) {
   };
 
   return createPortal(
-    <>
-      <div className="fixed inset-0 z-4" onClick={onPopClose} />
-      <div className="fixed z-50 bottom-12 left-1/2 -translate-x-1/2 w-164 h-99.5 shadow-edit bg-white rounded-md flex flex-col gap-3">
+    <div className="fixed inset-0 z-[90] pointer-events-none">
+      <div
+        className="absolute inset-0 pointer-events-auto"
+        onClick={onPopClose}
+      />
+      <div className="absolute bottom-12 left-1/2 -translate-x-1/2 w-164 h-99.5 shadow-edit bg-white rounded-md flex flex-col gap-3 pointer-events-auto">
         <div>
           <TabArea
             active={active}
@@ -75,7 +78,7 @@ function ComponentsPopup({ onPopClose }: Props) {
           sectionRefs={sectionRefs}
         />
       </div>
-    </>,
+    </div>,
     document.body
   );
 }

--- a/widgets/editor/preview/components/ContentsArea.tsx
+++ b/widgets/editor/preview/components/ContentsArea.tsx
@@ -64,7 +64,7 @@ function ContentsArea({ scrollContainerRef, sectionRefs }: Props) {
               모두 추가하기
             </UtilityButton>
           </div>
-          <div className="min-h-34">
+          <div>
             <ul className="grid grid-cols-5 gap-x-7 gap-y-0.5 ">
               {items.list.map((item, index) => (
                 <li


### PR DESCRIPTION
## 작업 개요

컴포넌트 프리뷰의 스타일 일관성을 개선 진행했습니다.  
영문 제목 입력 정책, 본문 폰트 적용 범위, 사진 프리뷰 라운딩, 에디터 가드 및 페이지 추가 팝업 동작을 함께 정리했습니다.

## 작업 내용

- [x] 영문 제목 필드에 영문 입력 필터 적용
- [x] 사진 컴포넌트 영문 제목 노출 조건 및 기본값 처리 개선
- [x] 사진 프리뷰 이미지 영역 라운딩 적용
- [x] 행사장소, 행사일시, 인터뷰/공지사항 항목 제목, 가족 소개 프리뷰에 일괄편집 본문 폰트 적용
- [x] 행사장소 프리뷰의 장소명/주소/층·홀 텍스트 스타일을 16px regular로 정리
- [x] EditorViewportGuard 활성화 시 페이지 추가 팝업이 남아 보이지 않도록 처리
- [x] 페이지 추가 팝업의 카테고리 간격 불균형 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npm run lint` 통과
- `npm run build` 통과
- 기존 lint warning은 유지됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 본문 폰트 설정이 미리보기 영역 전반에 일관되게 적용되도록 개선

* **개선 사항**
  * 영문 제목 입력값 자동 정제 기능 추가 (알파벳 및 공백만 허용)
  * 이미지 블록의 미리보기 스타일 개선 (라운드 모서리 및 정렬 조정)
  * 에디터 팝업의 뷰포트 반응성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->