### PR TITLE
[feat] 대시보드에서 에디터로 넘어가는 버튼 추가

### DIFF
--- a/app/dashboard/components/title/DashboardCreateInvitationButton.tsx
+++ b/app/dashboard/components/title/DashboardCreateInvitationButton.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+function DashboardCreateInvitationButton() {
+  return (
+    <Link
+      href="/editor"
+      className="
+        pointer-events-auto flex h-13.25 w-fit items-center justify-center rounded-full px-8
+        bg-[#121212] font-pretendard text-2xl font-medium text-white
+        transition-all hover:bg-[#202020] active:scale-95 active:bg-[#0D0D0D] cursor-pointer
+      "
+    >
+      다른 초대장 제작하기
+    </Link>
+  );
+}
+
+export default DashboardCreateInvitationButton;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 
 import DashboardCarouselSkeleton from './components/carousel/DashboardCarouselSkeleton';
 import DashboardInvitations from './components/DashboardInvitations';
+import DashboardCreateInvitationButton from './components/title/DashboardCreateInvitationButton';
 import DashboardTitle from './components/title/DashboardTitle';
 
 import type { Metadata } from 'next';
@@ -16,10 +17,11 @@ export default function DashboardPage() {
   return (
     <>
       <div
-        className="pointer-events-none fixed z-10"
+        className="pointer-events-none fixed z-10 flex flex-col items-end gap-10"
         style={{ right: '2.5rem', top: '30%' }}
       >
         <DashboardTitle />
+        <DashboardCreateInvitationButton />
       </div>
       <Suspense fallback={<DashboardCarouselSkeleton />}>
         <DashboardInvitations />


### PR DESCRIPTION
## 작업 개요

마이페이지 글래스모피즘 타이틀 영역 아래에 초대장 제작 버튼을 추가했습니다.

## 작업 내용

- [x] 마이페이지 타이틀 영역 아래 40px 간격으로 버튼 추가
- [x] 버튼 클릭 시 `/editor`로 이동하도록 설정
- [x] 버튼 텍스트를 `다른 초대장 제작하기`로 적용
- [x] 홈 CTA와 동일한 hover/active 스타일 적용

## 관련 이슈

Closes #

## 테스트 결과 보고

- `npx eslint app/dashboard/page.tsx app/dashboard/components/title/DashboardCreateInvitationButton.tsx` 통과