### PR TITLE
[refactor] 텍스트에디터 사용성 개선

### DIFF
--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  type ChainedCommands,
   EditorContent,
   JSONContent,
   type Editor,
@@ -30,16 +31,24 @@ import {
   loadCustomFont,
   preloadFontFamilyWeights,
 } from '@/shared/fonts/fontLoader';
-import { FontFamilyOption, FontWeightOption } from '@/shared/fonts/fontOptions';
+import {
+  FontFamilyOption,
+  FontWeightOption,
+  getFallbackWeight,
+} from '@/shared/fonts/fontOptions';
 import { cn } from '@/shared/utils/cn';
 
 import { Selector } from '../selector';
 
 import TextEditorColorPickerPopover from './components/TextEditorColorPickerPopover';
 import { isTextMarkFullyActive } from './utils/markState';
-import { stripFontSizeFromHtml } from './utils/paste';
+import {
+  normalizePastedHtmlToPlainText,
+  normalizePastedText,
+} from './utils/paste';
 import {
   createFontWeightOptions,
+  findFontWeightOption,
   FONT_FAMILY_OPTIONS,
   FONT_SIZE_OPTIONS,
   getDefaultFontWeightOption,
@@ -63,6 +72,25 @@ export interface TextEditorRef {
   getEditor: () => Editor | null;
 }
 
+type SavedTextSelection = {
+  from: number;
+  to: number;
+};
+
+type TextStyleAttributes = {
+  fontFamily?: unknown;
+  fontWeight?: unknown;
+  fontSize?: unknown;
+  color?: unknown;
+};
+
+type TextMark = {
+  type: {
+    name: string;
+  };
+  attrs: TextStyleAttributes;
+};
+
 const TEXT_ALIGN_OPTIONS: TextAlignOption[] = [
   { label: <AlignRightIcon />, value: 'right' },
   { label: <AlignCenterIcon />, value: 'center' },
@@ -74,6 +102,106 @@ const DEFAULT_FONT_SIZE_OPTION =
   FONT_SIZE_OPTIONS[0];
 const DEFAULT_TEXT_ALIGN_OPTION = TEXT_ALIGN_OPTIONS[1];
 const DEFAULT_EDITOR_TEXT = '내용을 입력해주세요';
+const MIXED_STYLE_VALUE = '__mixed__';
+
+const MIXED_FONT_FAMILY_OPTION: FontFamilyOption = {
+  label: 'Mixed',
+  value: MIXED_STYLE_VALUE,
+  weights: [],
+  defaultWeight: '',
+};
+
+const MIXED_FONT_WEIGHT_OPTION: FontWeightOption = {
+  label: 'Mixed',
+  value: MIXED_STYLE_VALUE,
+};
+
+const MIXED_FONT_SIZE_OPTION: FontSizeOption = {
+  label: 'Mixed',
+  value: MIXED_STYLE_VALUE,
+};
+
+const getTextStyleAttributesFromMarks = (
+  marks: readonly TextMark[] | null | undefined
+): TextStyleAttributes => {
+  return marks?.find(mark => mark.type.name === 'textStyle')?.attrs ?? {};
+};
+
+const getTextStyleAttributesAtSelection = (
+  editor: Editor,
+  pendingStoredMarkPosition?: number | null
+): TextStyleAttributes => {
+  const { state } = editor;
+  const { selection } = state;
+
+  if (selection.empty) {
+    const shouldUseStoredMarks =
+      pendingStoredMarkPosition !== null &&
+      pendingStoredMarkPosition !== undefined &&
+      pendingStoredMarkPosition === selection.from;
+
+    const beforeTextStyle = getTextStyleAttributesFromMarks(
+      selection.$from.nodeBefore?.marks
+    );
+    if (!shouldUseStoredMarks && Object.keys(beforeTextStyle).length > 0) {
+      return beforeTextStyle;
+    }
+
+    const storedTextStyle = getTextStyleAttributesFromMarks(state.storedMarks);
+    if (shouldUseStoredMarks && Object.keys(storedTextStyle).length > 0) {
+      return storedTextStyle;
+    }
+
+    const afterTextStyle = getTextStyleAttributesFromMarks(
+      selection.$from.nodeAfter?.marks
+    );
+    if (Object.keys(afterTextStyle).length > 0) return afterTextStyle;
+
+    return storedTextStyle;
+  }
+
+  const selectedValues: Record<
+    'fontFamily' | 'fontWeight' | 'fontSize' | 'color',
+    Set<unknown>
+  > = {
+    fontFamily: new Set(),
+    fontWeight: new Set(),
+    fontSize: new Set(),
+    color: new Set(),
+  };
+
+  state.doc.nodesBetween(selection.from, selection.to, node => {
+    if (!node.isText) return;
+
+    const textStyle = getTextStyleAttributesFromMarks(node.marks);
+
+    selectedValues.fontFamily.add(textStyle.fontFamily);
+    selectedValues.fontWeight.add(textStyle.fontWeight);
+    selectedValues.fontSize.add(textStyle.fontSize);
+    selectedValues.color.add(textStyle.color);
+
+    return;
+  });
+
+  return {
+    fontFamily:
+      selectedValues.fontFamily.size > 1
+        ? MIXED_STYLE_VALUE
+        : selectedValues.fontFamily.values().next().value,
+    fontWeight:
+      selectedValues.fontWeight.size > 1
+        ? MIXED_STYLE_VALUE
+        : selectedValues.fontWeight.values().next().value,
+    fontSize:
+      selectedValues.fontSize.size > 1
+        ? MIXED_STYLE_VALUE
+        : selectedValues.fontSize.values().next().value,
+    color:
+      selectedValues.color.size > 1
+        ? MIXED_STYLE_VALUE
+        : selectedValues.color.values().next().value,
+  };
+};
 
 export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
   (
@@ -88,10 +216,10 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
   ) => {
     const [, forceUpdate] = useReducer((count: number) => count + 1, 0);
 
-    const initialStyles = useMemo(
-      () => getInitialEditorStyles(value, defaultAlign),
-      [value, defaultAlign]
+    const [editorBaseStyles] = useState(() =>
+      getInitialEditorStyles(null, defaultAlign)
     );
+    const initialStyles = editorBaseStyles;
 
     const [fontFamilySelected, setFontFamilySelected] =
       useState<FontFamilyOption>(initialStyles.fontFamily);
@@ -106,11 +234,17 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
     const [colorPickerOpen, setColorPickerOpen] = useState(false);
     const [selectedColor, setSelectedColor] = useState(initialStyles.color);
     const editorRef = useRef<Editor | null>(null);
-    const fontSizeSelectedRef = useRef(initialStyles.fontSize);
+    const savedSelectionRef = useRef<SavedTextSelection | null>(null);
+    const pendingStoredMarkPositionRef = useRef<number | null>(null);
     const colorPickerContainerRef = useRef<HTMLDivElement>(null);
     const fontWeightOptions = useMemo(
-      () => createFontWeightOptions(fontFamilySelected),
-      [fontFamilySelected]
+      () =>
+        createFontWeightOptions(
+          fontFamilySelected.value === MIXED_STYLE_VALUE
+            ? editorBaseStyles.fontFamily
+            : fontFamilySelected
+        ),
+      [editorBaseStyles.fontFamily, fontFamilySelected]
     );
 
     const loadEditorFont = useCallback(
@@ -131,9 +265,148 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       []
     );
 
-    useEffect(() => {
-      fontSizeSelectedRef.current = fontSizeSelected;
-    }, [fontSizeSelected]);
+    const saveSelection = useCallback((editor: Editor) => {
+      const { from, to } = editor.state.selection;
+      savedSelectionRef.current = { from, to };
+
+      if (
+        pendingStoredMarkPositionRef.current !== null &&
+        (from !== to || from !== pendingStoredMarkPositionRef.current)
+      ) {
+        pendingStoredMarkPositionRef.current = null;
+      }
+    }, []);
+
+    const getCommandAtSavedSelection = useCallback(
+      (editor: Editor): ChainedCommands => {
+        const command = editor.chain();
+        const savedSelection = savedSelectionRef.current;
+
+        if (!savedSelection) {
+          return command.focus();
+        }
+
+        const docSize = editor.state.doc.content.size;
+        const from = Math.min(Math.max(savedSelection.from, 0), docSize);
+        const to = Math.min(Math.max(savedSelection.to, 0), docSize);
+
+        if (from === to) {
+          return command.setTextSelection(from);
+        }
+
+        return command.setTextSelection({ from, to });
+      },
+      []
+    );
+
+    const runAtSavedSelection = useCallback(
+      (
+        editor: Editor,
+        applyCommand: (command: ChainedCommands) => ChainedCommands
+      ) => {
+        const savedSelection = savedSelectionRef.current;
+        const selectionIsEmpty =
+          savedSelection && savedSelection.from === savedSelection.to
+            ? true
+            : !savedSelection && editor.state.selection.empty;
+        const storedMarkPosition =
+          savedSelection?.from ?? editor.state.selection.from;
+        pendingStoredMarkPositionRef.current = selectionIsEmpty
+          ? storedMarkPosition
+          : null;
+
+        let command = applyCommand(getCommandAtSavedSelection(editor));
+
+        if (!selectionIsEmpty) {
+          command = command.command(({ tr }) => {
+            tr.setStoredMarks(null);
+            return true;
+          });
+        }
+
+        command.run();
+        editor.view.focus();
+        saveSelection(editor);
+      },
+      [getCommandAtSavedSelection, saveSelection]
+    );
+
+    const syncToolbarState = useCallback(
+      (editor: Editor) => {
+        const textStyleAttributes = getTextStyleAttributesAtSelection(
+          editor,
+          pendingStoredMarkPositionRef.current
+        );
+        const paragraphAttributes = editor.getAttributes('paragraph');
+
+        const nextFontFamily =
+          textStyleAttributes.fontFamily === MIXED_STYLE_VALUE
+            ? MIXED_FONT_FAMILY_OPTION
+            : typeof textStyleAttributes.fontFamily === 'string'
+              ? (FONT_FAMILY_OPTIONS.find(
+                  option => option.value === textStyleAttributes.fontFamily
+                ) ?? editorBaseStyles.fontFamily)
+              : editorBaseStyles.fontFamily;
+
+        const nextFontWeightFamily =
+          nextFontFamily.value === MIXED_STYLE_VALUE
+            ? editorBaseStyles.fontFamily
+            : nextFontFamily;
+        const nextFontWeight =
+          textStyleAttributes.fontWeight === MIXED_STYLE_VALUE
+            ? MIXED_FONT_WEIGHT_OPTION
+            : typeof textStyleAttributes.fontWeight === 'string'
+              ? findFontWeightOption(
+                  createFontWeightOptions(nextFontWeightFamily),
+                  textStyleAttributes.fontWeight
+                )
+              : getDefaultFontWeightOption(nextFontWeightFamily);
+
+        const fontSize =
+          textStyleAttributes.fontSize === MIXED_STYLE_VALUE
+            ? MIXED_STYLE_VALUE
+            : typeof textStyleAttributes.fontSize === 'string'
+              ? textStyleAttributes.fontSize
+              : editorBaseStyles.fontSize.value;
+        const nextFontSize =
+          fontSize === MIXED_STYLE_VALUE
+            ? MIXED_FONT_SIZE_OPTION
+            : (FONT_SIZE_OPTIONS.find(option => option.value === fontSize) ?? {
+                label: fontSize.replace('px', ''),
+                value: fontSize,
+              });
+
+        const textAlign =
+          typeof paragraphAttributes.textAlign === 'string'
+            ? paragraphAttributes.textAlign
+            : defaultAlign;
+        const nextTextAlign =
+          TEXT_ALIGN_OPTIONS.find(option => option.value === textAlign) ??
+          editorBaseStyles.textAlign;
+
+        const nextColor =
+          textStyleAttributes.color === MIXED_STYLE_VALUE
+            ? selectedColor
+            : typeof textStyleAttributes.color === 'string'
+              ? textStyleAttributes.color
+              : editorBaseStyles.color;
+
+        setFontFamilySelected(prev =>
+          prev.value === nextFontFamily.value ? prev : nextFontFamily
+        );
+        setFontWeightSelected(prev =>
+          prev.value === nextFontWeight.value ? prev : nextFontWeight
+        );
+        setFontSizeSelected(prev =>
+          prev.value === nextFontSize.value ? prev : nextFontSize
+        );
+        setTextAlignSelected(prev =>
+          prev.value === nextTextAlign.value ? prev : nextTextAlign
+        );
+        setSelectedColor(prev => (prev === nextColor ? prev : nextColor));
+      },
+      [defaultAlign, editorBaseStyles, selectedColor]
+    );
 
     useEffect(() => {
       void loadEditorFont(fontFamilySelected.value, fontWeightSelected.value);
@@ -141,19 +414,14 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
 
     const editorContentStyle = useMemo<CSSProperties>(
       () => ({
-        fontFamily: fontFamilySelected.style?.fontFamily,
-        fontWeight: fontWeightSelected.value,
-        fontSize: fontSizeSelected.value || DEFAULT_FONT_SIZE_OPTION.value,
-        color: selectedColor,
-        textAlign: textAlignSelected.value,
+        fontFamily: editorBaseStyles.fontFamily.style?.fontFamily,
+        fontWeight: editorBaseStyles.fontWeight.value,
+        fontSize:
+          editorBaseStyles.fontSize.value || DEFAULT_FONT_SIZE_OPTION.value,
+        color: editorBaseStyles.color,
+        textAlign: editorBaseStyles.textAlign.value,
       }),
-      [
-        fontFamilySelected.style?.fontFamily,
-        fontWeightSelected.value,
-        fontSizeSelected.value,
-        selectedColor,
-        textAlignSelected.value,
-      ]
+      [editorBaseStyles]
     );
 
     const editor = useEditor({
@@ -166,44 +434,35 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
             'flex flex-col justify-center min-h-[120px] outline-none text-[14px] leading-7 selection:bg-primary/20 selection:text-inherit',
         },
         transformPastedHTML(html) {
-          return stripFontSizeFromHtml(html);
+          return normalizePastedHtmlToPlainText(html);
         },
-        handlePaste(view) {
-          const pasteFrom = view.state.selection.from;
-
-          window.requestAnimationFrame(() => {
-            const currentEditor = editorRef.current;
-            const pasteTo = currentEditor?.state.selection.from;
-
-            if (!currentEditor || !pasteTo || pasteTo <= pasteFrom) return;
-
-            currentEditor
-              .chain()
-              .setTextSelection({ from: pasteFrom, to: pasteTo })
-              .setFontSize(fontSizeSelectedRef.current.value)
-              .setTextSelection(pasteTo)
-              .run();
-          });
-
-          return false;
+        transformPastedText(text) {
+          return normalizePastedText(text);
         },
       },
       onCreate({ editor }) {
         editorRef.current = editor;
-        onChange?.(editor.getJSON());
+        saveSelection(editor);
+        syncToolbarState(editor);
         forceUpdate();
       },
       onUpdate({ editor }) {
+        saveSelection(editor);
+        syncToolbarState(editor);
         onChange?.(editor.getJSON());
         forceUpdate();
       },
-      onSelectionUpdate() {
+      onSelectionUpdate({ editor }) {
+        saveSelection(editor);
+        syncToolbarState(editor);
         forceUpdate();
       },
-      onTransaction() {
+      onTransaction({ editor }) {
+        syncToolbarState(editor);
         forceUpdate();
       },
-      onFocus() {
+      onFocus({ editor }) {
+        syncToolbarState(editor);
         forceUpdate();
       },
       onBlur() {
@@ -229,11 +488,7 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
 
     if (!editor) return null;
 
-    const textStyleAttributes = editor.getAttributes('textStyle');
-    const activeColor =
-      typeof textStyleAttributes.color === 'string'
-        ? textStyleAttributes.color
-        : selectedColor;
+    const activeColor = selectedColor;
     const italicActive = isTextMarkFullyActive(editor, 'italic');
     const underlineActive = isTextMarkFullyActive(editor, 'underline');
     const editorFocused = editor.isFocused;
@@ -244,21 +499,18 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       option: FontFamilyOption | { label: string; value: string }
     ) => {
       const selected = option as FontFamilyOption;
-      const nextWeight = getDefaultFontWeightOption(selected);
+      const nextWeight = findFontWeightOption(
+        createFontWeightOptions(selected),
+        getFallbackWeight(selected.value, fontWeightSelected.value)
+      );
 
       setFontFamilySelected(selected);
       setFontWeightSelected(nextWeight);
 
-      void (async () => {
-        await loadEditorFont(selected.value, nextWeight.value);
-
-        editor
-          .chain()
-          .focus()
-          .setFontFamily(selected.value)
-          .setFontWeight(nextWeight.value)
-          .run();
-      })();
+      runAtSavedSelection(editor, command =>
+        command.setFontFamily(selected.value).setFontWeight(nextWeight.value)
+      );
+      void loadEditorFont(selected.value, nextWeight.value);
     };
 
     const handleFontWeightSelect = (
@@ -266,10 +518,15 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
     ) => {
       const selected = option as FontWeightOption;
       setFontWeightSelected(selected);
-      void (async () => {
-        await loadEditorFont(fontFamilySelected.value, selected.value);
-        editor.chain().focus().setFontWeight(selected.value).run();
-      })();
+      runAtSavedSelection(editor, command =>
+        command.setFontWeight(selected.value)
+      );
+      void loadEditorFont(
+        fontFamilySelected.value === MIXED_STYLE_VALUE
+          ? editorBaseStyles.fontFamily.value
+          : fontFamilySelected.value,
+        selected.value
+      );
     };
 
     const handleFontSizeSelect = (
@@ -278,7 +535,9 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       const selected = option as FontSizeOption;
       setFontSizeSelected(selected);
       if (selected.value) {
-        editor.chain().focus().setFontSize(selected.value).run();
+        runAtSavedSelection(editor, command =>
+          command.setFontSize(selected.value)
+        );
       }
     };
 
@@ -291,14 +550,18 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       setFontSizeSelected(option);
 
       if (numericValue) {
-        editor.chain().setFontSize(option.value).run();
+        runAtSavedSelection(editor, command =>
+          command.setFontSize(option.value)
+        );
       }
     };
 
     const handleFontSizeInputBlur = () => {
       if (!fontSizeSelected.value) {
         setFontSizeSelected(DEFAULT_FONT_SIZE_OPTION);
-        editor.chain().setFontSize(DEFAULT_FONT_SIZE_OPTION.value).run();
+        runAtSavedSelection(editor, command =>
+          command.setFontSize(DEFAULT_FONT_SIZE_OPTION.value)
+        );
       }
     };
 
@@ -307,7 +570,9 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
     ) => {
       const selected = option as TextAlignOption;
       setTextAlignSelected(selected);
-      editor.chain().focus().setTextAlign(selected.value).run();
+      runAtSavedSelection(editor, command =>
+        command.setTextAlign(selected.value)
+      );
     };
 
     const handleColorPickerToggle = () => {
@@ -315,25 +580,34 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
     };
 
     const handleItalicToggle = () => {
-      const command = editor.chain().focus();
-
       if (italicActive) {
-        command.unsetItalic().setFontStyleOverride('normal').run();
+        runAtSavedSelection(editor, command =>
+          command.unsetItalic().setFontStyleOverride('normal')
+        );
         return;
       }
 
-      command.setItalic().setFontStyleOverride(null).run();
+      runAtSavedSelection(editor, command =>
+        command.setItalic().setFontStyleOverride(null)
+      );
     };
 
     const handleUnderlineToggle = () => {
-      const command = editor.chain().focus();
-
       if (underlineActive) {
-        command.unsetUnderline().setTextDecorationOverride('none').run();
+        runAtSavedSelection(editor, command =>
+          command.unsetUnderline().setTextDecorationOverride('none')
+        );
         return;
       }
 
-      command.setUnderline().setTextDecorationOverride(null).run();
+      runAtSavedSelection(editor, command =>
+        command.setUnderline().setTextDecorationOverride(null)
+      );
+    };
+
+    const handleColorChange = (color: string) => {
+      setSelectedColor(color);
+      runAtSavedSelection(editor, command => command.setColor(color));
     };
 
     return (
@@ -402,10 +676,10 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
               </button>
 
               <TextEditorColorPickerPopover
-                editor={editor}
                 isOpen={colorPickerOpen}
+                initialHex={activeColor}
                 onClose={() => setColorPickerOpen(false)}
-                onColorChange={setSelectedColor}
+                onColorChange={handleColorChange}
                 containerRef={colorPickerContainerRef}
               />
             </div>

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -179,8 +179,6 @@ const getTextStyleAttributesAtSelection = (
     selectedValues.fontWeight.add(textStyle.fontWeight);
     selectedValues.fontSize.add(textStyle.fontSize);
     selectedValues.color.add(textStyle.color);
-
-    return;
   });
 
   return {

--- a/components/molecules/text-editor/components/TextEditorColorPickerPopover.tsx
+++ b/components/molecules/text-editor/components/TextEditorColorPickerPopover.tsx
@@ -19,10 +19,7 @@ import {
   type FloatingPlacementMode,
 } from '@/shared/utils/floatingPosition';
 
-import type { Editor } from '@tiptap/react';
-
 interface Props {
-  editor: Editor | null;
   isOpen: boolean;
   initialHex?: string;
   onClose?: () => void;
@@ -36,7 +33,6 @@ const PANEL_GAP = 12;
 const LEFT_PANEL_SELECTOR = '[data-editor-left-panel]';
 
 export default function TextEditorColorPickerPopover({
-  editor,
   isOpen,
   initialHex = '#FF4D6D',
   onClose,
@@ -149,7 +145,6 @@ export default function TextEditorColorPickerPopover({
               const nextColor = `rgba(${r}, ${g}, ${b}, ${a})`;
 
               onColorChange?.(nextColor);
-              editor?.chain().focus().setColor(nextColor).run();
             }}
           />
         </motion.div>

--- a/components/molecules/text-editor/utils/paste.ts
+++ b/components/molecules/text-editor/utils/paste.ts
@@ -1,18 +1,53 @@
-export function stripFontSizeFromHtml(html: string): string {
+const BLOCK_SELECTOR =
+  'address, article, aside, blockquote, dd, div, dl, dt, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hr, li, main, nav, ol, p, pre, section, table, tr, ul';
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizePlainText(text: string): string {
+  return text
+    .replace(/\u00a0/g, ' ')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function plainTextToHtml(text: string): string {
+  const normalizedText = normalizePlainText(text);
+
+  if (!normalizedText) return '';
+
+  return normalizedText
+    .split(/\n{2,}/)
+    .map(
+      paragraph =>
+        `<p>${paragraph.split('\n').map(escapeHtml).join('<br />')}</p>`
+    )
+    .join('');
+}
+
+export function normalizePastedHtmlToPlainText(html: string): string {
   const parser = new DOMParser();
   const document = parser.parseFromString(html, 'text/html');
 
-  document.body.querySelectorAll<HTMLElement>('[style]').forEach(element => {
-    element.style.removeProperty('font-size');
-
-    if (!element.getAttribute('style')?.trim()) {
-      element.removeAttribute('style');
-    }
+  document.body.querySelectorAll('br').forEach(element => {
+    element.replaceWith(document.createTextNode('\n'));
   });
 
-  document.body.querySelectorAll('font[size]').forEach(element => {
-    element.removeAttribute('size');
+  document.body.querySelectorAll(BLOCK_SELECTOR).forEach(element => {
+    element.append(document.createTextNode('\n'));
   });
 
-  return document.body.innerHTML;
+  return plainTextToHtml(document.body.textContent ?? '');
+}
+
+export function normalizePastedText(text: string): string {
+  return normalizePlainText(text);
 }

--- a/components/molecules/text-editor/utils/textEditorOptions.ts
+++ b/components/molecules/text-editor/utils/textEditorOptions.ts
@@ -4,6 +4,7 @@ import {
   type FontFamilyOption,
   type FontWeightOption,
   getDefaultFontFamilyOption,
+  getFallbackWeight,
   getFontFamilyOption,
 } from '@/shared/fonts/fontOptions';
 
@@ -70,7 +71,7 @@ export function getDefaultFontWeightOption(
 ): FontWeightOption {
   const options = createFontWeightOptions(fontFamily);
 
-  return findFontWeightOption(options, fontFamily.defaultWeight);
+  return findFontWeightOption(options, getFallbackWeight(fontFamily.value));
 }
 
 export interface InitialEditorStyles {

--- a/components/molecules/text-editor/utils/tiptapExtensions.ts
+++ b/components/molecules/text-editor/utils/tiptapExtensions.ts
@@ -10,6 +10,7 @@ import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
 import { FontFamily, FontSize, TextStyle } from '@tiptap/extension-text-style';
 import Underline from '@tiptap/extension-underline';
+import { UndoRedo } from '@tiptap/extensions/undo-redo';
 
 import { FontWeight } from './fontWeight';
 import {
@@ -41,6 +42,9 @@ export function createTextEditorBarExtensions(
     FontSize,
     FontStyleOverride,
     TextDecorationOverride,
+    UndoRedo.configure({
+      depth: 100,
+    }),
     TextAlign.configure({
       types: ['paragraph'],
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@tiptap/extension-text-align": "^3.19.0",
         "@tiptap/extension-text-style": "^3.19.0",
         "@tiptap/extension-underline": "^3.19.0",
+        "@tiptap/extensions": "^3.22.4",
         "@tiptap/html": "^3.20.0",
         "@tiptap/pm": "^3.19.0",
         "@tiptap/react": "^3.19.0",
@@ -5920,7 +5921,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
       "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tiptap/extension-text-align": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
+    "@tiptap/extensions": "^3.22.4",
     "@tiptap/html": "^3.20.0",
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",

--- a/shared/fonts/fontOptions.ts
+++ b/shared/fonts/fontOptions.ts
@@ -1,5 +1,4 @@
 import {
-  getDefaultFontWeight,
   getFontFamilies,
   getFontFallbackStack,
   getFontWeights,
@@ -35,6 +34,29 @@ const FONT_WEIGHT_LABELS: Record<string, string> = {
 };
 
 const DEFAULT_FONT_FAMILY = 'LINESeedKR';
+
+const getRegularFallbackWeight = (
+  weights: string[],
+  currentWeight?: string
+) => {
+  if (currentWeight && weights.includes(currentWeight)) return currentWeight;
+  if (weights.includes('400')) return '400';
+
+  return (
+    weights
+      .filter(weight => !Number.isNaN(Number(weight)))
+      .toSorted((a, b) => {
+        const aDistance = Math.abs(Number(a) - 400);
+        const bDistance = Math.abs(Number(b) - 400);
+
+        if (aDistance !== bDistance) return aDistance - bDistance;
+
+        return Number(a) - Number(b);
+      })[0] ??
+    weights[0] ??
+    '400'
+  );
+};
 
 export const getFontWeightLabel = (weight: string) => {
   return FONT_WEIGHT_LABELS[weight] ?? weight;
@@ -95,11 +117,5 @@ export const getFontFamilyOption = (value?: string | null) => {
 export const getFallbackWeight = (family: string, currentWeight?: string) => {
   const weights = getFontWeights(resolveFontFamily(family));
 
-  if (currentWeight && weights.includes(currentWeight)) return currentWeight;
-
-  const defaultWeight = getDefaultFontWeight(resolveFontFamily(family));
-  if (weights.includes(defaultWeight)) return defaultWeight;
-  if (weights.includes('400')) return '400';
-
-  return weights[0] ?? '400';
+  return getRegularFallbackWeight(weights, currentWeight);
 };


### PR DESCRIPTION
작업 개요
텍스트 에디터 사용성 및 안정성 개선

작업 내용
- 텍스트 에디터 커서 상태 스타일 적용 개선
- 드래그 선택 영역 스타일 적용 범위 보정
- 툴바 셀렉터 상태를 현재 커서/선택 영역 스타일과 동기화
- 폰트/크기/두께가 섞인 선택 영역에서 Mixed 표시 추가
- 폰트 변경 시 Thin으로 떨어지지 않도록 weight fallback 정책 개선
- 저장 데이터 재진입 시 TextEditor가 기존 JSON/HTML을 불필요하게 덮어쓰지 않도록 수정
- Undo/Redo 단축키 지원 추가(depth 100)
- 붙여넣기 시 외부 HTML 스타일 제거 및 텍스트/줄바꿈 중심으로 정규화

관련 이슈
Closes #

테스트 결과
- npx eslint components/molecules/text-editor/TextEditor.tsx components/molecules/text-editor/utils/paste.ts components/molecules/text-editor/utils/textEditorOptions.ts components/molecules/text-editor/utils/tiptapExtensions.ts shared/fonts/fontOptions.ts components/molecules/text-editor/components/TextEditorColorPickerPopover.tsx
  - 통과

- npx tsc --noEmit --pretty false
  - 실패: 기존 app/guest/[id]/components/GuestRenderer.test.tsx 타입 오류 2건
  - 이번 텍스트 에디터 변경 관련 타입 오류는 확인되지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 실행 취소 및 다시 실행 기능 추가 (최대 100단계 히스토리)

* **버그 수정**
  * 텍스트 선택 시 툴바 상태 동기화 개선
  * 붙여넣기 내용 정규화 처리 개선
  * 폰트 굵기 선택 로직 최적화
  * 혼합된 서식 표시 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->