### PR TITLE
[fix] 발행 시 게스트 페이지에서 디폴트 이미지 보이지 않도록 수정

### DIFF
--- a/app/guest/[id]/components/GuestRenderer.tsx
+++ b/app/guest/[id]/components/GuestRenderer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 
@@ -44,7 +45,10 @@ function extractFontFamiliesFromString(value: string) {
   return families;
 }
 
-function collectGuestFontFamilies(value: unknown, families = new Set<string>()) {
+function collectGuestFontFamilies(
+  value: unknown,
+  families = new Set<string>()
+) {
   if (typeof value === 'string') {
     extractFontFamiliesFromString(value).forEach(fontFamily => {
       families.add(fontFamily);
@@ -90,7 +94,7 @@ function GuestRenderer({
     }))
   );
   const [fontsReady, setFontsReady] = useState(false);
-
+  const pathname = usePathname();
   const fontFamiliesToPreload = useMemo(() => {
     const families = collectGuestFontFamilies({
       blocks,
@@ -174,11 +178,16 @@ function GuestRenderer({
         const View = registryItem.viewComponent as React.ComponentType<{
           blockInfo: GuestBlock;
           className?: string;
+          isGuestPage?: boolean;
         }>;
 
         return (
           <div key={block.id} className="w-full">
-            <View blockInfo={block} className="" />
+            <View
+              blockInfo={block}
+              className=""
+              isGuestPage={pathname.startsWith('/guest')}
+            />
           </div>
         );
       })}

--- a/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
+++ b/components/organisms/couple-introduction/CoupleIntroductionPreview.tsx
@@ -19,12 +19,14 @@ function pickResolvableImageSource(value: unknown): ResolvableImageSource {
 interface Props extends HTMLAttributes<HTMLDivElement> {
   blockInfo: EditorBlock<'coupleIntroduction'>;
   titleClassName?: string;
+  isGuestPage?: boolean;
 }
 
 function CoupleIntroductionPreview({
   blockInfo,
   className = '',
   titleClassName,
+  isGuestPage = false,
   ...rest
 }: Props) {
   const {
@@ -126,9 +128,11 @@ function CoupleIntroductionPreview({
                 />
               </div>
             ) : (
-              <div className="flex aspect-square w-full items-center justify-center rounded-3xl bg-border-neutral">
-                <p>사진을 추가해 주세요.</p>
-              </div>
+              !isGuestPage && (
+                <div className="flex aspect-square w-full items-center justify-center rounded-3xl bg-border-neutral">
+                  <p>사진을 추가해 주세요.</p>
+                </div>
+              )
             )}
             <p className="text-[16px] font-semibold">
               {profile.name || '성함'}

--- a/components/organisms/gallery/GalleryPreview.tsx
+++ b/components/organisms/gallery/GalleryPreview.tsx
@@ -14,6 +14,7 @@ interface Props {
   blockInfo: EditorBlock<'gallery'>;
   className: string;
   titleClassName?: string;
+  isGuestPage?: boolean;
   onClick: () => void;
 }
 
@@ -21,6 +22,7 @@ function GalleryPreview({
   blockInfo,
   className,
   titleClassName,
+  isGuestPage = false,
   ...rest
 }: Props) {
   const [isOpen, setIsOpen] = useState(false);
@@ -52,7 +54,7 @@ function GalleryPreview({
       titleClassName={titleClassName}
       {...rest}
     >
-      {preview.length === 0 && <ImageDefault />}
+      {preview.length === 0 && !isGuestPage && <ImageDefault />}
       {preview.length !== 0 && (
         <TemplateComponent
           preview={preview}

--- a/components/organisms/myChild/MyChildPreview.tsx
+++ b/components/organisms/myChild/MyChildPreview.tsx
@@ -10,12 +10,14 @@ interface Props {
   className: string;
   titleClassName?: string;
   blockInfo: EditorBlock<'myChild'>;
+  isGuestPage?: boolean;
 }
 
 export const MyChildPreview = ({
   className,
   titleClassName,
   blockInfo,
+  isGuestPage = false,
   ...rest
 }: Props) => {
   const {
@@ -46,6 +48,11 @@ export const MyChildPreview = ({
       childClassName="w-full flex flex-col gap-6"
       {...rest}
     >
+      {!preview && !isGuestPage && (
+        <div className="relative w-full aspect-square overflow-hidden rounded-3xl flex-center bg-border-neutral">
+          <p className="text-text-secondary text-sm">사진을 추가해주세요.</p>
+        </div>
+      )}
       {preview && (
         <div className="relative w-full aspect-square overflow-hidden rounded-3xl">
           <Image src={preview} alt="아기 사진" fill className="object-cover" />

--- a/components/organisms/myFamily/MemberPreview.tsx
+++ b/components/organisms/myFamily/MemberPreview.tsx
@@ -12,15 +12,25 @@ interface Props {
     flower: boolean;
   };
   fontFamily?: CSSProperties['fontFamily'];
+  isGuestPage?: boolean;
 }
 
-export const MemberPreview = ({ member, fontFamily }: Props) => {
+export const MemberPreview = ({
+  member,
+  fontFamily,
+  isGuestPage = false,
+}: Props) => {
   const { image, relation, name, flower } = member;
   const preview = useResolvedImageSource(
     image && image.length > 0 ? image[0] : null
   );
   return (
     <>
+      {!preview && !isGuestPage && (
+        <div className="w-[158.5px] h-[158.5px] rounded-3xl overflow-hidden flex-center bg-border-neutral">
+          <p className="text-text-secondary text-sm">사진을 추가해주세요.</p>
+        </div>
+      )}
       {preview && (
         <div className="w-[158.5px] h-[158.5px] rounded-3xl overflow-hidden">
           <Image src={preview} alt="가족 사진" fill className="object-cover" />

--- a/components/organisms/myFamily/MyFamilyPreview.tsx
+++ b/components/organisms/myFamily/MyFamilyPreview.tsx
@@ -11,12 +11,14 @@ interface Props {
   className: string;
   titleClassName?: string;
   blockInfo: EditorBlock<'myFamily'>;
+  isGuestPage?: boolean;
 }
 
 export const MyFamilyPreview = ({
   className,
   titleClassName,
   blockInfo,
+  isGuestPage = false,
   ...rest
 }: Props) => {
   const {
@@ -49,7 +51,11 @@ export const MyFamilyPreview = ({
             key={index}
             className="flex flex-col items-center gap-4.5 w-[calc(50%-9px)] max-w-[158.5px]"
           >
-            <MemberPreview member={member} fontFamily={bodyFontFamily} />
+            <MemberPreview
+              member={member}
+              fontFamily={bodyFontFamily}
+              isGuestPage={isGuestPage}
+            />
           </div>
         ))}
       </div>

--- a/components/organisms/organizerInfo/OrganizerInformationPreview.tsx
+++ b/components/organisms/organizerInfo/OrganizerInformationPreview.tsx
@@ -12,12 +12,14 @@ interface Props {
   blockInfo: EditorBlock<'organizerInformation'>;
   className: string;
   titleClassName?: string;
+  isGuestPage?: boolean;
 }
 
 export const OrganizerInformationPreview = ({
   blockInfo,
   className,
   titleClassName,
+  isGuestPage = false,
   ...rest
 }: Props) => {
   const {
@@ -56,6 +58,11 @@ export const OrganizerInformationPreview = ({
       childClassName="gap-6"
       {...rest}
     >
+      {!preview && !isGuestPage && (
+        <div className="w-83.75 h-83.75 overflow-hidden rounded-3xl flex-center bg-border-neutral">
+          <p className="text-text-secondary text-sm">사진을 추가해주세요.</p>
+        </div>
+      )}
       {preview && (
         <button
           type="button"

--- a/components/organisms/picture/PictureBlockPreview.tsx
+++ b/components/organisms/picture/PictureBlockPreview.tsx
@@ -13,10 +13,16 @@ interface Props {
   blockInfo: EditorBlock<'picture'>;
   className: string;
   titleClassName?: string;
+  isGuestPage?: boolean;
   onClick: () => void;
 }
 
-function PictureBlockPreview({ blockInfo, className, ...rest }: Props) {
+function PictureBlockPreview({
+  blockInfo,
+  className,
+  isGuestPage = false,
+  ...rest
+}: Props) {
   const preview = useResolvedImageSource(
     blockInfo.props.image && blockInfo.props.image.length > 0
       ? blockInfo.props.image[0]
@@ -46,7 +52,7 @@ function PictureBlockPreview({ blockInfo, className, ...rest }: Props) {
             <PreviewBody html={blockInfo.props.contentsHtml ?? ''} />
           )}
         </div>
-        {!preview && (
+        {!preview && !isGuestPage && (
           <div className="w-full aspect-square flex-center bg-border-neutral rounded-3xl">
             <p className="text-text-secondary text-sm">사진을 추가해주세요.</p>
           </div>

--- a/components/organisms/speakerInformation/InformationPreview.tsx
+++ b/components/organisms/speakerInformation/InformationPreview.tsx
@@ -7,6 +7,7 @@ import { useResolvedImageSource } from '@/shared/hooks/useResolvedImageSource';
 
 export const InformationPreview = ({
   speaker,
+  isGuestPage = false,
 }: {
   speaker: {
     id: string;
@@ -15,6 +16,7 @@ export const InformationPreview = ({
     messageHtml: string | null;
     image: (File | string)[];
   };
+  isGuestPage?: boolean;
 }) => {
   const html =
     speaker.messageHtml ?? tiptapJsonToHtmlUniversal(speaker.messageJson);
@@ -33,12 +35,15 @@ export const InformationPreview = ({
           />
         </div>
       )}
-      {!preview && (
-        <div className="w-83.75 h-83.75 overflow-hidden rounded-3xl border border-dashed border-gray-300 flex items-center justify-center">
+      {!preview && !isGuestPage && (
+        <div className="w-83.75 h-83.75 overflow-hidden rounded-3xl flex-center bg-border-neutral">
           <p className="text-text-secondary text-sm">
             이미지를 업로드해 주세요.
           </p>
         </div>
+      )}
+      {!preview && isGuestPage && (
+        <div className="w-83.75 overflow-hidden rounded-3xl"></div>
       )}
       <p className="w-full px-5 text-center text-[16px] font-semibold">
         {speaker.name}

--- a/components/organisms/speakerInformation/SpeakerInformationPreview.tsx
+++ b/components/organisms/speakerInformation/SpeakerInformationPreview.tsx
@@ -12,12 +12,14 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   blockInfo: EditorBlock<'speakerInformation'>;
   className: string;
   titleClassName?: string;
+  isGuestPage?: boolean;
 }
 
 export const SpeakerInformationPreview = ({
   blockInfo,
   className,
   titleClassName,
+  isGuestPage = false,
   ...rest
 }: Props) => {
   const { title, speakers, checkedEnglishTitle, englishTitle } =
@@ -81,7 +83,7 @@ export const SpeakerInformationPreview = ({
                 (displayItems?.length ?? 0) === 1 && 'flex-center'
               )}
             >
-              <InformationPreview speaker={speaker} />
+              <InformationPreview speaker={speaker} isGuestPage={isGuestPage} />
             </div>
           ))}
         </Carousel>

--- a/components/organisms/sponsorshipInfomation/SposorshipInfomationPreview.tsx
+++ b/components/organisms/sponsorshipInfomation/SposorshipInfomationPreview.tsx
@@ -11,12 +11,14 @@ interface Props {
   blockInfo: EditorBlock<'sponsorshipInfomation'>;
   className: string;
   titleClassName?: string;
+  isGuestPage?: boolean;
   onClick: () => void;
 }
 
 function SponsorshipInfomationPreview({
   blockInfo,
   className,
+  isGuestPage = false,
   ...rest
 }: Props) {
   const preview = useResolvedImageSources(blockInfo.props.images);
@@ -35,12 +37,16 @@ function SponsorshipInfomationPreview({
       koTitleDefault="후원사"
       {...rest}
     >
-      <AutoScrollCarousel className="h-21 w-full" carouselClassName="gap-10">
-        {displayPreview.map((item, index) => (
-          <div
-            key={index}
-            className={`min-w-0 flex-[0_0_26%] rounded-lg ${index === 0 ? 'ml-10' : ''}`}
-          >
+      {(!displayPreview || displayPreview.length === 0) && !isGuestPage && (
+        <div className="w-full flex justify-between">
+          <div className="w-21 h-21 bg-border-neutral rounded-lg" />
+          <div className="w-21 h-21 bg-border-neutral rounded-lg" />
+          <div className="w-21 h-21 bg-border-neutral rounded-lg" />
+        </div>
+      )}
+      {displayPreview.length === 1 &&
+        displayPreview.map((item, index) => (
+          <div key={index} className={`w-21 h-21 flex-center`}>
             <Image
               src={item}
               alt="후원사 로고 이미지"
@@ -49,7 +55,23 @@ function SponsorshipInfomationPreview({
             />
           </div>
         ))}
-      </AutoScrollCarousel>
+      {displayPreview.length > 1 && (
+        <AutoScrollCarousel className="h-21 w-full" carouselClassName="gap-10">
+          {displayPreview.map((item, index) => (
+            <div
+              key={index}
+              className={`min-w-0 flex-[0_0_26%] ${index === 0 ? 'ml-10' : ''}`}
+            >
+              <Image
+                src={item}
+                alt="후원사 로고 이미지"
+                fill
+                className="object-cover rounded-lg"
+              />
+            </div>
+          ))}
+        </AutoScrollCarousel>
+      )}
     </MiddlePreviewWrapper>
   );
 }

--- a/components/organisms/video/VideoPreview.tsx
+++ b/components/organisms/video/VideoPreview.tsx
@@ -13,6 +13,7 @@ import { MiddlePreviewWrapper } from '../wrapper/MiddlePreviewWrapper';
 interface Props extends HTMLAttributes<HTMLDivElement> {
   blockInfo: EditorBlock<'video'>;
   className: string;
+  isGuestPage?: boolean;
 }
 
 const ThemeColor = 'white';
@@ -36,7 +37,12 @@ const ratioVariants = cva('', {
   },
 });
 
-export const VideoPreview = ({ blockInfo, className, ...rest }: Props) => {
+export const VideoPreview = ({
+  blockInfo,
+  className,
+  isGuestPage = false,
+  ...rest
+}: Props) => {
   const {
     image,
     videoUrl,
@@ -69,12 +75,14 @@ export const VideoPreview = ({ blockInfo, className, ...rest }: Props) => {
         )}
       >
         {!embedUrl ? (
-          /* 1. 영상 URL이 없는 경우 */
-          <div className="absolute inset-0 flex items-center justify-center bg-border-neutral">
-            <p className="text-text-secondary text-sm">
-              영상을 업로드해 주세요.
-            </p>
-          </div>
+          !isGuestPage && (
+            /* 1. 영상 URL이 없는 경우 */
+            <div className="absolute inset-0 flex items-center justify-center bg-border-neutral">
+              <p className="text-text-secondary text-sm">
+                영상을 업로드해 주세요.
+              </p>
+            </div>
+          )
         ) : !checkThumbnail ? (
           /* 2. 썸네일 사용 안 함 -> 바로 영상 노출 */
           <iframe


### PR DESCRIPTION
## 작업 개요

- 편집에서 이미지 가이드라인을 발행 페이지에서는 보이지 않도록 수정했습니다.

## 작업 내용

- [x] 게스트 페이지에서 도메인 정보를 컴포넌트로 전달
- [x] 이미지를 사용하는 컴포넌트에서 게스트 페이지에서 디폴트 이미지를 출력하지 않도록 수정
- [x] 아기소개, 가족소개, 주최정보, 후원정보 디폴트 이미지 추가

## 관련 이슈

Closes #

## 테스트 결과 보고

인터뷰/공지사항은 제외


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기능 개선

* **게스트 페이지 모드 추가**
  * 게스트 페이지 여부에 따라 콘텐츠 영역의 편집 안내 UI 표시 제어
  * 사진, 영상, 정보 추가 등의 프롬프트가 게스트 페이지에서는 숨겨짐

<!-- end of auto-generated comment: release notes by coderabbit.ai -->