### PR TITLE
[Fix] 메인포스터 버그 개선 (씹힘 현상, 컨텍스트 메뉴 조정, 스프레이 비활성화, 디폴트 배경색 변경)

### DIFF
--- a/widgets/editor/rightPanel/components/PosterPanel.tsx
+++ b/widgets/editor/rightPanel/components/PosterPanel.tsx
@@ -9,7 +9,7 @@ import { useToast } from '@/shared/hooks/useToast';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 function PosterPanel() {
-  const { canvas, applyTemplateToCanvas, saveHistory } = useFabricContext();
+  const { canvas, applyTemplateToCanvas } = useFabricContext();
   const [templates, setTemplates] = useState<TemplateItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -35,7 +35,6 @@ function PosterPanel() {
   const handleSelectTemplate = async (template: TemplateItem) => {
     try {
       await applyTemplateToCanvas(canvas, template.jsonUrl);
-      saveHistory();
     } catch (err) {
       errorToast('템플릿을 적용하는 중 오류가 발생했습니다.');
       console.error('템플릿을 적용하는 중 오류가 발생했습니다.', err);

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -120,6 +120,7 @@ export const MainPosterPreview = () => {
     const fabricCanvas = new Canvas(canvasRef.current, {
       width: 375,
       height: 812,
+      backgroundColor: '#ffffff',
       fireRightClick: true,
       stopContextMenu: true,
     });

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -234,10 +234,6 @@ export const MainPosterPreview = () => {
         return obj.type;
       };
 
-      console.log(
-        `[Fabric] 마우스 다운: ${getType(target)} (ID: ${targetId}, 잠금: ${isLocked})`
-      );
-
       // 잠긴 객체가 잡혔을 때, 그 위치에 있는 다른 (잠기지 않은) 객체를 찾아서 선택해줌
       if (target && isLocked && !isBackground) {
         const pointer =
@@ -282,9 +278,6 @@ export const MainPosterPreview = () => {
     };
 
     const handleMouseUp = () => {
-      if (typeof window !== 'undefined') {
-        console.log('[Fabric] 마우스 업: 선택 가능 상태 복구');
-      }
       // 드래그 종료 시 (또는 클릭 종료 시) 잠긴 객체와 배경 레이어의 selectable 다시 복구
       fabricCanvas.getObjects().forEach(obj => {
         const target = obj as FabricObjectWithLock;

--- a/widgets/mainPoster/components/Toolbar.tsx
+++ b/widgets/mainPoster/components/Toolbar.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/atoms/button';
 import AddDrawing from '@/shared/assets/icons/add-drawing.svg';
 // import AddEraser from '@/shared/assets/icons/add-eraser.svg';
 import AddImage from '@/shared/assets/icons/add-image.svg';
-import AddPencil from '@/shared/assets/icons/add-pencil.svg';
+// import AddPencil from '@/shared/assets/icons/add-pencil.svg';
 import AddText from '@/shared/assets/icons/add-text.svg';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
@@ -106,7 +106,7 @@ function Toolbar() {
           {item.icon}
         </Button>
       ))}
-      {activeTab === 'graphic' && (
+      {/* {activeTab === 'graphic' && (
         <div className="absolute top-full mt-3 flex flex-col gap-3 items-center">
           <Button
             className="size-8"
@@ -118,7 +118,7 @@ function Toolbar() {
           >
             <AddPencil width={14} height={14} />
           </Button>
-          {/* <Button
+          <Button
             className="size-8"
             variant="bordered"
             active={drawingType === 'eraser'}
@@ -127,9 +127,9 @@ function Toolbar() {
             }}
           >
             <AddEraser width={14} height={14} />
-          </Button> */}
+          </Button>
         </div>
-      )}
+      )} */}
     </div>
   );
 }

--- a/widgets/mainPoster/components/context-menu/ContextMenu.tsx
+++ b/widgets/mainPoster/components/context-menu/ContextMenu.tsx
@@ -11,6 +11,7 @@ import { ActiveStyle, DisabledShortCutStyle, DisabledStyle } from './style';
 import { UndoRedo } from './UndoRedo';
 
 export function ContextMenu() {
+  const CONTEXT_MENU_MAX_HEIGHT = 400;
   const { canvas, handleDeleteShape, activeInfo } = useFabricContext();
   const hasActiveObject = activeInfo.type !== null;
   const [open, setOpen] = useState(false);
@@ -62,11 +63,19 @@ export function ContextMenu() {
   }, [open]);
 
   if (!open) return null;
+
+  const shouldOpenUpward =
+    window.innerHeight - pos.y <= CONTEXT_MENU_MAX_HEIGHT;
+
   return (
     <div
       ref={menuRef}
-      className="fixed z-9999 font-pretendard w-55 flex flex-col gap-3 p-3 bg-white border border-gray-200 rounded-md shadow-lg"
-      style={{ top: pos.y, left: pos.x }}
+      className="fixed z-9999 font-pretendard w-55 max-h-[360px] overflow-y-auto flex flex-col gap-3 p-3 bg-white border border-gray-200 rounded-md shadow-lg"
+      style={
+        shouldOpenUpward
+          ? { bottom: window.innerHeight - pos.y, left: pos.x }
+          : { top: pos.y, left: pos.x }
+      }
       onContextMenu={e => e.preventDefault()}
     >
       <CopyAndPaste onClick={() => setOpen(false)} />

--- a/widgets/mainPoster/context/FabricContext.tsx
+++ b/widgets/mainPoster/context/FabricContext.tsx
@@ -53,7 +53,9 @@ export const FabricProvider = ({
 
   const fabricShapeValues = useFabricShape();
 
-  const fabricTemplateValues = useTemplate();
+  const fabricTemplateValues = useTemplate({
+    runHistoryTransaction: fabricValues.runHistoryTransaction,
+  });
 
   const value = useMemo(
     () => ({

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -389,10 +389,7 @@ export const useFabric = () => {
     const activeObjects = canvas.getActiveObjects();
 
     if (activeObjects.length === 0) {
-      if (
-        typeof window !== 'undefined' &&
-        window.location.pathname.startsWith('/editor?type=admin')
-      ) {
+      if (shouldLogSelection) {
         console.log('[Fabric] 선택 해제됨');
       }
       setActiveInfo({ type: null, isLocked: false, filters: [], styles: {} });
@@ -412,11 +409,7 @@ export const useFabric = () => {
       return obj.type;
     };
 
-    const isDev =
-      typeof window !== 'undefined' &&
-      window.location.pathname.startsWith('/editor?type=admin');
-
-    if (isDev) {
+    if (shouldLogSelection) {
       console.log(`[Fabric] 객체 활성화: ${getKoreanType(primaryObject)}`, {
         id: primaryObject.get('id'),
         isLocked: (primaryObject as any).isLocked,

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -22,6 +22,50 @@ export const useFabric = () => {
   const isDeleting = useRef<boolean>(false);
   const { confirm } = useConfirm();
   const MAX_STACK_SIZE = 30;
+  const shouldLogSelection =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('type') === 'admin';
+
+  const logSelectionSnapshot = useCallback(
+    (label: string, targetCanvas?: Canvas | null) => {
+      const currentCanvas = targetCanvas ?? canvas;
+      if (!currentCanvas || !shouldLogSelection) return;
+
+      const activeObject = currentCanvas.getActiveObject();
+      const activeObjects = currentCanvas.getActiveObjects();
+
+      console.groupCollapsed(`[Fabric][Selection] ${label}`);
+      console.log('activeObject', {
+        id: activeObject?.get?.('id'),
+        type: activeObject?.type,
+        selectable: activeObject?.selectable,
+        evented: activeObject?.evented,
+        isLocked: (activeObject as any)?.isLocked,
+      });
+      console.log(
+        'activeObjects',
+        activeObjects.map(obj => ({
+          id: obj.get?.('id'),
+          type: obj.type,
+          selectable: obj.selectable,
+          evented: obj.evented,
+          isLocked: (obj as any)?.isLocked,
+        }))
+      );
+      console.log(
+        'allObjects',
+        currentCanvas.getObjects().map(obj => ({
+          id: obj.get?.('id'),
+          type: obj.type,
+          selectable: obj.selectable,
+          evented: obj.evented,
+          isLocked: (obj as any)?.isLocked,
+        }))
+      );
+      console.groupEnd();
+    },
+    [canvas, shouldLogSelection]
+  );
 
   const saveHistory = useCallback(() => {
     if (isUpdating.current || !canvas) return;
@@ -33,15 +77,6 @@ export const useFabric = () => {
         'id',
         'name',
         'isLocked',
-        'lockMovementX',
-        'lockMovementY',
-        'lockScalingX',
-        'lockScalingY',
-        'lockRotation',
-        'hasControls',
-        'editable',
-        'selectable',
-        'evented',
         'fontSize',
         'fontFamily',
         'fontWeight',
@@ -108,7 +143,7 @@ export const useFabric = () => {
   };
 
   const handleDeleteShape = useCallback(
-    async(canvas: Canvas, e?: KeyboardEvent, flag?: boolean) => {
+    async (canvas: Canvas, e?: KeyboardEvent, flag?: boolean) => {
       if (e?.repeat) return;
 
       const activeObjects = [...canvas.getActiveObjects()];
@@ -142,18 +177,17 @@ export const useFabric = () => {
       }
 
       if (e?.key === 'Backspace') {
-              const isConfirm = await confirm({
-        message:
-          '정말 뒤돌아가시겠습니까?\n 저장되지 않은 내역은 모두 사라집니다',
-        variant: 'white',
-        xPosition : 'center',
-        yPosition : 'center'
-      });
-      if (!isConfirm) {
-        e.preventDefault();
-        return;
-      }
-
+        const isConfirm = await confirm({
+          message:
+            '정말 뒤돌아가시겠습니까?\n 저장되지 않은 내역은 모두 사라집니다',
+          variant: 'white',
+          xPosition: 'center',
+          yPosition: 'center',
+        });
+        if (!isConfirm) {
+          e.preventDefault();
+          return;
+        }
       }
     },
     [saveHistory]
@@ -355,7 +389,10 @@ export const useFabric = () => {
     const activeObjects = canvas.getActiveObjects();
 
     if (activeObjects.length === 0) {
-      if (typeof window !== 'undefined' && window.location.pathname.startsWith('/dev')) {
+      if (
+        typeof window !== 'undefined' &&
+        window.location.pathname.startsWith('/editor?type=admin')
+      ) {
         console.log('[Fabric] 선택 해제됨');
       }
       setActiveInfo({ type: null, isLocked: false, filters: [], styles: {} });
@@ -365,15 +402,19 @@ export const useFabric = () => {
     const primaryObject = activeObjects[0];
     const getKoreanType = (obj: any) => {
       if (obj.get('id') === 'background-layer') return '배경';
-      if (obj.isType('textbox') || obj.isType('itext') || obj.isType('text')) return '텍스트';
+      if (obj.isType('textbox') || obj.isType('itext') || obj.isType('text'))
+        return '텍스트';
       if (obj.isType('image')) return '이미지';
-      if (obj.isType('rect') || obj.isType('circle') || obj.isType('triangle')) return '도형';
+      if (obj.isType('rect') || obj.isType('circle') || obj.isType('triangle'))
+        return '도형';
       if (obj.isType('path') || obj.isType('line')) return '선/경로';
       if (obj.isType('activeSelection')) return '다중 선택';
       return obj.type;
     };
 
-    const isDev = typeof window !== 'undefined' && window.location.pathname.startsWith('/dev');
+    const isDev =
+      typeof window !== 'undefined' &&
+      window.location.pathname.startsWith('/editor?type=admin');
 
     if (isDev) {
       console.log(`[Fabric] 객체 활성화: ${getKoreanType(primaryObject)}`, {
@@ -414,7 +455,9 @@ export const useFabric = () => {
         'text:selection:changed',
       ];
 
-      const handleSelection = () => syncActiveObjectInfo(canvas);
+      const handleSelection = () => {
+        syncActiveObjectInfo(canvas);
+      };
 
       selectionEvents.forEach(event => {
         canvas.off(event as any, handleSelection);
@@ -438,64 +481,104 @@ export const useFabric = () => {
     [syncActiveObjectInfo, saveHistory]
   );
 
+  const normalizeInteractionState = useCallback((targetCanvas: Canvas) => {
+    targetCanvas.getObjects().forEach(obj => {
+      const isLocked = Boolean((obj as any).isLocked);
+      const isBackground = obj.get('id') === 'background-layer';
+
+      obj.set({
+        lockMovementX: isLocked,
+        lockMovementY: isLocked,
+        lockScalingX: isLocked,
+        lockScalingY: isLocked,
+        lockRotation: isLocked,
+        hasControls: !isLocked && !isBackground,
+        editable: !isLocked,
+        evented: !isBackground,
+        selectable: !isBackground,
+      });
+    });
+  }, []);
+
+  const finalizeLoadedCanvas = useCallback(
+    (targetCanvas: Canvas) => {
+      normalizeInteractionState(targetCanvas);
+
+      const objects = targetCanvas.getObjects();
+      for (const obj of objects) {
+        if (
+          obj.isType('image') &&
+          'applyFilters' in obj &&
+          (obj as any).filters?.length
+        ) {
+          (obj as any).applyFilters();
+        }
+
+        obj.setCoords();
+      }
+
+      targetCanvas.requestRenderAll();
+    },
+    [normalizeInteractionState]
+  );
+
+  const runHistoryTransaction = useCallback(
+    async (task: () => Promise<void> | void, options?: { save?: boolean }) => {
+      if (!canvas) return;
+
+      isUpdating.current = true;
+      canvas.discardActiveObject();
+
+      try {
+        await task();
+        finalizeLoadedCanvas(canvas);
+      } finally {
+        isUpdating.current = false;
+      }
+
+      syncActiveObjectInfo(canvas);
+
+      if (options?.save) {
+        saveHistory();
+      }
+    },
+    [canvas, finalizeLoadedCanvas, saveHistory, syncActiveObjectInfo]
+  );
+
   const undo = useCallback(async () => {
     if (undoStack.current.length <= 1 || isUpdating.current || !canvas) return;
 
-    isUpdating.current = true;
     const current = undoStack.current.pop();
     if (current) redoStack.current.push(current);
 
     const prevState = undoStack.current[undoStack.current.length - 1];
 
-    await canvas.loadFromJSON(prevState);
+    await runHistoryTransaction(async () => {
+      await canvas.loadFromJSON(prevState);
+    });
 
+    logSelectionSnapshot('undo:after-render');
     // 저장된 필터 효과를 다시 렌더링하도록 applyFilters 호출
-    const objects = canvas.getObjects();
-    for (const obj of objects) {
-      if (
-        obj.isType('image') &&
-        'applyFilters' in obj &&
-        (obj as any).filters?.length
-      ) {
-        (obj as any).applyFilters();
-      }
-    }
-
-    canvas.requestRenderAll();
-    isUpdating.current = false;
-    syncActiveObjectInfo(canvas);
     setCanUndo(undoStack.current.length > 1);
     setCanRedo(redoStack.current.length > 0);
-  }, [canvas, syncActiveObjectInfo]);
+  }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
 
   const redo = useCallback(async () => {
     if (redoStack.current.length === 0 || isUpdating.current || !canvas) return;
 
-    isUpdating.current = true;
     const nextState = redoStack.current.pop();
     if (nextState) {
       undoStack.current.push(nextState);
-      await canvas.loadFromJSON(nextState);
+      await runHistoryTransaction(async () => {
+        await canvas.loadFromJSON(nextState);
+      });
 
       // 저장된 필터 효과를 다시 렌더링하도록 applyFilters 호출
-      const objects = canvas.getObjects();
-      for (const obj of objects) {
-        if (
-          obj.isType('image') &&
-          'applyFilters' in obj &&
-          (obj as any & { filters?: any[] }).filters?.length
-        ) {
-          (obj as any).applyFilters();
-        }
-      }
-
-      canvas.requestRenderAll();
+      logSelectionSnapshot('redo:after-render');
     }
-    isUpdating.current = false;
-    syncActiveObjectInfo(canvas);
     setCanUndo(undoStack.current.length > 1);
     setCanRedo(redoStack.current.length > 0);
-  }, [canvas, syncActiveObjectInfo]);
+  }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
 
   const exportIntersectedJSON = useCallback(() => {
     if (!canvas) return;
@@ -611,6 +694,7 @@ export const useFabric = () => {
     lock,
     unLock,
     saveHistory,
+    runHistoryTransaction,
     exportIntersectedJSON,
     exportCanvasPreview,
     clipboard,

--- a/widgets/mainPoster/hooks/useFabricBackground.tsx
+++ b/widgets/mainPoster/hooks/useFabricBackground.tsx
@@ -1,7 +1,10 @@
 import { Canvas, FabricImage } from 'fabric';
 import { useState } from 'react';
 
-import { ColorPickerChange, ColorPickerValue } from '@/components/molecules/color-picker/components/colorPicker.types';
+import {
+  ColorPickerChange,
+  ColorPickerValue,
+} from '@/components/molecules/color-picker/components/colorPicker.types';
 
 import { convertFabricColor } from '../utils/fabricUtils';
 
@@ -13,11 +16,13 @@ export const useFabricBackground = ({ canvas, saveHistory }: Props) => {
   const [backgroundColor, setBackgroundColor] = useState<ColorPickerValue>({
     h: 0,
     s: 0,
-    v: 0,
+    v: 100,
     a: 1,
   });
 
-  const updateBackgroundColor = (color: ColorPickerChange | ColorPickerValue) => {
+  const updateBackgroundColor = (
+    color: ColorPickerChange | ColorPickerValue
+  ) => {
     if (!canvas) return;
 
     // 기존 배경 이미지 객체 제거

--- a/widgets/mainPoster/hooks/useTemplate.ts
+++ b/widgets/mainPoster/hooks/useTemplate.ts
@@ -70,7 +70,14 @@ export const preloadFonts = async (templateJson: any) => {
   await document.fonts.ready;
 };
 
-export const useTemplate = () => {
+interface UseTemplateProps {
+  runHistoryTransaction?: (
+    task: () => Promise<void> | void,
+    options?: { save?: boolean }
+  ) => Promise<void>;
+}
+
+export const useTemplate = ({ runHistoryTransaction }: UseTemplateProps = {}) => {
   /**
    * 템플릿 JSON을 가져와서 캔버스에 적용합니다.
    * @param canvas Fabric 캔버스 인스턴스
@@ -90,7 +97,45 @@ export const useTemplate = () => {
       await preloadFonts(templateJson);
 
       // 2. JSON 로드
-      await canvas.loadFromJSON(templateJson);
+      const prepareTextObjects = () => {
+        const objects = canvas.getObjects();
+        for (const obj of objects) {
+          if (
+            obj.isType('textbox') ||
+            obj.isType('itext') ||
+            obj.isType('text')
+          ) {
+            const textObj = obj as Textbox | IText;
+
+            textObj.set({
+              dirty: true,
+              objectCaching: false,
+            });
+
+            if ('_initDimensions' in textObj) {
+              (textObj as any)._initDimensions();
+            } else if ('initDimensions' in textObj) {
+              (textObj as any).initDimensions();
+            }
+
+            textObj.setCoords();
+          }
+        }
+      };
+
+      if (runHistoryTransaction) {
+        await runHistoryTransaction(
+          async () => {
+            await canvas.loadFromJSON(templateJson);
+            prepareTextObjects();
+            await new Promise(resolve => requestAnimationFrame(resolve));
+          },
+          { save: true }
+        );
+      } else {
+        await canvas.loadFromJSON(templateJson);
+        prepareTextObjects();
+      }
 
       // 3. 개체별 보정 및 렌더링 최적화
       const objects = canvas.getObjects();


### PR DESCRIPTION
## 작업 개요

메인포스터 버그 개선 (씹힘 현상, 컨텍스트 메뉴 조정, 스프레이 비활성화, 디폴트 배경색 변경)

## 작업 내용

- saveHistory에서 임시 상호작용 상태 저장 제거
- isLocked만 저장하고, undo/redo 복원 후 normalizeInteractionState()로 잠금/조작 상태를 다시 계산하도록 수정
- undo/redo 복원 경로를 공통 트랜잭션(runHistoryTransaction)으로 정리
- 템플릿 적용을 히스토리 트랜잭션 안에서 처리하도록 변경하여 중간 loadFromJSON 상태가 스택에 저장되지 않도록 개선
- 템플릿 적용 후 외부에서 중복 호출하던 saveHistory() 제거
- 컨텍스트 메뉴의 위치를 특정 높이에서 상단으로 펼쳐지게 수정
- 디폴트 배경색이 없던 부분을 흰색으로 설정
- 스프레이 비활성화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 컨텍스트 메뉴가 화면 하단을 넘치지 않도록 위치 자동 조정
  * 실행 취소/다시 실행 기능 안정성 개선

* **Chores**
  * 펜슬/지우개 도구 비활성화
  * 캔버스 배경색을 흰색으로 고정
  * 디버그 로그 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->