### PR TITLE
[fix] 빌드 오류 (타입 이슈) 해결

### DIFF
--- a/app/guest/[id]/validation/parseGuestPayload.ts
+++ b/app/guest/[id]/validation/parseGuestPayload.ts
@@ -30,6 +30,10 @@ export type GuestPayloadWarning = GuestBlockWarning;
 
 export type NormalizedGuestPayload = GuestPayload;
 
+type GuestShareLocationInfo = NonNullable<
+  NonNullable<GuestPayload['shareUrl']>['locationInfo']
+>;
+
 export type GuestPayloadParseResult =
   | {
       ok: true;
@@ -157,6 +161,27 @@ function normalizeGuestBlocks(blocks: unknown[]) {
   return { blocks: normalizedBlocks, warnings };
 }
 
+function normalizeShareLocationInfo(
+  value: unknown
+): GuestShareLocationInfo | null | undefined {
+  if (value === undefined) return undefined;
+
+  if (
+    !isRecord(value) ||
+    typeof value.lat !== 'number' ||
+    typeof value.lng !== 'number' ||
+    typeof value.placeName !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    lat: value.lat,
+    lng: value.lng,
+    placeName: value.placeName,
+  };
+}
+
 function normalizeShareUrl(
   shareUrl: unknown
 ): GuestPayload['shareUrl'] | undefined {
@@ -175,13 +200,8 @@ function normalizeShareUrl(
     return undefined;
   }
 
-  if (
-    shareUrl.locationInfo !== undefined &&
-    (!isRecord(shareUrl.locationInfo) ||
-      typeof shareUrl.locationInfo.lat !== 'number' ||
-      typeof shareUrl.locationInfo.lng !== 'number' ||
-      typeof shareUrl.locationInfo.placeName !== 'string')
-  ) {
+  const locationInfo = normalizeShareLocationInfo(shareUrl.locationInfo);
+  if (locationInfo === null) {
     return undefined;
   }
 
@@ -193,7 +213,7 @@ function normalizeShareUrl(
     urlDescription: shareUrl.urlDescription,
     urlImage: shareUrl.urlImage,
     showLocationButton: shareUrl.showLocationButton,
-    ...(shareUrl.locationInfo ? { locationInfo: shareUrl.locationInfo } : {}),
+    ...(locationInfo ? { locationInfo } : {}),
   };
 }
 


### PR DESCRIPTION
## 작업 개요

- 게스트 페이지 타입 가드에서 TypeScript의 문제로 빌드가 안되던 이슈를 해결했습니다

## 작업 내용

- [x] locationInfo 전용 정규화 함수 normalizeShareLocationInfo 추가
- [x] 반환 객체에는 타입이 확정된 { lat, lng, placeName }만 넣도록 변경

## 관련 이슈

Closes #

## 테스트 결과 보고

<!-- 테스트 결과나 내용 텍스트 또는 사진 등 기입 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 게스트 공유 주소 검증 로직을 개선하여 위치 정보 정규화 처리를 최적화했습니다.

---

**참고:** 이 변경사항은 내부 검증 체계의 개선사항으로, 사용자 화면에 직접 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->