### PR TITLE
Refactor/editor/check popup

### DIFF
--- a/app/editor/[id]/components/EditorUpdate.tsx
+++ b/app/editor/[id]/components/EditorUpdate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { notFound } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { EditorBgmPlayerProvider } from '@/components/organisms/bgm/context/EditorBgmPlayerContext';
 import { useBgmStore } from '@/components/organisms/bgm/store/useBgmStore';
@@ -14,6 +14,7 @@ import Preview from '@/widgets/editor/preview/Preview';
 import RightPanel from '@/widgets/editor/rightPanel/RightPanel';
 import { FabricProvider } from '@/widgets/mainPoster/context/FabricContext';
 
+import { useEditorDirtyTracker } from '../../hooks/useEditorDirtyTracker';
 import { useInitData } from '../hooks/useInitData';
 import { useSavedData } from '../hooks/useSavedData';
 
@@ -29,6 +30,8 @@ function EditorUpdate({ folderId, uuid }: Props) {
     uuid,
     invitationFolderId: folderId,
   });
+
+  const [isStoreReady, setIsStoreReady] = useState(false);
 
   const reset = useEditorStore(state => state.reset);
   const resetBgm = useBgmStore(state => state.reset);
@@ -46,9 +49,12 @@ function EditorUpdate({ folderId, uuid }: Props) {
         initBulkData();
         await initEditStore();
         initBgmStore();
+        setIsStoreReady(true);
       })();
     }
   }, [savedData, initEditStore, initBgmStore, initBulkData]);
+  console.log('isStoreReady', isStoreReady);
+  useEditorDirtyTracker(isStoreReady);
   usePreventBack();
   if (error) notFound();
   if (loading || !savedData) {

--- a/app/editor/[id]/hooks/useEditorDirtyTracker.ts
+++ b/app/editor/[id]/hooks/useEditorDirtyTracker.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { shallow } from 'zustand/shallow';
+
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
+export function useEditorDirtyTracker(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const unsubscribe = useEditorStore.subscribe(
+      state => [
+        state.block,
+        state.images,
+        state.shareUrl,
+        state.titleData,
+        state.bodyData,
+        state.backgroundColor,
+        state.isZoom,
+      ],
+      () => {
+        useEditorStore.getState().setIsDirty(true);
+      },
+      { equalityFn: shallow }
+    );
+
+    return unsubscribe;
+  }, [enabled]);
+}

--- a/app/editor/components/MainContentsArea.tsx
+++ b/app/editor/components/MainContentsArea.tsx
@@ -12,6 +12,8 @@ import MenuPanel from '@/widgets/editor/menuPanel/OrderPanel';
 import Preview from '@/widgets/editor/preview/Preview';
 import RightPanel from '@/widgets/editor/rightPanel/RightPanel';
 
+import { useEditorDirtyTracker } from '../hooks/useEditorDirtyTracker';
+
 function MainContentsArea() {
   usePreventBack();
   const reset = useEditorStore(state => state.reset);
@@ -20,6 +22,8 @@ function MainContentsArea() {
     state => state.showAllCalloutsFor
   );
   const hideAllCallouts = useEditorCalloutStore(state => state.hideAllCallouts);
+
+  useEditorDirtyTracker(true);
 
   useEffect(() => {
     resetBgm();

--- a/app/editor/hooks/useEditorDirtyTracker.ts
+++ b/app/editor/hooks/useEditorDirtyTracker.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { shallow } from 'zustand/shallow';
+
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
+export function useEditorDirtyTracker(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const unsubscribe = useEditorStore.subscribe(
+      state => [
+        state.block,
+        state.images,
+        state.shareUrl,
+        state.titleData,
+        state.bodyData,
+        state.backgroundColor,
+        state.isZoom,
+      ],
+      () => {
+        useEditorStore.getState().setIsDirty(true);
+      },
+      { equalityFn: shallow }
+    );
+
+    return unsubscribe;
+  }, [enabled]);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,7 +91,7 @@ export default function RootLayout({
       className={`${pretendard.variable} ${inter.variable} ${notoSansKr.variable} ${lineSeedKr.variable}`}
     >
       <body className="antialiased font-pretendard">
-        {children}
+        <div id="app-root">{children}</div>
         <ToastContainer />
         <ConfirmContainer />
         <Script

--- a/components/molecules/confirm/Confirm.style.ts
+++ b/components/molecules/confirm/Confirm.style.ts
@@ -12,7 +12,7 @@ export const confirmVariants = cva(
     },
   }
 );
-export const confirmPositionVariants = cva('fixed inset-0 z-9999 flex', {
+export const confirmPositionVariants = cva('fixed inset-0 z-9999 flex bg-black/30', {
   variants: {
     xPosition: {
       left: 'justify-start pl-5',

--- a/components/molecules/confirm/Confirm.tsx
+++ b/components/molecules/confirm/Confirm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import { cn } from '@/shared/utils/cn';
+import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
 
 import { confirmPositionVariants, confirmVariants } from './Confirm.style';
 
@@ -34,38 +35,66 @@ const Confirm = forwardRef<HTMLDivElement, ConfirmProps>(
     }: ConfirmProps,
     ref
   ) => {
+    useEffect(() => {
+      const enableRestore = disableBodyScroll();
+      getHiddenRoot();
+
+      // 포커스를 모달로 이동
+      const timer = setTimeout(() => {
+        if (ref && 'current' in ref && ref.current) {
+          ref.current.focus();
+        }
+      }, 0);
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+        if (ref && 'current' in ref && ref.current) {
+          trapFocus(e, ref.current);
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        clearTimeout(timer);
+        document.removeEventListener('keydown', handleKeyDown);
+        enableRestore();
+        removeHiddenRoot();
+      };
+    }, [onClose, ref]);
+
     return createPortal(
       <div
-        className={cn(confirmPositionVariants({ xPosition, yPosition }))}
+        className={confirmPositionVariants({ xPosition, yPosition })}
         onClick={onClose}
       >
         <div
           ref={ref}
           role="dialog"
           aria-modal="true"
-          aria-label={message}
+          aria-labelledby="confirm-message"
+          tabIndex={-1}
           onClick={e => e.stopPropagation()}
-          onKeyDown={e => {
-            if (e.key === 'Escape') onClose();
-          }}
           className={cn(confirmVariants({ variant }))}
         >
           <div>
-            <p className="whitespace-pre text-center text-sm font-semibold text-text-primary font-pretendard">
+            <p id="confirm-message" className="whitespace-pre text-center text-sm font-semibold text-text-primary font-pretendard">
               {message}
             </p>
           </div>
           <div className="flex items-center justify-center gap-5">
             <button
               type="button"
-              className="text-[13px] text-status-error rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 cursor-pointer"
+              className="text-[13px] text-status-error rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 cursor-pointer focus:outline-none focus:ring-2 focus:ring-status-error focus:ring-offset-2"
               onClick={onConfirm}
             >
               {confirmText}
             </button>
             <button
               type="button"
-              className="text-[13px] text-text-primary rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 cursor-pointer"
+              className="text-[13px] text-text-primary rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 cursor-pointer focus:outline-none focus:ring-2 focus:ring-text-primary focus:ring-offset-2"
               onClick={onCancel}
             >
               {cancelText}

--- a/features/session/components/HeaderAuthControl.tsx
+++ b/features/session/components/HeaderAuthControl.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import { useAuthGate } from '@/features/session/hooks/useAuthGate';
 import { useConfirm } from '@/shared/hooks/useConfirm';
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 
 import LoginModal from './LoginModal';
 import PrivacyNoticeModal from './PrivacyNoticeModal';
@@ -34,6 +35,7 @@ function HeaderAuthControl({ initialIsLoggedIn }: HeaderAuthControlProps) {
   } = useAuthGate({ initialIsLoggedIn });
   const pathname = usePathname();
   const { confirm } = useConfirm();
+  const isDirty = useEditorStore(state => state.isDirty);
   const modals = (
     <>
       <LoginModal
@@ -50,7 +52,7 @@ function HeaderAuthControl({ initialIsLoggedIn }: HeaderAuthControlProps) {
   );
 
   const handleDashboardClick = async (e: MouseEvent) => {
-    if (pathname.startsWith('/editor')) {
+    if (pathname.startsWith('/editor') && isDirty) {
       const isConfirm = await confirm({
         message:
           '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',
@@ -68,7 +70,7 @@ function HeaderAuthControl({ initialIsLoggedIn }: HeaderAuthControlProps) {
   };
 
   const handleLogoutClick = async () => {
-    if (pathname.startsWith('/editor')) {
+    if (pathname.startsWith('/editor') && isDirty) {
       const isConfirm = await confirm({
         message:
           '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',

--- a/features/session/components/HomeButton.tsx
+++ b/features/session/components/HomeButton.tsx
@@ -15,7 +15,6 @@ function HomeButton() {
   const isDirty = useEditorStore(state => state.isDirty);
 
   const handleHomeClick = async (e: React.MouseEvent) => {
-    console.log('isDirty', isDirty);
     if (pathname.startsWith('/editor') && isDirty) {
       e.preventDefault();
 

--- a/features/session/components/HomeButton.tsx
+++ b/features/session/components/HomeButton.tsx
@@ -6,18 +6,19 @@ import React from 'react';
 
 import InviaLogo from '@/shared/assets/logo/invia-logo.svg';
 import { useConfirm } from '@/shared/hooks/useConfirm';
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 
 function HomeButton() {
   const pathname = usePathname();
   const router = useRouter();
   const { confirm } = useConfirm();
+  const isDirty = useEditorStore(state => state.isDirty);
 
   const handleHomeClick = async (e: React.MouseEvent) => {
-    if (pathname.startsWith('/editor')) {
-      // 1. 비동기 작업 전에 즉시 기본 브라우저/Next.js 이동 방지
+    console.log('isDirty', isDirty);
+    if (pathname.startsWith('/editor') && isDirty) {
       e.preventDefault();
 
-      // 2. 모달 승인 대기
       const isConfirm = await confirm({
         message:
           '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',
@@ -25,7 +26,6 @@ function HomeButton() {
         yPosition: 'center',
       });
 
-      // 3. 승인 시 수동으로 이동 처리
       if (isConfirm) {
         router.push('/');
       }

--- a/features/session/components/LoginModal.tsx
+++ b/features/session/components/LoginModal.tsx
@@ -4,9 +4,13 @@ import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
-
 import InviaSimpleLogo3d from '@/shared/assets/logo/invia-simple-logo-3d.png';
+import {
+  trapFocus,
+  disableBodyScroll,
+  getHiddenRoot,
+  removeHiddenRoot,
+} from '@/shared/utils/focusTrap';
 
 interface LoginModalProps {
   open: boolean;

--- a/features/session/components/LoginModal.tsx
+++ b/features/session/components/LoginModal.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
 
 import InviaSimpleLogo3d from '@/shared/assets/logo/invia-simple-logo-3d.png';
 
@@ -21,6 +24,8 @@ function LoginModal({
   onGoogleLogin,
 }: LoginModalProps) {
   const [isClosing, setIsClosing] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const googleButtonRef = useRef<HTMLButtonElement>(null);
 
   const closeWithFade = () => {
     if (isClosing) return;
@@ -32,16 +37,49 @@ function LoginModal({
     }, FADE_OUT_MS);
   };
 
+  useEffect(() => {
+    if (!open || isClosing) return;
+
+    const enableRestore = disableBodyScroll();
+    getHiddenRoot();
+
+    // 포커스를 Google 버튼으로 이동
+    const timer = setTimeout(() => {
+      googleButtonRef.current?.focus();
+    }, 0);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeWithFade();
+      }
+      if (modalRef.current) {
+        trapFocus(e, modalRef.current);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('keydown', handleKeyDown);
+      enableRestore();
+      removeHiddenRoot();
+    };
+  }, [open, isClosing]);
+
   if (!open && !isClosing) return null;
 
-  return (
+  return createPortal(
     <div
-      className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-200 ${
+      ref={modalRef}
+      className={`fixed inset-0 z-9999 flex items-center justify-center transition-opacity duration-200 ${
         isClosing ? 'opacity-0' : 'animate-[fade-in_180ms_ease-out] opacity-100'
       }`}
       onClick={closeWithFade}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="login-modal-title"
+      tabIndex={-1}
     >
       <div className="absolute inset-0 bg-[rgb(0_0_0_/_8%)]" />
 
@@ -63,10 +101,11 @@ function LoginModal({
         />
 
         <button
+          ref={googleButtonRef}
           type="button"
           onClick={onGoogleLogin}
           disabled={isLoading}
-          className="relative flex h-11 w-[352px] cursor-pointer items-center justify-center rounded-lg border border-[#e5e7eb] bg-white px-2 py-1.5 text-[15px] font-medium text-[#111827] enabled:hover:bg-[#FAFAFB] enabled:active:bg-[#F5F8FF] disabled:cursor-not-allowed disabled:opacity-60"
+          className="relative flex h-11 w-[352px] cursor-pointer items-center justify-center rounded-lg border border-[#e5e7eb] bg-white px-2 py-1.5 text-[15px] font-medium text-[#111827] enabled:hover:bg-[#FAFAFB] enabled:active:bg-[#F5F8FF] disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
           <Image
             src="/assets/icons/google-icon.svg"
@@ -78,7 +117,8 @@ function LoginModal({
           <p>{isLoading ? '로그인중..' : 'Google로 계속하기'}</p>
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/shared/hooks/usePreventBack.ts
+++ b/shared/hooks/usePreventBack.ts
@@ -1,17 +1,27 @@
 import { useEffect } from 'react';
 
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
 import { useConfirm } from './useConfirm';
 
 export function usePreventBack() {
   const { confirm } = useConfirm();
+  const isDirty = useEditorStore(state => state.isDirty);
+
   useEffect(() => {
     // 1. 탭 닫기 / 새로고침 방지
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
+      if (isDirty) {
+        e.preventDefault();
+      }
     };
 
     // 2. 뒤로가기 방지
     const handlePopState = async () => {
+      if (!isDirty) {
+        return;
+      }
+
       const isConfirm = await confirm({
         message:
           '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',
@@ -34,5 +44,5 @@ export function usePreventBack() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [confirm]);
+  }, [confirm, isDirty]);
 }

--- a/shared/store/editorStore/slices/uiSlice.ts
+++ b/shared/store/editorStore/slices/uiSlice.ts
@@ -40,4 +40,6 @@ export const createUISlice: StateCreator<
     set(state => ({
       shapeConfig: { ...state.shapeConfig, ...config },
     })),
+  isDirty: false,
+  setIsDirty: (isDirty: boolean) => set({ isDirty }),
 });

--- a/shared/store/editorStore/useEditorStore.ts
+++ b/shared/store/editorStore/useEditorStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, subscribeWithSelector } from 'zustand/middleware';
 
 import { BODY_BULK_DATA, TITLE_BULK_DATA } from '@/shared/data/sample/bulkData';
 import { EditorState } from '@/shared/types/block';
@@ -13,15 +13,16 @@ import { createShareUrlSlice } from './slices/shareUrlSlice';
 import { createUISlice } from './slices/uiSlice';
 
 export const useEditorStore = create<EditorState>()(
-  devtools((...a) => {
-    const [set] = a;
-    return {
-      ...createBlockSlice(...a),
-      ...createImageSlice(...a),
-      ...createUISlice(...a),
-      ...createDriveSlice(...a),
-      ...createBulkSlice(...a),
-      ...createShareUrlSlice(...a),
+  devtools(
+    subscribeWithSelector((...a) => {
+      const [set] = a;
+      return {
+        ...createBlockSlice(...a),
+        ...createImageSlice(...a),
+        ...createUISlice(...a),
+        ...createDriveSlice(...a),
+        ...createBulkSlice(...a),
+        ...createShareUrlSlice(...a),
       reset: () =>
         set({
           block: [],
@@ -47,9 +48,11 @@ export const useEditorStore = create<EditorState>()(
           hashFiles: [],
           cleanUpFiles: [],
           shareUrlTab: 'url',
+          isDirty: false,
         }),
-    };
-  })
+      };
+    })
+  )
 );
 
 export const selectUploadData = (state: EditorState) => ({

--- a/shared/types/block.ts
+++ b/shared/types/block.ts
@@ -93,6 +93,8 @@ export interface UISlice {
   setDrawingConfig: (config: Partial<DrawingConfig>) => void;
   shapeConfig: ShapeConfig;
   setShapeConfig: (config: Partial<ShapeConfig>) => void;
+  isDirty: boolean;
+  setIsDirty: (isDirty: boolean) => void;
 }
 
 export interface DriveSlice {

--- a/shared/utils/focusTrap.ts
+++ b/shared/utils/focusTrap.ts
@@ -1,0 +1,80 @@
+// 모달 내에서 포커스 트랩을 구현하는 유틸리티
+
+const FOCUSABLE_ELEMENTS = [
+  'button',
+  'a[href]',
+  'input',
+  'select',
+  'textarea',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export const getFocusableElements = (element: HTMLElement): HTMLElement[] => {
+  return Array.from(element.querySelectorAll(FOCUSABLE_ELEMENTS)).filter(
+    (el) => {
+      const htmlEl = el as HTMLElement;
+      return !htmlEl.hasAttribute('disabled') &&
+             htmlEl.offsetParent !== null &&
+             getComputedStyle(htmlEl).visibility !== 'hidden';
+    }
+  ) as HTMLElement[];
+};
+
+export const trapFocus = (event: KeyboardEvent, element: HTMLElement): void => {
+  if (event.key !== 'Tab') return;
+
+  const focusableElements = getFocusableElements(element);
+  if (focusableElements.length === 0) return;
+
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+  const activeElement = document.activeElement as HTMLElement;
+
+  if (event.shiftKey) {
+    // Shift + Tab
+    if (activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    }
+  } else {
+    // Tab
+    if (activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  }
+};
+
+export const disableBodyScroll = (): (() => void) => {
+  const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+  const originalStyle = document.body.style.cssText;
+
+  document.body.style.overflow = 'hidden';
+  document.body.style.paddingRight = `${scrollbarWidth}px`;
+
+  return () => {
+    document.body.style.cssText = originalStyle;
+  };
+};
+
+let ariaHiddenCount = 0;
+
+export const getHiddenRoot = (): void => {
+  const root = document.getElementById('app-root');
+  if (!root) return;
+  if (ariaHiddenCount === 0) {
+    root.setAttribute('aria-hidden', 'true');
+    root.setAttribute('inert', '');
+  }
+  ariaHiddenCount++;
+};
+
+export const removeHiddenRoot = (): void => {
+  const root = document.getElementById('app-root');
+  if (!root) return;
+  ariaHiddenCount--;
+  if (ariaHiddenCount === 0) {
+    root.removeAttribute('aria-hidden');
+    root.removeAttribute('inert');
+  }
+};

--- a/widgets/editor/preview/components/DeleteModal.tsx
+++ b/widgets/editor/preview/components/DeleteModal.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
 
 interface DeleteModalProps {
   setIsDeleteModal: (isDeleteModal: boolean) => void;
@@ -8,36 +9,64 @@ interface DeleteModalProps {
 
 const DeleteModal = forwardRef<HTMLDivElement, DeleteModalProps>(
   ({ setIsDeleteModal, onDelete }: DeleteModalProps, ref) => {
+    useEffect(() => {
+      const enableRestore = disableBodyScroll();
+      getHiddenRoot();
+
+      // 포커스를 모달로 이동
+      const timer = setTimeout(() => {
+        if (ref && 'current' in ref && ref.current) {
+          ref.current.focus();
+        }
+      }, 0);
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          setIsDeleteModal(false);
+        }
+        if (ref && 'current' in ref && ref.current) {
+          trapFocus(e, ref.current);
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        clearTimeout(timer);
+        document.removeEventListener('keydown', handleKeyDown);
+        enableRestore();
+        removeHiddenRoot();
+      };
+    }, [setIsDeleteModal, ref]);
+
     return createPortal(
-      <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/30">
         <div
           ref={ref}
           role="dialog"
           aria-modal="true"
           aria-labelledby="delete-modal-title"
-          onKeyDown={e => {
-            if (e.key === 'Escape') setIsDeleteModal(false);
-          }}
-          className="flex flex-col gap-5 px-5 w-57 box-border border border-white/22 bg-white rounded-xl 
+          tabIndex={-1}
+          className="flex flex-col gap-5 px-5 w-57 box-border border border-white/22 bg-white rounded-xl
       shadow-[0_24px_60px_-20px_rgba(0,0,0,0.12),0_8px_24px_-8px_rgba(0,0,0,0.18),0_1px_8px_-2px_rgba(255,255,255,0.35)] backdrop-blur-2xl
       "
         >
           <div className="pt-5">
-            <p className="w-full text-sm font-semibold text-text-primary font-pretendard text-center">
+            <p id="delete-modal-title" className="w-full text-sm font-semibold text-text-primary font-pretendard text-center">
               해당 페이지를 삭제하시겠습니까?
             </p>
           </div>
           <div className="flex items-center justify-center gap-5 mb-3">
             <button
               type="button"
-              className="text-[13px] text-status-error rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32"
+              className="text-[13px] text-status-error rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 focus:outline-none focus:ring-2 focus:ring-status-error focus:ring-offset-2"
               onClick={onDelete}
             >
               예
             </button>
             <button
               type="button"
-              className="text-[13px] text-text-primary rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32"
+              className="text-[13px] text-text-primary rounded-lg w-[66px] h-8 hover:bg-[#FFE8E8]/32 focus:outline-none focus:ring-2 focus:ring-text-primary focus:ring-offset-2"
               onClick={() => setIsDeleteModal(false)}
             >
               아니오

--- a/widgets/editor/preview/components/DeleteModal.tsx
+++ b/widgets/editor/preview/components/DeleteModal.tsx
@@ -1,6 +1,12 @@
 import React, { forwardRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
+
+import {
+  trapFocus,
+  disableBodyScroll,
+  getHiddenRoot,
+  removeHiddenRoot,
+} from '@/shared/utils/focusTrap';
 
 interface DeleteModalProps {
   setIsDeleteModal: (isDeleteModal: boolean) => void;
@@ -52,7 +58,10 @@ const DeleteModal = forwardRef<HTMLDivElement, DeleteModalProps>(
       "
         >
           <div className="pt-5">
-            <p id="delete-modal-title" className="w-full text-sm font-semibold text-text-primary font-pretendard text-center">
+            <p
+              id="delete-modal-title"
+              className="w-full text-sm font-semibold text-text-primary font-pretendard text-center"
+            >
               해당 페이지를 삭제하시겠습니까?
             </p>
           </div>

--- a/widgets/editor/preview/components/SaveModal.tsx
+++ b/widgets/editor/preview/components/SaveModal.tsx
@@ -1,8 +1,9 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useToast } from '@/shared/hooks/useToast';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+import { trapFocus, disableBodyScroll, getHiddenRoot, removeHiddenRoot } from '@/shared/utils/focusTrap';
 
 import { useInvitationPublish } from '../hooks/useInvitationPublish';
 
@@ -40,6 +41,10 @@ const ModalFrame = forwardRef<
     />
     <div
       ref={ref}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-modal-title"
+      tabIndex={-1}
       className={`fixed top-1/2 left-1/2 z-[101] flex w-[335px] -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-6 rounded-xl border border-white/22 bg-white/72 p-5 shadow-[0_24px_60px_-20px_rgb(0_0_0_/_12%),0_8px_24px_-8px_rgb(0_0_0_/_18%),0_1px_8px_-2px_rgb(255_255_255_/_35%)] backdrop-blur-xl ${isLoading ? 'justify-center' : ''}`}
     >
       {isLoading ? <SaveLottie variant="loading" loop /> : children}
@@ -72,7 +77,7 @@ const SaveStepView = ({
       {isFail ? (
         <button
           type="button"
-          className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[295px] h-[44px]"
+          className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[295px] h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
           onClick={onUpload}
         >
           다시 저장하기
@@ -81,14 +86,14 @@ const SaveStepView = ({
         <>
           <button
             type="button"
-            className="font-semibold text-sm border border-white/12 rounded-lg bg-white text-black flex-center w-[143px] h-[44px]"
+            className="font-semibold text-sm border border-white/12 rounded-lg bg-white text-black flex-center w-[143px] h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             onClick={onClose}
           >
             다시 수정하기
           </button>
           <button
             type="button"
-            className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[143px] h-[44px]"
+            className="font-semibold text-sm border border-white/12 rounded-lg bg-black text-white flex-center w-[143px] h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
             onClick={onPublish}
           >
             초대장 URL 만들기
@@ -150,7 +155,7 @@ const PublishStepView = ({
             {!finalGuestUrl || error ? (
               <button
                 type="button"
-                className={PUBLISHED_URL_ACTION_CLASS}
+                className={`${PUBLISHED_URL_ACTION_CLASS} focus:outline-none focus:ring-2 focus:ring-blue-400`}
                 onClick={onPublish}
               >
                 초대장 URL 다시 발행하기
@@ -158,7 +163,7 @@ const PublishStepView = ({
             ) : (
               <>
                 <a
-                  className={PUBLISHED_URL_ACTION_CLASS}
+                  className={`${PUBLISHED_URL_ACTION_CLASS} focus:outline-none focus:ring-2 focus:ring-blue-400`}
                   href={finalGuestUrl}
                   target="_blank"
                   rel="noreferrer"
@@ -167,7 +172,7 @@ const PublishStepView = ({
                 </a>
                 <button
                   type="button"
-                  className={COPY_URL_ACTION_CLASS}
+                  className={`${COPY_URL_ACTION_CLASS} focus:outline-none focus:ring-2 focus:ring-blue-300`}
                   onClick={async e => {
                     e.stopPropagation();
                     try {
@@ -194,6 +199,36 @@ const PublishStepView = ({
 
 export const SaveModal = forwardRef<HTMLDivElement, Props>(
   ({ isLoading, isFail, retry, onClose }: Props, ref) => {
+    useEffect(() => {
+      const enableRestore = disableBodyScroll();
+      getHiddenRoot();
+
+      // 포커스를 모달로 이동
+      const timer = setTimeout(() => {
+        if (ref && 'current' in ref && ref.current) {
+          ref.current.focus();
+        }
+      }, 0);
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+        if (ref && 'current' in ref && ref.current) {
+          trapFocus(e, ref.current);
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        clearTimeout(timer);
+        document.removeEventListener('keydown', handleKeyDown);
+        enableRestore();
+        removeHiddenRoot();
+      };
+    }, [onClose, ref]);
+
     const invitationFolderId = useEditorStore(
       state => state.invitationFolderId
     );

--- a/widgets/editor/preview/hooks/useInvitationUpload.ts
+++ b/widgets/editor/preview/hooks/useInvitationUpload.ts
@@ -258,6 +258,7 @@ export const useInvitationUpload = () => {
         console.log('[uploadFlow] saveInvitationFlow 완료');
         await applySaveResult(saveResult, allTasks);
         console.log('[uploadFlow] applySaveResult 완료');
+        useEditorStore.getState().setIsDirty(false);
       } else {
         console.log('[uploadFlow] 재저장 (invitationUuid:', editorData.invitationUuid, ')');
         const result = hasPreparedInvitation(editorData.invitationUuid)
@@ -286,6 +287,7 @@ export const useInvitationUpload = () => {
         console.log('[uploadFlow] saveInvitationFlow 완료');
         await applySaveResult(saveResult, allTasks);
         console.log('[uploadFlow] applySaveResult 완료');
+        useEditorStore.getState().setIsDirty(false);
 
         // 클린업 대상 계산 및 실행 (non-blocking)
         const newHashFileIds = new Set(

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -33,6 +33,7 @@ export const MainPosterPreview = () => {
   const isAdmin = searchParams.get('type') === 'admin';
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isMouseInCanvasRef = useRef(false);
+  const isInitialLoadDoneRef = useRef(false);
 
   const { activeTab, selectedId, selectedBlock, setActiveTab, setIsEdit } =
     useEditorStore(
@@ -60,7 +61,15 @@ export const MainPosterPreview = () => {
   useKeyboardEvents(canvas, isMouseInCanvasRef);
 
   useEffect(() => {
-    if (!canvas || !initialData) return;
+    if (!canvas) {
+      isInitialLoadDoneRef.current = true;
+      return;
+    }
+
+    if (!initialData) {
+      isInitialLoadDoneRef.current = true;
+      return;
+    }
 
     const loadData = async () => {
       try {
@@ -106,8 +115,10 @@ export const MainPosterPreview = () => {
 
         await new Promise(resolve => requestAnimationFrame(resolve));
         canvas.requestRenderAll();
+        isInitialLoadDoneRef.current = true;
       } catch (error) {
         console.error('Fabric load Error:', error);
+        isInitialLoadDoneRef.current = true;
       }
     };
 
@@ -190,6 +201,24 @@ export const MainPosterPreview = () => {
       }
     }
   }, [canvas, activeTab, toggleDrawingMode, setActiveTab]);
+
+  useEffect(() => {
+    const fabricCanvas = canvas;
+    if (!fabricCanvas) return;
+
+    const markDirty = () => {
+      if (isInitialLoadDoneRef.current) {
+        useEditorStore.getState().setIsDirty(true);
+      }
+    };
+
+    const events = ['object:added', 'object:modified', 'object:removed'] as const;
+    events.forEach(event => fabricCanvas.on(event, markDirty));
+
+    return () => {
+      events.forEach(event => fabricCanvas.off(event, markDirty));
+    };
+  }, [canvas]);
 
   useEffect(() => {
     const fabricCanvas = canvas;


### PR DESCRIPTION
## 작업 개요

- 에디터 이탈 시 데이터 유실 안내 팝업 로직을 개선했습니다. EditorStore와 poster의 데이터 변경 사항을 감지하여
팝업의 여부를 판단하도록 하였습니다.
- 모달 접근성을 개선 하였습니다.

## 작업 내용

- [x] EditorStore와 poster 감지 훅 개발
- [x] confirm, deleteModal, SaveModal, LoginModal 접근성개선 

## 관련 이슈

Closes #

## 테스트 결과 보고

<!-- 테스트 결과나 내용 텍스트 또는 사진 등 기입 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에디터에서 저장하지 않은 변경 사항을 감지하여 페이지 이동 시 확인 메시지 표시
  * 모달 및 대화상자에서 Escape 키로 닫기 및 Tab 키 포커스 순환 기능 추가

* **개선 사항**
  * 모달의 접근성 개선 (포커스 관리, ARIA 속성 강화)
  * 포커스 상태의 시각적 피드백 추가
  * 모달 열림 시 배경 스크롤 잠금 처리
  * 확인 모달의 배경 오버레이 투명도 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->