### PR TITLE
[feat] 구글 드라이브 초대장명 생성 날짜로 변경

### DIFF
--- a/app/api/drive/_lib/ensureInvitationFolder.test.ts
+++ b/app/api/drive/_lib/ensureInvitationFolder.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/app/api/drive/_lib/googleFetch', () => ({
+  googleFetch: jest.fn(),
+}));
+
+import {
+  buildInvitationFolderName,
+  createInvitationFolder,
+} from '@/app/api/drive/_lib/ensureInvitationFolder';
+import { googleFetch } from '@/app/api/drive/_lib/googleFetch';
+
+describe('ensureInvitationFolder helpers', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('생성 시각을 초대장 폴더명에 포함한다', () => {
+    const name = buildInvitationFolderName({
+      createdAt: new Date('2026-06-06T05:07:00.000Z'),
+    });
+
+    expect(name).toBe('초대장 - 2026년 06월 06일 14시 07분');
+  });
+
+  it('추후 사용자 지정 초대장 이름을 기준명으로 사용할 수 있다', () => {
+    const name = buildInvitationFolderName({
+      baseName: '민지와 준호',
+      createdAt: new Date('2026-06-06T05:07:00.000Z'),
+    });
+
+    expect(name).toBe('민지와 준호 - 2026년 06월 06일 14시 07분');
+  });
+
+  it('신규 Drive 초대장 폴더 생성 요청에 생성 시각 기반 이름을 사용한다', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-06T05:07:00.000Z'));
+    (googleFetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'created-folder-id' }),
+    });
+
+    await createInvitationFolder({
+      workspaceFolderId: 'workspace-folder-id',
+      invitationUuid: 'invitation-uuid',
+    });
+
+    const [, requestInit] = (googleFetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(requestInit.body);
+
+    expect(body.name).toBe('초대장 - 2026년 06월 06일 14시 07분');
+  });
+});

--- a/app/api/drive/_lib/ensureInvitationFolder.ts
+++ b/app/api/drive/_lib/ensureInvitationFolder.ts
@@ -19,9 +19,88 @@ export type EnsureInvitationFolderResult = {
   reused: boolean;
 };
 
-const INVITATION_FOLDER_NAME = '초대장'; // 추후 초대장 이름은 유저로부터 받을것.
+const DEFAULT_INVITATION_FOLDER_BASE_NAME = '초대장';
+const INVITATION_FOLDER_TIME_ZONE = 'Asia/Seoul';
 const APP_IDENTIFIER = 'Bread-Barbershop';
 const INVITATION_KIND = 'invitation';
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function formatInvitationCreatedAt(createdAt: Date): string {
+  const parts = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: INVITATION_FOLDER_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(createdAt);
+
+  const partMap = Object.fromEntries(
+    parts.map(part => [part.type, part.value])
+  ) as Partial<Record<Intl.DateTimeFormatPartTypes, string>>;
+
+  const year = partMap.year ?? String(createdAt.getFullYear());
+  const month = partMap.month ?? padDatePart(createdAt.getMonth() + 1);
+  const day = partMap.day ?? padDatePart(createdAt.getDate());
+  const hour = partMap.hour ?? padDatePart(createdAt.getHours());
+  const minute = partMap.minute ?? padDatePart(createdAt.getMinutes());
+
+  return `${year}년 ${month}월 ${day}일 ${hour}시 ${minute}분`;
+}
+
+export function buildInvitationFolderName(params?: {
+  baseName?: string | null;
+  createdAt?: Date;
+}): string {
+  const baseName =
+    params?.baseName?.trim() || DEFAULT_INVITATION_FOLDER_BASE_NAME;
+  const createdAt = params?.createdAt ?? new Date();
+
+  return `${baseName} - ${formatInvitationCreatedAt(createdAt)}`;
+}
+
+async function createDriveInvitationFolder(params: {
+  workspaceFolderId: string;
+  invitationUuid: string;
+  baseName?: string | null;
+}): Promise<string> {
+  const createRes = await googleFetch(
+    'https://www.googleapis.com/drive/v3/files',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: buildInvitationFolderName({ baseName: params.baseName }),
+        mimeType: 'application/vnd.google-apps.folder',
+        parents: [params.workspaceFolderId],
+        appProperties: {
+          app_id: APP_IDENTIFIER,
+          kind: INVITATION_KIND,
+          inv_id: params.invitationUuid,
+        },
+      }),
+    }
+  );
+
+  const created = (await createRes.json().catch(() => ({}))) as {
+    id?: string;
+    error?: unknown;
+  };
+
+  if (!createRes.ok || !created.id) {
+    throw new DriveHttpError(
+      '초대장 폴더(uuid) 생성 실패',
+      createRes.status,
+      created
+    );
+  }
+
+  return created.id;
+}
 
 /**
  * 초대장 폴더를 uuid 기준으로 보장한다.
@@ -32,6 +111,7 @@ const INVITATION_KIND = 'invitation';
 export async function ensureInvitationFolder(params: {
   workspaceFolderId: string;
   invitationUuid?: string;
+  baseName?: string | null;
 }): Promise<EnsureInvitationFolderResult> {
   const { workspaceFolderId } = params;
 
@@ -92,39 +172,14 @@ export async function ensureInvitationFolder(params: {
   }
 
   // 2) 없으면 생성
-  const createRes = await googleFetch(
-    'https://www.googleapis.com/drive/v3/files',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: INVITATION_FOLDER_NAME,
-        mimeType: 'application/vnd.google-apps.folder',
-        parents: [workspaceFolderId],
-        appProperties: {
-          app_id: APP_IDENTIFIER,
-          kind: INVITATION_KIND,
-          inv_id: invitationUuid,
-        },
-      }),
-    }
-  );
-
-  const created = (await createRes.json().catch(() => ({}))) as {
-    id?: string;
-    error?: unknown;
-  };
-
-  if (!createRes.ok || !created.id) {
-    throw new DriveHttpError(
-      '초대장 폴더(uuid) 생성 실패',
-      createRes.status,
-      created
-    );
-  }
+  const invitationFolderId = await createDriveInvitationFolder({
+    workspaceFolderId,
+    invitationUuid,
+    baseName: params.baseName,
+  });
 
   return {
-    invitationFolderId: created.id,
+    invitationFolderId,
     invitationUuid,
     reused: false,
   };
@@ -133,6 +188,7 @@ export async function ensureInvitationFolder(params: {
 export async function createInvitationFolder(params: {
   workspaceFolderId: string;
   invitationUuid?: string;
+  baseName?: string | null;
 }): Promise<EnsureInvitationFolderResult> {
   const { workspaceFolderId } = params;
 
@@ -144,39 +200,14 @@ export async function createInvitationFolder(params: {
 
   const invitationUuid = params.invitationUuid ?? generateUuid();
 
-  const createRes = await googleFetch(
-    'https://www.googleapis.com/drive/v3/files',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: INVITATION_FOLDER_NAME,
-        mimeType: 'application/vnd.google-apps.folder',
-        parents: [workspaceFolderId],
-        appProperties: {
-          app_id: APP_IDENTIFIER,
-          kind: INVITATION_KIND,
-          inv_id: invitationUuid,
-        },
-      }),
-    }
-  );
-
-  const created = (await createRes.json().catch(() => ({}))) as {
-    id?: string;
-    error?: unknown;
-  };
-
-  if (!createRes.ok || !created.id) {
-    throw new DriveHttpError(
-      '초대장 폴더(uuid) 생성 실패',
-      createRes.status,
-      created
-    );
-  }
+  const invitationFolderId = await createDriveInvitationFolder({
+    workspaceFolderId,
+    invitationUuid,
+    baseName: params.baseName,
+  });
 
   return {
-    invitationFolderId: created.id,
+    invitationFolderId,
     invitationUuid,
     reused: false,
   };


### PR DESCRIPTION
## 작업 개요

Google Drive에 생성되는 초대장 폴더명을 생성 일시 기반으로 구분 가능하게 개선했습니다.

## 작업 내용

- [x] 신규 초대장 폴더명을 `초대장 - YYYY년 MM월 DD일 HH시 mm분` 형식으로 변경
- [x] 재편집 시 기존 폴더명을 유지하도록 기존 uuid 기반 재사용 흐름 유지
- [x] 추후 초대장별 이름 확장을 위한 `baseName` 구조 추가
- [x] 폴더명 생성 로직 테스트 추가

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npm test -- --runTestsByPath app/api/drive/_lib/ensureInvitationFolder.test.ts` 통과
- `npx eslint app/api/drive/_lib/ensureInvitationFolder.ts app/api/drive/_lib/ensureInvitationFolder.test.ts` 통과
- `npx tsc --noEmit` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 초대장 폴더 생성 로직에 대한 단위 테스트 추가

* **Refactor**
  * 초대장 폴더명에 생성 시간 정보 포함
  * 폴더 생성 로직을 재사용 가능한 헬퍼 함수로 분리
  * 커스텀 폴더명 기본값 설정 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->