### PR TITLE
[fix] 에디터 기본 폰트와 발행 화면 스타일 동기화

### DIFF
--- a/components/molecules/preview-text-editor/TextEditorPreview.tsx
+++ b/components/molecules/preview-text-editor/TextEditorPreview.tsx
@@ -11,7 +11,11 @@ import FontColorIcon from '@/shared/assets/icons/color.svg';
 import ItalicIcon from '@/shared/assets/icons/italic.svg';
 import UnderlineIcon from '@/shared/assets/icons/underline.svg';
 import { loadCustomFont } from '@/shared/fonts/fontLoader';
-import { FontFamilyOption, FontWeightOption } from '@/shared/fonts/fontOptions';
+import {
+  FontFamilyOption,
+  FontWeightOption,
+  getDefaultFontFamilyOption,
+} from '@/shared/fonts/fontOptions';
 import { resolveFontFamily } from '@/shared/fonts/fontRegistry';
 import { BulkData } from '@/shared/types/block';
 import { cn } from '@/shared/utils/cn';
@@ -31,7 +35,9 @@ import { useBulkEditor } from './hooks/useBulkEditor';
 
 import type { BulkColorPickerId } from './types';
 
-const DEFAULT_FONT_SIZE_OPTION = FONT_SIZE_OPTIONS[0];
+const DEFAULT_FONT_SIZE_OPTION =
+  FONT_SIZE_OPTIONS.find(option => option.value === '14px') ??
+  FONT_SIZE_OPTIONS[0];
 
 interface TextEditorPreviewProps {
   children: ReactNode;
@@ -48,7 +54,7 @@ const TEXT_ALIGN_OPTIONS: TextAlignOption[] = [
   { label: <AlignLeftIcon />, value: 'left' },
 ];
 
-const DEFAULT_FONT_FAMILY_OPTION = FONT_FAMILY_OPTIONS[0];
+const DEFAULT_FONT_FAMILY_OPTION = getDefaultFontFamilyOption();
 const DEFAULT_TEXT_ALIGN_OPTION = TEXT_ALIGN_OPTIONS[1];
 
 export function TextEditorPreview({

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -10,6 +10,7 @@ import { ChevronDown } from 'lucide-react';
 import React, {
   type CSSProperties,
   useEffect,
+  useCallback,
   useMemo,
   useReducer,
   useRef,
@@ -112,16 +113,31 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       [fontFamilySelected]
     );
 
+    const loadEditorFont = useCallback(
+      async (family: string, weight: string) => {
+        try {
+          await preloadFontFamilyWeights(family);
+          await loadCustomFont(family, weight);
+        } catch (error) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error('Failed to load editor font.', {
+              family,
+              weight,
+              error,
+            });
+          }
+        }
+      },
+      []
+    );
+
     useEffect(() => {
       fontSizeSelectedRef.current = fontSizeSelected;
     }, [fontSizeSelected]);
 
     useEffect(() => {
-      void (async () => {
-        await preloadFontFamilyWeights(fontFamilySelected.value);
-        await loadCustomFont(fontFamilySelected.value, fontWeightSelected.value);
-      })();
-    }, [fontFamilySelected.value, fontWeightSelected.value]);
+      void loadEditorFont(fontFamilySelected.value, fontWeightSelected.value);
+    }, [fontFamilySelected.value, fontWeightSelected.value, loadEditorFont]);
 
     const editorContentStyle = useMemo<CSSProperties>(
       () => ({
@@ -234,8 +250,7 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       setFontWeightSelected(nextWeight);
 
       void (async () => {
-        await preloadFontFamilyWeights(selected.value);
-        await loadCustomFont(selected.value, nextWeight.value);
+        await loadEditorFont(selected.value, nextWeight.value);
 
         editor
           .chain()
@@ -252,7 +267,7 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       const selected = option as FontWeightOption;
       setFontWeightSelected(selected);
       void (async () => {
-        await loadCustomFont(fontFamilySelected.value, selected.value);
+        await loadEditorFont(fontFamilySelected.value, selected.value);
         editor.chain().focus().setFontWeight(selected.value).run();
       })();
     };

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -116,6 +116,30 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       fontSizeSelectedRef.current = fontSizeSelected;
     }, [fontSizeSelected]);
 
+    useEffect(() => {
+      void (async () => {
+        await preloadFontFamilyWeights(fontFamilySelected.value);
+        await loadCustomFont(fontFamilySelected.value, fontWeightSelected.value);
+      })();
+    }, [fontFamilySelected.value, fontWeightSelected.value]);
+
+    const editorContentStyle = useMemo<CSSProperties>(
+      () => ({
+        fontFamily: fontFamilySelected.style?.fontFamily,
+        fontWeight: fontWeightSelected.value,
+        fontSize: fontSizeSelected.value || DEFAULT_FONT_SIZE_OPTION.value,
+        color: selectedColor,
+        textAlign: textAlignSelected.value,
+      }),
+      [
+        fontFamilySelected.style?.fontFamily,
+        fontWeightSelected.value,
+        fontSizeSelected.value,
+        selectedColor,
+        textAlignSelected.value,
+      ]
+    );
+
     const editor = useEditor({
       immediatelyRender: false,
       extensions: createTextEditorBarExtensions(defaultText),
@@ -417,7 +441,7 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
               ? 'border-primary bg-bg-base'
               : 'border-transparent bg-border-neutral'
           )}
-          style={{ textAlign: defaultAlign }}
+          style={editorContentStyle}
         >
           <EditorContent editor={editor} />
         </div>

--- a/components/molecules/text-editor/utils/textEditorOptions.ts
+++ b/components/molecules/text-editor/utils/textEditorOptions.ts
@@ -3,6 +3,7 @@ import {
   createFontWeightOptions as buildFontWeightOptions,
   type FontFamilyOption,
   type FontWeightOption,
+  getDefaultFontFamilyOption,
   getFontFamilyOption,
 } from '@/shared/fonts/fontOptions';
 
@@ -118,6 +119,14 @@ export function getInitialEditorStyles(
               if (!fontFamily && attrs.fontFamily) {
                 fontFamily = getFontFamilyOption(attrs.fontFamily);
               }
+              if (!fontWeight && attrs.fontWeight) {
+                const weightFontFamily =
+                  fontFamily ?? getDefaultFontFamilyOption();
+                fontWeight = findFontWeightOption(
+                  createFontWeightOptions(weightFontFamily),
+                  String(attrs.fontWeight)
+                );
+              }
               if (!fontSize && attrs.fontSize) {
                 fontSize = FONT_SIZE_OPTIONS.find(
                   opt => opt.value === attrs.fontSize
@@ -138,7 +147,7 @@ export function getInitialEditorStyles(
 
   // fontFamily 기본값 결정
   if (!fontFamily) {
-    fontFamily = FONT_FAMILY_OPTIONS[0];
+    fontFamily = getDefaultFontFamilyOption();
   }
 
   // fontWeight는 fontFamily에 따라 결정

--- a/components/molecules/text-editor/utils/textEditorOptions.ts
+++ b/components/molecules/text-editor/utils/textEditorOptions.ts
@@ -56,6 +56,12 @@ export function findFontWeightOption(
   options: FontWeightOption[],
   weight: string
 ): FontWeightOption {
+  if (options.length === 0) {
+    throw new Error(
+      'Font weight options are empty. At least one font weight must be registered.'
+    );
+  }
+
   return options.find(option => option.value === weight) ?? options[0];
 }
 

--- a/shared/data/sample/bulkData.ts
+++ b/shared/data/sample/bulkData.ts
@@ -17,7 +17,7 @@ export const BODY_BULK_DATA: BulkData = {
   font: 'LINESeedKR',
   fontSize: '14px',
   color: '#000000',
-  fontWeight: '500',
+  fontWeight: '400',
   bold: false,
   underline: false,
   italic: false,

--- a/shared/fonts/fontOptions.ts
+++ b/shared/fonts/fontOptions.ts
@@ -67,8 +67,14 @@ export const createFontWeightOptions = (
   }));
 };
 
-export const getDefaultFontFamilyOption = () => {
+export const getDefaultFontFamilyOption = (): FontFamilyOption => {
   const options = createFontFamilyOptions();
+
+  if (options.length === 0) {
+    throw new Error(
+      'Font registry is empty. At least one font family must be registered.'
+    );
+  }
 
   return (
     options.find(option => option.value === DEFAULT_FONT_FAMILY) ?? options[0]

--- a/shared/fonts/fontOptions.ts
+++ b/shared/fonts/fontOptions.ts
@@ -34,6 +34,8 @@ const FONT_WEIGHT_LABELS: Record<string, string> = {
   '900': 'Black',
 };
 
+const DEFAULT_FONT_FAMILY = 'LINESeedKR';
+
 export const getFontWeightLabel = (weight: string) => {
   return FONT_WEIGHT_LABELS[weight] ?? weight;
 };
@@ -66,7 +68,11 @@ export const createFontWeightOptions = (
 };
 
 export const getDefaultFontFamilyOption = () => {
-  return createFontFamilyOptions().find(option => option.value === 'Pretendard');
+  const options = createFontFamilyOptions();
+
+  return (
+    options.find(option => option.value === DEFAULT_FONT_FAMILY) ?? options[0]
+  );
 };
 
 export const getFontFamilyOption = (value?: string | null) => {

--- a/shared/hooks/useBodyFontInfo.ts
+++ b/shared/hooks/useBodyFontInfo.ts
@@ -4,13 +4,13 @@ import { useMemo } from 'react';
 
 import { resolveFontFamily } from '@/shared/fonts/fontRegistry';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
-import { createBulkOverrideStyle } from '@/shared/utils/createBulkOverrideStyle';
+import { toStyle } from '@/shared/utils/toStyle';
 
 export const useBodyFontInfo = () => {
   const bodyData = useEditorStore(state => state.bodyData);
 
   return useMemo(() => {
-    const style = createBulkOverrideStyle(bodyData, 'body');
+    const style = toStyle(bodyData, false);
     const resolvedFontFamily = resolveFontFamily(bodyData.font);
 
     return {

--- a/shared/hooks/useTitleFontInfo.ts
+++ b/shared/hooks/useTitleFontInfo.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 
 import { resolveFontFamily } from '@/shared/fonts/fontRegistry';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
-import { createBulkOverrideStyle } from '@/shared/utils/createBulkOverrideStyle';
+import { toStyle } from '@/shared/utils/toStyle';
 
 export const useTitleFontInfo = () => {
   const titleData = useEditorStore(state => state.titleData);
@@ -15,8 +15,8 @@ export const useTitleFontInfo = () => {
     return {
       font: titleData.font,
       resolvedFontFamily,
-      koStyle: createBulkOverrideStyle(titleData, 'title'),
-      enStyle: createBulkOverrideStyle(titleData, 'title', true),
+      koStyle: toStyle(titleData, true),
+      enStyle: toStyle(titleData, true, true),
     };
   }, [titleData]);
 };


### PR DESCRIPTION
## 작업 개요

에디터 기본 폰트를 LINESeedKR로 정리하고, 발행된 초대장에서도 제목/본문 기본 스타일이 동일하게 적용되도록 수정했습니다.

## 작업 내용

- [x] 텍스트 에디터 기본 폰트/크기/굵기 설정 정리
- [x] 일괄편집 본문 기본값을 LINESeedKR 14px Regular로 맞춤
- [x] 발행 화면에서 본문 기본 스타일이 생략되지 않도록 수정
- [x] 발행 화면에서 제목/소제목 기본 스타일이 생략되지 않도록 수정

## 관련 이슈

Closes #

## 테스트 결과 보고

- 관련 파일 ESLint 통과
- 에디터 및 발행 화면에서 기본 폰트 상속 흐름 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 텍스트 에디터에서 선택된 폰트 스타일(크기, 색상, 정렬)이 제대로 반영되도록 개선했습니다.
  * 기본 폰트 가중치를 500에서 400으로 조정했습니다.

* **Refactor**
  * 기본 폰트 패밀리 설정 로직을 개선하여 일관된 폰트 기본값을 적용하도록 변경했습니다.
  * 폰트 처리 유틸을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->