### PR TITLE
[refactor] Google Drive 권한 누락 시 재동의 플로우 추가

### DIFF
--- a/app/(home)/components/Cta.tsx
+++ b/app/(home)/components/Cta.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import DrivePermissionRequiredModal from '@/features/session/components/DrivePermissionRequiredModal';
 import LoginModal from '@/features/session/components/LoginModal';
 import PrivacyNoticeModal from '@/features/session/components/PrivacyNoticeModal';
 import { useAuthGate } from '@/features/session/hooks/useAuthGate';
@@ -19,9 +20,12 @@ function Cta({ initialIsLoggedIn }: CtaProps) {
     isLoginOpen,
     isLoginPending,
     isPrivacyNoticeOpen,
+    isDrivePermissionRequiredOpen,
     closeLogin,
     closePrivacyNotice,
+    closeDrivePermissionRequired,
     loginWithGoogle,
+    retryDrivePermission,
     runAfterAuth,
   } = useAuthGate({ initialIsLoggedIn });
 
@@ -85,6 +89,12 @@ function Cta({ initialIsLoggedIn }: CtaProps) {
       <PrivacyNoticeModal
         open={isPrivacyNoticeOpen}
         onClose={closePrivacyNotice}
+      />
+      <DrivePermissionRequiredModal
+        open={isDrivePermissionRequiredOpen}
+        isLoading={isLoginPending}
+        onClose={closeDrivePermissionRequired}
+        onRetry={retryDrivePermission}
       />
     </>
   );

--- a/app/(home)/components/useAuthGate.test.tsx
+++ b/app/(home)/components/useAuthGate.test.tsx
@@ -22,16 +22,21 @@ describe('useAuthGate', () => {
   const mockFetch = jest.fn();
   const mockPopupFocus = jest.fn();
   const mockPopupClose = jest.fn();
+  let mockPopupClosed = false;
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     global.fetch = mockFetch as unknown as typeof fetch;
+    mockPopupClosed = false;
 
     window.open = jest.fn(() => {
       return {
         focus: mockPopupFocus,
         close: mockPopupClose,
+        get closed() {
+          return mockPopupClosed;
+        },
       } as unknown as Window;
     });
   });
@@ -119,6 +124,7 @@ describe('useAuthGate', () => {
     });
 
     expect(result.current.isLoginPending).toBe(true);
+    mockPopupClosed = true;
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));
@@ -131,8 +137,10 @@ describe('useAuthGate', () => {
       });
     });
 
-    expect(result.current.isLoginPending).toBe(false);
-    expect(result.current.isLoginOpen).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isLoginPending).toBe(false);
+      expect(result.current.isLoginOpen).toBe(false);
+    });
   });
 
   it('clears popup and modal state when closeLogin is called while login is pending', async () => {
@@ -229,6 +237,66 @@ describe('useAuthGate', () => {
     expect(action).toHaveBeenCalledTimes(1);
     expect(result.current.isPrivacyNoticeOpen).toBe(false);
     expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('opens Drive permission modal and preserves pending action when Drive scope is missing', async () => {
+    const action = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAuthGate({ initialIsLoggedIn: false })
+    );
+
+    act(() => {
+      result.current.runAfterAuth(action);
+    });
+
+    act(() => {
+      result.current.closePrivacyNotice();
+    });
+
+    act(() => {
+      result.current.loginWithGoogle();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            type: 'GOOGLE_OAUTH_ERROR',
+            reason: 'missing_drive_scope',
+          },
+        })
+      );
+    });
+
+    expect(result.current.isLoginPending).toBe(false);
+    expect(result.current.isLoginOpen).toBe(false);
+    expect(result.current.isDrivePermissionRequiredOpen).toBe(true);
+    expect(action).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.retryDrivePermission();
+    });
+
+    expect(window.open).toHaveBeenCalledTimes(2);
+    expect(result.current.isDrivePermissionRequiredOpen).toBe(false);
+    expect(result.current.isLoginPending).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: { type: 'GOOGLE_OAUTH_SUCCESS' },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoggedIn).toBe(true);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
   });
 
   it('only the hook instance with an OAuth popup handles the success message', async () => {

--- a/app/api/auth/_lib/getAuthSession.ts
+++ b/app/api/auth/_lib/getAuthSession.ts
@@ -1,10 +1,13 @@
 import 'server-only';
 import { cookies } from 'next/headers';
 
+import { hasRequiredDriveScope } from '@/app/api/auth/_lib/googleScopes';
+
 export type AuthSession = {
   isLoggedIn: boolean;
   hasAccessToken: boolean;
   hasRefreshToken: boolean;
+  hasRequiredDriveScope: boolean;
 };
 
 export async function getAuthSession(): Promise<AuthSession> {
@@ -12,10 +15,14 @@ export async function getAuthSession(): Promise<AuthSession> {
 
   const hasAccessToken = Boolean(cookieStore.get('access_token')?.value);
   const hasRefreshToken = Boolean(cookieStore.get('refresh_token')?.value);
+  const hasRequiredScope = hasRequiredDriveScope(
+    cookieStore.get('granted_scopes')?.value
+  );
 
   return {
-    isLoggedIn: hasRefreshToken || hasAccessToken,
+    isLoggedIn: hasRefreshToken && hasRequiredScope,
     hasAccessToken,
     hasRefreshToken,
+    hasRequiredDriveScope: hasRequiredScope,
   };
 }

--- a/app/api/auth/_lib/googleScopes.ts
+++ b/app/api/auth/_lib/googleScopes.ts
@@ -1,0 +1,16 @@
+export const GOOGLE_DRIVE_FILE_SCOPE =
+  'https://www.googleapis.com/auth/drive.file';
+
+export const GOOGLE_AUTH_SCOPE = `openid ${GOOGLE_DRIVE_FILE_SCOPE}`;
+
+export function parseGrantedScopes(scope: unknown): Set<string> {
+  if (typeof scope !== 'string') {
+    return new Set();
+  }
+
+  return new Set(scope.split(/\s+/).filter(Boolean));
+}
+
+export function hasRequiredDriveScope(scope: unknown): boolean {
+  return parseGrantedScopes(scope).has(GOOGLE_DRIVE_FILE_SCOPE);
+}

--- a/app/api/auth/_lib/tokenRefresh.ts
+++ b/app/api/auth/_lib/tokenRefresh.ts
@@ -27,5 +27,6 @@ export async function tokenRefresh(refreshToken: string) {
     accessToken: data.access_token as string,
     expiresAt: Date.now() + Number(data.expires_in) * 1000,
     refreshToken: (data.refresh_token as string | undefined) ?? undefined,
+    scope: (data.scope as string | undefined) ?? undefined,
   };
 }

--- a/app/api/auth/callback/route.test.ts
+++ b/app/api/auth/callback/route.test.ts
@@ -111,6 +111,7 @@ describe('auth callback Route Handler 테스트', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toContain('text/html');
     expect(html).toContain('GOOGLE_OAUTH_ERROR');
+    expect(html).toContain('"reason":"access_denied"');
     expect(html).toContain('로그인이 취소되었습니다. 창을 닫는 중...');
     expect(cookieStore.set).toHaveBeenCalledWith('oauth_state', '', {
       path: '/',
@@ -239,6 +240,7 @@ describe('auth callback Route Handler 테스트', () => {
         access_token: 'new-access-token',
         refresh_token: 'new-refresh-token',
         expires_in: 3600,
+        scope: 'openid https://www.googleapis.com/auth/drive.file',
       }),
     });
 
@@ -305,6 +307,17 @@ describe('auth callback Route Handler 테스트', () => {
       })
     );
 
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'granted_scopes',
+      'openid https://www.googleapis.com/auth/drive.file',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 180,
+      })
+    );
+
     /**
      * 최종 응답은 팝업 닫기용 HTML
      */
@@ -312,6 +325,50 @@ describe('auth callback Route Handler 테스트', () => {
     expect(res.headers.get('Content-Type')).toContain('text/html');
     expect(html).toContain('로그인 성공! 창을 닫는 중...');
     expect(html).toContain('GOOGLE_OAUTH_SUCCESS');
+  });
+
+  it('Drive scope가 없으면 로그인 실패로 처리한다', async () => {
+    const cookieStore = createCookieStore({
+      oauth_state: 'matched-state',
+      pkce_code_verifier: 'verifier-abc',
+    });
+
+    (cookies as jest.Mock).mockResolvedValue(cookieStore);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+        scope: 'openid',
+      }),
+    });
+
+    const req = new Request(
+      'http://localhost:3000/api/auth/callback?code=auth-code-3&state=matched-state',
+      {
+        method: 'GET',
+      }
+    );
+
+    const res = await GET(req);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('GOOGLE_OAUTH_ERROR');
+    expect(html).toContain('"reason":"missing_drive_scope"');
+    expect(html).toContain('Google Drive');
+    expect(cookieStore.set).toHaveBeenCalledWith('access_token', '', {
+      path: '/',
+      maxAge: 0,
+    });
+    expect(cookieStore.set).not.toHaveBeenCalledWith(
+      'access_token',
+      'new-access-token',
+      expect.anything()
+    );
   });
 
   it('token 교환 실패 시 Google 응답 status/json을 그대로 반환한다', async () => {

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,17 +1,26 @@
 ﻿import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
+import { hasRequiredDriveScope } from '@/app/api/auth/_lib/googleScopes';
+
 function oauthPopupResponse({
   messageType,
+  reason,
   origin,
   title,
   body,
 }: {
   messageType: 'GOOGLE_OAUTH_SUCCESS' | 'GOOGLE_OAUTH_ERROR';
+  reason?: 'access_denied' | 'missing_drive_scope';
   origin: string;
   title: string;
   body: string;
 }) {
+  const payload = JSON.stringify({
+    type: messageType,
+    ...(reason ? { reason } : {}),
+  });
+
   const html = `<!doctype html>
 <html>
   <head>
@@ -28,7 +37,7 @@ function oauthPopupResponse({
       (function () {
         try {
           if (window.opener) {
-            window.opener.postMessage({ type: '${messageType}' }, '${origin}');
+            window.opener.postMessage(${payload}, '${origin}');
           }
         } catch (e) {}
         window.close();
@@ -40,6 +49,12 @@ function oauthPopupResponse({
   return new NextResponse(html, {
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });
+}
+
+function clearAuthCookies(cookieStore: Awaited<ReturnType<typeof cookies>>) {
+  cookieStore.set('access_token', '', { path: '/', maxAge: 0 });
+  cookieStore.set('refresh_token', '', { path: '/', maxAge: 0 });
+  cookieStore.set('granted_scopes', '', { path: '/', maxAge: 0 });
 }
 
 export async function GET(request: Request) {
@@ -55,6 +70,7 @@ export async function GET(request: Request) {
 
     return oauthPopupResponse({
       messageType: 'GOOGLE_OAUTH_ERROR',
+      reason: 'access_denied',
       origin,
       title: '로그인 취소',
       body: '로그인이 취소되었습니다. 창을 닫는 중...',
@@ -106,6 +122,18 @@ export async function GET(request: Request) {
       return NextResponse.json(tokenData, { status: tokenResponse.status });
     }
 
+    if (!hasRequiredDriveScope(tokenData.scope) || !tokenData.refresh_token) {
+      clearAuthCookies(cookieStore);
+
+      return oauthPopupResponse({
+        messageType: 'GOOGLE_OAUTH_ERROR',
+        reason: 'missing_drive_scope',
+        origin,
+        title: 'Google Drive 권한 필요',
+        body: 'Google Drive 권한이 필요합니다. 권한을 모두 허용한 뒤 다시 로그인해 주세요.',
+      });
+    }
+
     // 브라우저에 쿠키 심기.
     const isProd = process.env.NODE_ENV === 'production';
 
@@ -118,16 +146,22 @@ export async function GET(request: Request) {
       maxAge: tokenData.expires_in,
     });
 
+    cookieStore.set('granted_scopes', tokenData.scope, {
+      httpOnly: true,
+      secure: isProd,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 180,
+    });
+
     // Refresh Token 저장
-    if (tokenData.refresh_token) {
-      cookieStore.set('refresh_token', tokenData.refresh_token, {
-        httpOnly: true,
-        secure: isProd,
-        sameSite: 'lax',
-        path: '/',
-        maxAge: 60 * 60 * 24 * 180, // 180일
-      });
-    }
+    cookieStore.set('refresh_token', tokenData.refresh_token, {
+      httpOnly: true,
+      secure: isProd,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 180, // 180일
+    });
 
     return oauthPopupResponse({
       messageType: 'GOOGLE_OAUTH_SUCCESS',

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -177,6 +177,7 @@ describe('auth login Route Handler 테스트', () => {
     expect(redirectUrl.searchParams.get('response_type')).toBe('code');
     expect(redirectUrl.searchParams.get('access_type')).toBe('offline');
     expect(redirectUrl.searchParams.get('prompt')).toBe('consent');
+    expect(redirectUrl.searchParams.get('include_granted_scopes')).toBe('true');
     expect(redirectUrl.searchParams.get('scope')).toBe(
       'openid https://www.googleapis.com/auth/drive.file'
     );

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { generateOAuthState } from '@/app/api/auth/_lib/generateOAuthState';
+import { GOOGLE_AUTH_SCOPE } from '@/app/api/auth/_lib/googleScopes';
 import {
   generateCodeVerifier,
   generateCodeChallenge,
@@ -48,10 +49,8 @@ export async function GET(request: Request) {
   authUrl.searchParams.set('response_type', 'code');
   authUrl.searchParams.set('access_type', 'offline');
   authUrl.searchParams.set('prompt', 'consent');
-  authUrl.searchParams.set(
-    'scope',
-    'openid https://www.googleapis.com/auth/drive.file'
-  );
+  authUrl.searchParams.set('include_granted_scopes', 'true');
+  authUrl.searchParams.set('scope', GOOGLE_AUTH_SCOPE);
   authUrl.searchParams.set('state', state);
   authUrl.searchParams.set('code_challenge', codeChallenge);
   authUrl.searchParams.set('code_challenge_method', 'S256');

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -14,5 +14,10 @@ export async function POST() {
     maxAge: 0,
   });
 
+  cookieStore.set('granted_scopes', '', {
+    path: '/',
+    maxAge: 0,
+  });
+
   return NextResponse.json({ ok: true });
 }

--- a/app/api/auth/session/route.test.ts
+++ b/app/api/auth/session/route.test.ts
@@ -154,6 +154,44 @@ describe('auth session Route Handler 테스트', () => {
     expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 
+  it('refresh token은 있지만 granted_scopes가 없으면 쿠키를 정리하고 비로그인 상태를 반환한다', async () => {
+    const cookieStore = createCookieStore({
+      access_token: undefined,
+      refresh_token: 'refresh-token-value',
+      granted_scopes: undefined,
+    });
+
+    (cookies as jest.Mock).mockResolvedValue(cookieStore);
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(tokenRefresh).not.toHaveBeenCalled();
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'refresh_token',
+      '',
+      expect.objectContaining({
+        path: '/',
+        maxAge: 0,
+      })
+    );
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'granted_scopes',
+      '',
+      expect.objectContaining({
+        path: '/',
+        maxAge: 0,
+      })
+    );
+    expect(json).toEqual({
+      isLoggedIn: false,
+      hasAccessToken: false,
+      hasRefreshToken: false,
+      hasRequiredDriveScope: false,
+    });
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
   it('refresh token만 있고 refresh에 성공하면 access token을 재설정하고 로그인 상태를 반환한다', async () => {
     /**
      * 목적:
@@ -220,6 +258,63 @@ describe('auth session Route Handler 테스트', () => {
       })
     );
 
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('refresh 후 Drive scope가 빠진 scope가 내려오면 쿠키를 정리하고 비로그인 상태를 반환한다', async () => {
+    const cookieStore = createCookieStore({
+      access_token: undefined,
+      refresh_token: 'refresh-token-value',
+      granted_scopes: 'openid https://www.googleapis.com/auth/drive.file',
+    });
+
+    (cookies as jest.Mock).mockResolvedValue(cookieStore);
+
+    (tokenRefresh as jest.Mock).mockResolvedValue({
+      accessToken: 'new-access-token',
+      expiresAt: Date.UTC(2026, 2, 21, 12, 0, 0),
+      scope: 'openid',
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(tokenRefresh).toHaveBeenCalledWith('refresh-token-value');
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'access_token',
+      '',
+      expect.objectContaining({
+        path: '/',
+        maxAge: 0,
+      })
+    );
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'refresh_token',
+      '',
+      expect.objectContaining({
+        path: '/',
+        maxAge: 0,
+      })
+    );
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'granted_scopes',
+      '',
+      expect.objectContaining({
+        path: '/',
+        maxAge: 0,
+      })
+    );
+    expect(cookieStore.set).not.toHaveBeenCalledWith(
+      'access_token',
+      'new-access-token',
+      expect.anything()
+    );
+    expect(json).toEqual({
+      isLoggedIn: false,
+      hasAccessToken: false,
+      hasRefreshToken: false,
+      hasRequiredDriveScope: false,
+    });
     expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 

--- a/app/api/auth/session/route.test.ts
+++ b/app/api/auth/session/route.test.ts
@@ -94,6 +94,7 @@ describe('auth session Route Handler 테스트', () => {
     const cookieStore = createCookieStore({
       access_token: 'access-token-value',
       refresh_token: 'refresh-token-value',
+      granted_scopes: 'openid https://www.googleapis.com/auth/drive.file',
     });
 
     (cookies as jest.Mock).mockResolvedValue(cookieStore);
@@ -106,6 +107,7 @@ describe('auth session Route Handler 테스트', () => {
       isLoggedIn: true,
       hasAccessToken: true,
       hasRefreshToken: true,
+      hasRequiredDriveScope: true,
     });
 
     /**
@@ -141,6 +143,7 @@ describe('auth session Route Handler 테스트', () => {
       isLoggedIn: false,
       hasAccessToken: false,
       hasRefreshToken: false,
+      hasRequiredDriveScope: false,
     });
 
     /**
@@ -161,6 +164,7 @@ describe('auth session Route Handler 테스트', () => {
     const cookieStore = createCookieStore({
       access_token: undefined,
       refresh_token: 'refresh-token-value',
+      granted_scopes: 'openid https://www.googleapis.com/auth/drive.file',
     });
 
     (cookies as jest.Mock).mockResolvedValue(cookieStore);
@@ -186,6 +190,7 @@ describe('auth session Route Handler 테스트', () => {
       isLoggedIn: true,
       hasAccessToken: true,
       hasRefreshToken: true,
+      hasRequiredDriveScope: true,
     });
 
     /**
@@ -229,6 +234,7 @@ describe('auth session Route Handler 테스트', () => {
     const cookieStore = createCookieStore({
       access_token: undefined,
       refresh_token: 'expired-refresh-token',
+      granted_scopes: 'openid https://www.googleapis.com/auth/drive.file',
     });
 
     (cookies as jest.Mock).mockResolvedValue(cookieStore);
@@ -272,6 +278,7 @@ describe('auth session Route Handler 테스트', () => {
       isLoggedIn: false,
       hasAccessToken: false,
       hasRefreshToken: false,
+      hasRequiredDriveScope: false,
     });
 
     expect(res.headers.get('Cache-Control')).toBe('no-store');

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -2,18 +2,21 @@ import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import type { AuthSession } from '@/app/api/auth/_lib/getAuthSession';
+import { hasRequiredDriveScope } from '@/app/api/auth/_lib/googleScopes';
 import { tokenRefresh } from '@/app/api/auth/_lib/tokenRefresh';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' };
 
 function buildSession(
   hasAccessToken: boolean,
-  hasRefreshToken: boolean
+  hasRefreshToken: boolean,
+  hasRequiredScope: boolean
 ): AuthSession {
   return {
-    isLoggedIn: hasAccessToken || hasRefreshToken,
+    isLoggedIn: hasRefreshToken && hasRequiredScope,
     hasAccessToken,
     hasRefreshToken,
+    hasRequiredDriveScope: hasRequiredScope,
   };
 }
 
@@ -26,27 +29,48 @@ function clearAuthCookies(cookieStore: Awaited<ReturnType<typeof cookies>>) {
     path: '/',
     maxAge: 0,
   });
+  cookieStore.set('granted_scopes', '', {
+    path: '/',
+    maxAge: 0,
+  });
 }
 
 export async function GET() {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('access_token')?.value;
   const refreshToken = cookieStore.get('refresh_token')?.value;
+  const grantedScopes = cookieStore.get('granted_scopes')?.value;
+  const hasRequiredScope = hasRequiredDriveScope(grantedScopes);
 
-  if (accessToken) {
-    return NextResponse.json(buildSession(true, Boolean(refreshToken)), {
+  if (!refreshToken || !hasRequiredScope) {
+    if (accessToken || refreshToken || grantedScopes) {
+      clearAuthCookies(cookieStore);
+    }
+
+    return NextResponse.json(buildSession(false, false, false), {
       headers: NO_STORE_HEADERS,
     });
   }
 
-  if (!refreshToken) {
-    return NextResponse.json(buildSession(false, false), {
+  if (accessToken) {
+    return NextResponse.json(buildSession(true, true, true), {
       headers: NO_STORE_HEADERS,
     });
   }
 
   try {
     const refreshed = await tokenRefresh(refreshToken);
+
+    if (
+      refreshed.scope !== undefined &&
+      !hasRequiredDriveScope(refreshed.scope)
+    ) {
+      clearAuthCookies(cookieStore);
+
+      return NextResponse.json(buildSession(false, false, false), {
+        headers: NO_STORE_HEADERS,
+      });
+    }
 
     cookieStore.set('access_token', refreshed.accessToken, {
       httpOnly: true,
@@ -66,13 +90,23 @@ export async function GET() {
       });
     }
 
-    return NextResponse.json(buildSession(true, true), {
+    if (refreshed.scope) {
+      cookieStore.set('granted_scopes', refreshed.scope, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 180,
+      });
+    }
+
+    return NextResponse.json(buildSession(true, true, true), {
       headers: NO_STORE_HEADERS,
     });
   } catch {
     clearAuthCookies(cookieStore);
 
-    return NextResponse.json(buildSession(false, false), {
+    return NextResponse.json(buildSession(false, false, false), {
       headers: NO_STORE_HEADERS,
     });
   }

--- a/app/api/drive/_lib/getFreshAccessToken.test.ts
+++ b/app/api/drive/_lib/getFreshAccessToken.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+
+import { getFreshAccessToken } from '@/app/api/drive/_lib/getFreshAccessToken';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock('@/app/api/auth/_lib/tokenRefresh', () => ({
+  tokenRefresh: jest.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { tokenRefresh } from '@/app/api/auth/_lib/tokenRefresh';
+
+type MockCookieStore = {
+  get: jest.Mock;
+  set: jest.Mock;
+};
+
+function createCookieStore(values: Record<string, string | undefined>) {
+  const store: MockCookieStore = {
+    get: jest.fn((key: string) => {
+      const value = values[key];
+      return value ? { value } : undefined;
+    }),
+    set: jest.fn(),
+  };
+
+  return store;
+}
+
+describe('getFreshAccessToken', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('clears granted_scopes and rejects when refreshed scope no longer includes Drive access', async () => {
+    const cookieStore = createCookieStore({
+      refresh_token: 'refresh-token-value',
+      granted_scopes: 'openid https://www.googleapis.com/auth/drive.file',
+    });
+
+    (cookies as jest.Mock).mockResolvedValue(cookieStore);
+    (tokenRefresh as jest.Mock).mockResolvedValue({
+      accessToken: 'new-access-token',
+      expiresAt: Date.UTC(2026, 2, 21, 12, 0, 0),
+      scope: 'openid',
+    });
+
+    await expect(getFreshAccessToken()).rejects.toThrow('auth_required');
+
+    expect(tokenRefresh).toHaveBeenCalledWith('refresh-token-value');
+    expect(cookieStore.set).toHaveBeenCalledWith('granted_scopes', '', {
+      path: '/',
+      maxAge: 0,
+    });
+    expect(cookieStore.set).not.toHaveBeenCalledWith(
+      'access_token',
+      'new-access-token',
+      expect.anything()
+    );
+  });
+});

--- a/app/api/drive/_lib/getFreshAccessToken.ts
+++ b/app/api/drive/_lib/getFreshAccessToken.ts
@@ -24,11 +24,22 @@ export async function getFreshAccessToken(): Promise<{
   try {
     const refreshed = await tokenRefresh(refreshToken);
 
-    if (
-      refreshed.scope !== undefined &&
-      !hasRequiredDriveScope(refreshed.scope)
-    ) {
-      throw new Error('auth_required');
+    if (refreshed.scope !== undefined) {
+      if (!hasRequiredDriveScope(refreshed.scope)) {
+        cookieStore.set('granted_scopes', '', {
+          path: '/',
+          maxAge: 0,
+        });
+        throw new Error('auth_required');
+      }
+
+      cookieStore.set('granted_scopes', refreshed.scope, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 180,
+      });
     }
 
     cookieStore.set('access_token', refreshed.accessToken, {
@@ -41,16 +52,6 @@ export async function getFreshAccessToken(): Promise<{
 
     if (refreshed.refreshToken) {
       cookieStore.set('refresh_token', refreshed.refreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        path: '/',
-        maxAge: 60 * 60 * 24 * 180,
-      });
-    }
-
-    if (refreshed.scope) {
-      cookieStore.set('granted_scopes', refreshed.scope, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',

--- a/app/api/drive/_lib/getFreshAccessToken.ts
+++ b/app/api/drive/_lib/getFreshAccessToken.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { cookies } from 'next/headers';
 
+import { hasRequiredDriveScope } from '@/app/api/auth/_lib/googleScopes';
 import { tokenRefresh } from '@/app/api/auth/_lib/tokenRefresh';
 
 /**
@@ -14,13 +15,21 @@ export async function getFreshAccessToken(): Promise<{
 }> {
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get('refresh_token')?.value;
+  const grantedScopes = cookieStore.get('granted_scopes')?.value;
 
-  if (!refreshToken) {
+  if (!refreshToken || !hasRequiredDriveScope(grantedScopes)) {
     throw new Error('auth_required');
   }
 
   try {
     const refreshed = await tokenRefresh(refreshToken);
+
+    if (
+      refreshed.scope !== undefined &&
+      !hasRequiredDriveScope(refreshed.scope)
+    ) {
+      throw new Error('auth_required');
+    }
 
     cookieStore.set('access_token', refreshed.accessToken, {
       httpOnly: true,
@@ -32,6 +41,16 @@ export async function getFreshAccessToken(): Promise<{
 
     if (refreshed.refreshToken) {
       cookieStore.set('refresh_token', refreshed.refreshToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 180,
+      });
+    }
+
+    if (refreshed.scope) {
+      cookieStore.set('granted_scopes', refreshed.scope, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',

--- a/features/session/components/DrivePermissionRequiredModal.tsx
+++ b/features/session/components/DrivePermissionRequiredModal.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import InviaSimpleLogo3d from '@/shared/assets/logo/invia-simple-logo-3d.png';
+import {
+  trapFocus,
+  disableBodyScroll,
+  getHiddenRoot,
+  removeHiddenRoot,
+} from '@/shared/utils/focusTrap';
+
+type DrivePermissionRequiredModalProps = {
+  open: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onRetry: () => void;
+};
+
+const FADE_OUT_MS = 180;
+
+function DrivePermissionRequiredModal({
+  open,
+  isLoading,
+  onClose,
+  onRetry,
+}: DrivePermissionRequiredModalProps) {
+  const [isClosing, setIsClosing] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const retryButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeWithFade = useCallback(() => {
+    if (isClosing || isLoading) return;
+
+    setIsClosing(true);
+    window.setTimeout(() => {
+      onClose();
+      setIsClosing(false);
+    }, FADE_OUT_MS);
+  }, [isClosing, isLoading, onClose]);
+
+  useEffect(() => {
+    if (!open || isClosing) return;
+
+    const enableRestore = disableBodyScroll();
+    getHiddenRoot();
+
+    const timer = setTimeout(() => {
+      retryButtonRef.current?.focus();
+    }, 0);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeWithFade();
+      }
+      if (modalRef.current) {
+        trapFocus(e, modalRef.current);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('keydown', handleKeyDown);
+      enableRestore();
+      removeHiddenRoot();
+    };
+  }, [open, isClosing, closeWithFade]);
+
+  if (!open && !isClosing) return null;
+
+  return createPortal(
+    <div
+      ref={modalRef}
+      className={`fixed inset-0 z-9999 flex items-center justify-center transition-opacity duration-200 ${
+        isClosing ? 'opacity-0' : 'animate-[fade-in_180ms_ease-out] opacity-100'
+      }`}
+      onClick={closeWithFade}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="drive-permission-title"
+      tabIndex={-1}
+    >
+      <div className="absolute inset-0 bg-[rgb(0_0_0_/_8%)]" />
+
+      <div
+        className={`relative flex w-[min(392px,calc(100vw-40px))] flex-col items-center gap-5 rounded-xl border border-white/22 bg-white/72 p-5 text-center shadow-[0_24px_60px_-20px_rgb(0_0_0_/_12%),0_8px_24px_-8px_rgb(0_0_0_/_18%),0_1px_8px_-2px_rgb(255_255_255_/_35%)] backdrop-blur-xl transition-all duration-200 ${
+          isClosing
+            ? 'scale-[0.98] opacity-0'
+            : 'animate-[fade-in_180ms_ease-out] scale-100 opacity-100'
+        }`}
+        onClick={e => e.stopPropagation()}
+      >
+        <Image
+          src={InviaSimpleLogo3d}
+          alt="Invia"
+          width={92}
+          height={92}
+          className="block h-[92px] w-[92px] shrink-0"
+          priority
+        />
+
+        <div className="flex flex-col gap-2">
+          <h2
+            id="drive-permission-title"
+            className="text-[20px] font-bold leading-7 text-[#121212]"
+          >
+            Google Drive 권한이 필요해요
+          </h2>
+          <p className="text-[14px] font-medium leading-5 text-[#4b5563]">
+            초대장을 저장하려면 Drive 권한이 필요합니다.
+            <br />
+            다음 Google 화면에서 확인을 눌러 주세요.
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col gap-2">
+          <button
+            ref={retryButtonRef}
+            type="button"
+            onClick={onRetry}
+            disabled={isLoading}
+            className="h-11 w-full cursor-pointer rounded-lg bg-[#121212] px-4 text-[15px] font-semibold text-white transition-colors enabled:hover:bg-[#202020] enabled:active:bg-[#0D0D0D] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoading ? '권한 요청 중...' : '다시 권한 허용하기'}
+          </button>
+          <button
+            type="button"
+            onClick={closeWithFade}
+            disabled={isLoading}
+            className="h-10 w-full cursor-pointer rounded-lg text-[14px] font-medium text-[#4b5563] transition-colors enabled:hover:bg-white/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default DrivePermissionRequiredModal;

--- a/features/session/components/HeaderAuthControl.tsx
+++ b/features/session/components/HeaderAuthControl.tsx
@@ -6,6 +6,7 @@ import { useAuthGate } from '@/features/session/hooks/useAuthGate';
 import { useConfirm } from '@/shared/hooks/useConfirm';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 
+import DrivePermissionRequiredModal from './DrivePermissionRequiredModal';
 import LoginModal from './LoginModal';
 import PrivacyNoticeModal from './PrivacyNoticeModal';
 
@@ -26,10 +27,13 @@ function HeaderAuthControl({ initialIsLoggedIn }: HeaderAuthControlProps) {
     isLoginOpen,
     isLoginPending,
     isPrivacyNoticeOpen,
+    isDrivePermissionRequiredOpen,
     login,
     closeLogin,
     closePrivacyNotice,
+    closeDrivePermissionRequired,
     loginWithGoogle,
+    retryDrivePermission,
     logout,
     runAfterAuth,
   } = useAuthGate({ initialIsLoggedIn });
@@ -47,6 +51,12 @@ function HeaderAuthControl({ initialIsLoggedIn }: HeaderAuthControlProps) {
       <PrivacyNoticeModal
         open={isPrivacyNoticeOpen}
         onClose={closePrivacyNotice}
+      />
+      <DrivePermissionRequiredModal
+        open={isDrivePermissionRequiredOpen}
+        isLoading={isLoginPending}
+        onClose={closeDrivePermissionRequired}
+        onRetry={retryDrivePermission}
       />
     </>
   );

--- a/features/session/hooks/useAuthGate.ts
+++ b/features/session/hooks/useAuthGate.ts
@@ -13,6 +13,11 @@ type SessionResponse = {
   isLoggedIn: boolean;
 };
 
+type GoogleOAuthMessage = {
+  type?: 'GOOGLE_OAUTH_SUCCESS' | 'GOOGLE_OAUTH_ERROR';
+  reason?: 'access_denied' | 'missing_drive_scope';
+};
+
 function openGoogleLoginPopup() {
   const width = 480;
   const height = 640;
@@ -55,6 +60,8 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const [isLoginPending, setIsLoginPending] = useState(false);
   const [isPrivacyNoticeOpen, setIsPrivacyNoticeOpen] = useState(false);
+  const [isDrivePermissionRequiredOpen, setIsDrivePermissionRequiredOpen] =
+    useState(false);
 
   const popupRef = useRef<Window | null>(null);
   const pendingActionRef = useRef<(() => void | Promise<void>) | null>(null);
@@ -70,6 +77,7 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
     popupRef.current = null;
     setIsLoginPending(false);
     setIsLoginOpen(false);
+    setIsDrivePermissionRequiredOpen(false);
     pendingActionRef.current = null;
     openLoginAfterNoticeRef.current = false;
 
@@ -86,6 +94,7 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
     popupRef.current = null;
     setIsLoginPending(false);
     setIsLoginOpen(false);
+    setIsDrivePermissionRequiredOpen(false);
     setIsLoggedIn(true);
 
     success('로그인에 성공했습니다.');
@@ -122,12 +131,22 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
       if (event.origin !== window.location.origin) return;
       if (!popupRef.current) return;
 
-      if (event.data?.type === 'GOOGLE_OAUTH_SUCCESS') {
+      const message = event.data as GoogleOAuthMessage;
+
+      if (message.type === 'GOOGLE_OAUTH_SUCCESS') {
         completeLoginSuccess();
         return;
       }
 
-      if (event.data?.type === 'GOOGLE_OAUTH_ERROR') {
+      if (message.type === 'GOOGLE_OAUTH_ERROR') {
+        if (message.reason === 'missing_drive_scope') {
+          popupRef.current = null;
+          setIsLoginPending(false);
+          setIsLoginOpen(false);
+          setIsDrivePermissionRequiredOpen(true);
+          return;
+        }
+
         clearLoginAttempt();
       }
     };
@@ -149,7 +168,16 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
         console.error(err);
       }
 
-      releaseLoginPending();
+      const popup = popupRef.current;
+      if (popup && !popup.closed) {
+        return;
+      }
+
+      window.setTimeout(() => {
+        if (popupRef.current?.closed) {
+          releaseLoginPending();
+        }
+      }, 250);
     };
 
     window.addEventListener('focus', handleFocus);
@@ -178,6 +206,17 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
     }
   };
 
+  const closeDrivePermissionRequired = () => {
+    pendingActionRef.current = null;
+    setIsDrivePermissionRequiredOpen(false);
+    setIsLoginPending(false);
+  };
+
+  const retryDrivePermission = () => {
+    setIsDrivePermissionRequiredOpen(false);
+    loginWithGoogle();
+  };
+
   const validateSession = async () => {
     try {
       const isSessionValid = await fetchSessionState();
@@ -188,6 +227,7 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
         setIsLoggedIn(false);
         setIsLoginOpen(false);
         setIsPrivacyNoticeOpen(false);
+        setIsDrivePermissionRequiredOpen(false);
         router.replace('/');
         router.refresh();
         return false;
@@ -213,6 +253,7 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
 
       setIsLoggedIn(false);
       setIsPrivacyNoticeOpen(false);
+      setIsDrivePermissionRequiredOpen(false);
       openLoginAfterNoticeRef.current = false;
       router.replace('/');
       router.refresh();
@@ -251,10 +292,13 @@ export function useAuthGate(options: UseAuthGateOptions = {}) {
     isLoginOpen,
     isLoginPending,
     isPrivacyNoticeOpen,
+    isDrivePermissionRequiredOpen,
     login,
     closeLogin,
     closePrivacyNotice,
+    closeDrivePermissionRequired,
     loginWithGoogle,
+    retryDrivePermission,
     logout,
     runAfterAuth,
   };


### PR DESCRIPTION
## 작업 개요

Google Drive 권한을 허용하지 않은 사용자가 로그인 성공 상태로 진입하지 않도록 OAuth scope 검증 및 재동의 안내 플로우를 추가했습니다.

## 작업 내용

- [x] Google OAuth 로그인 요청에 Drive 권한 재동의 흐름 정리
- [x] OAuth callback에서 실제 승인된 `drive.file` scope 검증
- [x] Drive 권한 누락 시 로그인 실패 처리 및 안내 모달 표시
- [x] 재권한 요청 후 기존 pending action 이어서 실행
- [x] 세션/토큰 갱신 시 Drive 권한 보유 여부 재검증

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npm test -- app/api/auth/login/route.test.ts app/api/auth/callback/route.test.ts app/api/auth/session/route.test.ts` 통과
- `npx jest --runTestsByPath "app/(home)/components/useAuthGate.test.tsx"` 통과
- 관련 파일 ESLint 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**New Features**
* Google Drive 권한 검증 기능이 추가되었습니다.
* Drive 권한이 없을 경우 사용자에게 안내 모달을 표시하고 재시도할 수 있도록 개선되었습니다.

**Tests**
* 권한 검증 관련 테스트 케이스가 추가 및 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->