### PR TITLE
[refactor] 비디오 컴포넌트 아이프레임 예외처리

### DIFF
--- a/components/organisms/video/VideoPreview.tsx
+++ b/components/organisms/video/VideoPreview.tsx
@@ -17,6 +17,13 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 const ThemeColor = 'white';
 
+const youtubeIframeSecurityProps = {
+  allow: 'autoplay; encrypted-media; picture-in-picture',
+  allowFullScreen: true,
+  referrerPolicy: 'strict-origin-when-cross-origin' as const,
+  sandbox: 'allow-scripts allow-same-origin allow-presentation',
+};
+
 const ratioVariants = cva('', {
   variants: {
     ratio: {
@@ -73,8 +80,7 @@ export const VideoPreview = ({ blockInfo, className, ...rest }: Props) => {
           <iframe
             src={embedUrl as string}
             className="absolute inset-0 w-full h-full border-0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
+            {...youtubeIframeSecurityProps}
             title="동영상 플레이어"
           />
         ) : !thumbnail ? (
@@ -89,8 +95,7 @@ export const VideoPreview = ({ blockInfo, className, ...rest }: Props) => {
           <iframe
             src={embedUrl as string}
             className="absolute inset-0 w-full h-full border-0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
+            {...youtubeIframeSecurityProps}
             title="동영상 플레이어"
           />
         ) : (

--- a/shared/utils/media/getEmbedUrl.ts
+++ b/shared/utils/media/getEmbedUrl.ts
@@ -1,22 +1,55 @@
+const YOUTUBE_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'youtu.be',
+  'youtube-nocookie.com',
+  'www.youtube-nocookie.com',
+]);
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+const getYouTubeVideoId = (url: URL): string | null => {
+  const host = url.hostname.toLowerCase();
+
+  if (!YOUTUBE_HOSTS.has(host)) return null;
+
+  if (host === 'youtu.be') {
+    const id = url.pathname.split('/').filter(Boolean)[0];
+    return id && YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+  }
+
+  const idFromQuery = url.searchParams.get('v');
+  if (idFromQuery && YOUTUBE_VIDEO_ID_PATTERN.test(idFromQuery)) {
+    return idFromQuery;
+  }
+
+  const [prefix, id] = url.pathname.split('/').filter(Boolean);
+  if (
+    ['embed', 'shorts', 'live', 'v'].includes(prefix) &&
+    id &&
+    YOUTUBE_VIDEO_ID_PATTERN.test(id)
+  ) {
+    return id;
+  }
+
+  return null;
+};
+
 export const getEmbedUrl = (url: string | undefined): string | null => {
-  if (!url || url.length < 5) return null;
+  if (!url || url.trim().length < 5) return null;
 
   const parsed = (() => {
     try {
-      return new URL(url);
+      return new URL(url.trim());
     } catch {
       return null;
     }
   })();
-  if (!parsed || !['http:', 'https:'].includes(parsed.protocol)) return null;
+  if (!parsed || parsed.protocol !== 'https:') return null;
 
-  const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-  const match = url.match(regExp);
-  const id = match && match[2].length === 11 ? match[2] : null;
+  const id = getYouTubeVideoId(parsed);
+  if (!id) return null;
 
-  if (id) {
-    return `https://www.youtube.com/embed/${id}?autoplay=1&mute=1&playsinline=1&rel=0`;
-  }
-
-  return url;
+  return `https://www.youtube-nocookie.com/embed/${id}?autoplay=1&mute=1&playsinline=1&rel=0`;
 };


### PR DESCRIPTION
## 작업 개요

비디오 컴포넌트에서 iframe에 렌더링되는 URL을 유튜브로 제한하고, iframe 보안 속성을 강화했습니다.

## 작업 내용

- [x] 유튜브 URL만 embed URL로 변환하도록 검증 로직 추가
- [x] 유효하지 않거나 외부 도메인 URL은 iframe 렌더링 제외
- [x] iframe 권한 축소 및 sandbox/referrerPolicy 적용

## 관련 이슈

Closes #

## 테스트 결과 보고

- 변경 파일 대상 ESLint 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * YouTube 동영상 임베드 URL 검증 강화: 유효하지 않은 또는 형식이 맞지 않는 URL은 임베드되지 않습니다.

* **Refactor**
  * YouTube iframe 보안 속성 일원화: 공통 보안 및 재생 관련 설정을 통합하여 일관성 있게 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->