### PR TITLE
[feat] 게스트에서 바로가기 편집페이지 안내문구 없이 지도 앱 이동

### DIFF
--- a/components/organisms/place/Navigation.tsx
+++ b/components/organisms/place/Navigation.tsx
@@ -22,7 +22,30 @@ interface Props {
 
 export function Navigation({ lat, lng, name }: Props) {
   const { confirm } = useConfirm();
+
+  const openNavigation = (type: 'naver' | 'kakao' | 'tmap') => {
+    switch (type) {
+      case 'naver':
+        openNaverMap(lat, lng, name);
+        break;
+      case 'kakao':
+        openKakaoMap(lat, lng, name);
+        break;
+      case 'tmap':
+        openTMap(lat, lng, name);
+        break;
+    }
+  };
+
   const handleNavigation = async (type: 'naver' | 'kakao' | 'tmap') => {
+    const pathname = window.location.pathname;
+    const shouldConfirm = pathname.startsWith('/editor');
+
+    if (!shouldConfirm) {
+      openNavigation(type);
+      return;
+    }
+
     const isConfirm = await confirm({
       message: '편집 내역이 저장되지 않았습니다.\n길안내를 시작하시겠습니까?',
       variant: 'white',
@@ -34,17 +57,7 @@ export function Navigation({ lat, lng, name }: Props) {
       // 추후 수정되거나 삭제될 부분
       isConfirm
     ) {
-      switch (type) {
-        case 'naver':
-          openNaverMap(lat, lng, name);
-          break;
-        case 'kakao':
-          openKakaoMap(lat, lng, name);
-          break;
-        case 'tmap':
-          openTMap(lat, lng, name);
-          break;
-      }
+      openNavigation(type);
     }
   };
 
@@ -104,3 +117,4 @@ export function Navigation({ lat, lng, name }: Props) {
     </div>
   );
 }
+


### PR DESCRIPTION
## 작업 개요

게스트에서 바로가기 편집페이지 안내문구 없이 지도 앱 이동

## 작업 내용

- 라우팅에 따라 지도 앱 실행 로직 분기처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 코드 구조를 개선하여 지도 열기 로직의 유지보수성을 향상했습니다. 사용자에게는 영향을 미치지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->