### PR TITLE
[FEAT] 컴포넌트 UI 폴리싱 및 대시보드 CTA 스케일 개선

### DIFF
--- a/app/dashboard/components/carousel/carouselLayout.ts
+++ b/app/dashboard/components/carousel/carouselLayout.ts
@@ -5,7 +5,7 @@ const carouselCardHeight = '520px';
 export const dashboardCarouselLayout = {
   // 대시보드 셸 내부에서 캐러셀이 차지하는 전체 높이
   stageHeight: '75%',
-  dashboardStageHeight: '82%',
+  dashboardStageHeight: 'max(82%, 680px)',
   // 캐러셀 전체 트랙이 아래로 얼마나 묻혀 보일지 결정하는 값
   buriedOffset: '21rem',
   // 선택된 카드가 기본 위치에서 위로 얼마나 떠오를지 결정하는 값

--- a/app/dashboard/components/title/DashboardTitle.tsx
+++ b/app/dashboard/components/title/DashboardTitle.tsx
@@ -1,36 +1,15 @@
-'use client';
-
-import { useViewportScale } from '@/shared/hooks/useViewportScale';
-
 function DashboardTitle() {
-  const titleScale = useViewportScale();
-
   return (
     <div
-      className="border border-white/30 bg-white/15 text-right backdrop-blur-md"
+      className="rounded-4xl border border-white/30 bg-white/15 p-8 text-right backdrop-blur-md"
       style={{
-        padding: `${2 * titleScale}rem`,
-        borderRadius: `${2 * titleScale}rem`,
         boxShadow:
           'inset 4px 4px 18px rgba(0, 0, 0, 0.08), inset -4px -4px 18px rgba(255, 255, 255, 0.75)',
       }}
     >
-      <p
-        className="font-medium"
-        style={{ fontSize: `${1.5 * titleScale}rem` }}
-      >
-        Archive
-      </p>
-      <p
-        className="font-black"
-        style={{ fontSize: `${4 * titleScale}rem` }}
-      >
-        내 초대장
-      </p>
-      <p
-        className="font-medium"
-        style={{ fontSize: `${1.5 * titleScale}rem` }}
-      >
+      <p className="text-2xl font-medium">Archive</p>
+      <p className="text-[64px] font-black">내 초대장</p>
+      <p className="text-2xl font-medium">
         저장한 초대장을 다시 편집하거나 사용할 수 있어요.
       </p>
     </div>

--- a/app/dashboard/components/title/DashboardTitleActions.tsx
+++ b/app/dashboard/components/title/DashboardTitleActions.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useViewportScale } from '@/shared/hooks/useViewportScale';
+
+import DashboardCreateInvitationButton from './DashboardCreateInvitationButton';
+import DashboardTitle from './DashboardTitle';
+
+function DashboardTitleActions() {
+  const scale = useViewportScale();
+
+  return (
+    <div
+      className="pointer-events-none fixed z-10 flex flex-col items-end"
+      style={{ right: '2.5rem', top: '30%' }}
+    >
+      <section
+        className="flex origin-top-right flex-col items-end gap-10"
+        style={{ transform: `scale(${scale})` }}
+      >
+        <DashboardTitle />
+        <DashboardCreateInvitationButton />
+      </section>
+    </div>
+  );
+}
+
+export default DashboardTitleActions;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,8 +2,7 @@ import { Suspense } from 'react';
 
 import DashboardCarouselSkeleton from './components/carousel/DashboardCarouselSkeleton';
 import DashboardInvitations from './components/DashboardInvitations';
-import DashboardCreateInvitationButton from './components/title/DashboardCreateInvitationButton';
-import DashboardTitle from './components/title/DashboardTitle';
+import DashboardTitleActions from './components/title/DashboardTitleActions';
 
 import type { Metadata } from 'next';
 
@@ -16,13 +15,7 @@ export const metadata: Metadata = {
 export default function DashboardPage() {
   return (
     <>
-      <div
-        className="pointer-events-none fixed z-10 flex flex-col items-end gap-10"
-        style={{ right: '2.5rem', top: '30%' }}
-      >
-        <DashboardTitle />
-        <DashboardCreateInvitationButton />
-      </div>
+      <DashboardTitleActions />
       <Suspense fallback={<DashboardCarouselSkeleton />}>
         <DashboardInvitations />
       </Suspense>

--- a/components/atoms/checkbox-indicator/CheckboxIndicator.style.ts
+++ b/components/atoms/checkbox-indicator/CheckboxIndicator.style.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 const commonStyles =
-  'peer-disabled:opacity-50 peer-disabled:cursor-not-allowed select-none cursor-pointer';
+  'peer-disabled:cursor-not-allowed select-none cursor-pointer';
 
 export const sizeVariants = cva(
   `flex-center rounded-sm bg-border-neutral peer-checked:bg-primary ${commonStyles}`,
@@ -12,9 +12,14 @@ export const sizeVariants = cva(
         md: 'w-5 h-5',
         lg: 'w-6 h-6',
       },
+      dimDisabled: {
+        true: 'peer-disabled:opacity-50',
+        false: '',
+      },
     },
     defaultVariants: {
       size: 'sm',
+      dimDisabled: true,
     },
   }
 );
@@ -28,7 +33,11 @@ export const iconVariants = cva(
         md: 'size-4',
         lg: 'size-5',
       },
+      dimDisabled: {
+        true: 'peer-disabled:opacity-50',
+        false: '',
+      },
     },
-    defaultVariants: { size: 'sm' },
+    defaultVariants: { size: 'sm', dimDisabled: true },
   }
 );

--- a/components/atoms/checkbox-indicator/CheckboxIndicator.tsx
+++ b/components/atoms/checkbox-indicator/CheckboxIndicator.tsx
@@ -12,12 +12,15 @@ interface CheckboxProps
     VariantProps<typeof sizeVariants> {}
 
 export const CheckboxIndicator = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ className, size, ...props }, ref) => {
+  ({ className, size, dimDisabled, ...props }, ref) => {
     return (
       <label className="relative flex-center">
         <input ref={ref} type="checkbox" className="peer sr-only" {...props} />
-        <div className={cn(sizeVariants({ size }), className)} />
-        <CheckIcon className={cn(iconVariants({ size }))} strokeWidth={3} />
+        <div className={cn(sizeVariants({ size, dimDisabled }), className)} />
+        <CheckIcon
+          className={cn(iconVariants({ size, dimDisabled }))}
+          strokeWidth={3}
+        />
       </label>
     );
   }

--- a/components/molecules/checkbox/Checkbox.tsx
+++ b/components/molecules/checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ interface CheckboxProps extends Omit<
   children: ReactNode;
   id?: string;
   direction?: 'right' | 'left' | 'top' | 'bottom';
+  dimDisabled?: boolean;
 }
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
@@ -25,6 +26,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       className,
       disabled = false,
       direction = 'right',
+      dimDisabled = true,
       ...props
     },
     ref
@@ -35,13 +37,18 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     return (
       <div
         tabIndex={0}
-        className={cn(checkboxVariants({ direction, disabled }), className)}
+        className={cn(
+          checkboxVariants({ direction, disabled }),
+          disabled && !dimDisabled && 'opacity-100',
+          className
+        )}
       >
         <CheckboxIndicator
           size="sm"
           ref={ref}
           id={checkboxId}
           disabled={disabled}
+          dimDisabled={dimDisabled}
           {...props}
         />
         <Label

--- a/components/molecules/color-picker/components/ColorSlideSection.tsx
+++ b/components/molecules/color-picker/components/ColorSlideSection.tsx
@@ -38,6 +38,7 @@ export function ColorSlideSection({
             top={top}
             color={hsvaToHslaString({ h: hue, s: 100, v: 100, a: 1 })}
             size={pointerSize}
+            cursor="pointer"
           />
         )}
         onChange={newHue => {

--- a/components/molecules/color-picker/components/GlassPointer.tsx
+++ b/components/molecules/color-picker/components/GlassPointer.tsx
@@ -21,11 +21,13 @@ export function GlassPointer({
   top = '50%',
   color,
   size = DEFAULT_GLASS_POINTER_SIZE,
+  cursor = 'inherit',
 }: {
   left?: string | number;
   top?: string | number;
   color: string;
   size?: GlassPointerSize;
+  cursor?: string;
 }) {
   return (
     <div
@@ -34,7 +36,8 @@ export function GlassPointer({
         left,
         top,
         transform: 'translate(-50%, -50%)',
-        pointerEvents: 'none',
+        pointerEvents: 'auto',
+        cursor,
       }}
     >
       <div

--- a/components/molecules/color-picker/components/InputModeSelector.tsx
+++ b/components/molecules/color-picker/components/InputModeSelector.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import { ChevronDown } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 
 import { INPUT_MODE_OPTIONS } from './colorPicker.constants';
 
 import type { InputMode } from './colorPicker.types';
+
+const DROPDOWN_GAP = 4;
+const VIEWPORT_GAP = 8;
 
 /**
  * HEX, RGB 입력 모드를 전환하는 컬러피커 전용 셀렉터입니다.
@@ -21,16 +31,64 @@ export function InputModeSelector({
   onChange: (mode: InputMode) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({
+    position: 'fixed',
+    visibility: 'hidden',
+  });
   const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
   const selectedOption =
     INPUT_MODE_OPTIONS.find(option => option.value === value) ??
     INPUT_MODE_OPTIONS[0];
 
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    if (typeof window === 'undefined') return;
+
+    const updatePosition = () => {
+      const trigger = containerRef.current;
+      if (!trigger) return;
+
+      const rect = trigger.getBoundingClientRect();
+      const dropdownHeight =
+        listRef.current?.offsetHeight ?? INPUT_MODE_OPTIONS.length * 32 + 2;
+      const opensUp =
+        rect.bottom + DROPDOWN_GAP + dropdownHeight >
+        window.innerHeight - VIEWPORT_GAP;
+
+      setDropdownStyle({
+        position: 'fixed',
+        left: rect.left,
+        top: opensUp
+          ? Math.max(VIEWPORT_GAP, rect.top - DROPDOWN_GAP - dropdownHeight)
+          : rect.bottom + DROPDOWN_GAP,
+        width: rect.width,
+        visibility: 'visible',
+        zIndex: 10000,
+      });
+    };
+
+    updatePosition();
+    const animationFrameId = window.requestAnimationFrame(updatePosition);
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen]);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
       if (
         containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
+        !containerRef.current.contains(target) &&
+        !listRef.current?.contains(target)
       ) {
         setIsOpen(false);
       }
@@ -64,27 +122,32 @@ export function InputModeSelector({
         />
       </button>
 
-      {isOpen && (
-        <ul
-          className="absolute left-0 top-full z-10 mt-1 w-full overflow-hidden rounded-sm border-[0.5px] border-[#1F72EF] bg-white shadow-lg"
-          role="listbox"
-        >
-          {INPUT_MODE_OPTIONS.map(option => (
-            <li key={option.value}>
-              <button
-                type="button"
-                className="flex h-8 w-full items-center justify-center px-2 text-[14px] leading-5 text-text-primary transition-colors hover:bg-[#F3F8FF]"
-                onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
-                }}
-              >
-                {option.label}
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+      {isOpen &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <ul
+            ref={listRef}
+            className="overflow-hidden rounded-sm border-[0.5px] border-[#1F72EF] bg-white shadow-lg"
+            style={dropdownStyle}
+            role="listbox"
+          >
+            {INPUT_MODE_OPTIONS.map(option => (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  className="flex h-8 w-full items-center justify-center px-2 text-[14px] leading-5 text-text-primary transition-colors hover:bg-[#F3F8FF]"
+                  onClick={() => {
+                    onChange(option.value);
+                    setIsOpen(false);
+                  }}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))}
+          </ul>,
+          document.body
+        )}
     </div>
   );
 }

--- a/components/molecules/color-picker/components/ToneControlSection.tsx
+++ b/components/molecules/color-picker/components/ToneControlSection.tsx
@@ -40,12 +40,18 @@ export function ToneControlSection({
           radius={9999}
           width="100%"
           height={20}
+          bgProps={{
+            style: {
+              boxShadow: 'inset 0 0 0 1px #EAEAEA',
+            },
+          }}
           pointer={({ left, top }) => (
             <GlassPointer
               left={left}
               top={top}
               color={hsvaToHslaString(hsva)}
               size={pointerSize}
+              cursor="pointer"
             />
           )}
           onChange={newAlpha => {

--- a/components/molecules/text-editor/TextEditor.tsx
+++ b/components/molecules/text-editor/TextEditor.tsx
@@ -66,6 +66,7 @@ interface TextEditorProps {
   defaultAlign?: TextAlignValue;
   onChange?: (json: JSONContent) => void;
   additionalSlot?: React.ReactNode;
+  placeholderMode?: 'tiptap' | 'overlay';
 }
 
 export interface TextEditorRef {
@@ -210,6 +211,7 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       defaultAlign = DEFAULT_TEXT_ALIGN_OPTION.value,
       onChange,
       additionalSlot = null,
+      placeholderMode = 'tiptap',
     },
     ref
   ) => {
@@ -426,7 +428,9 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
 
     const editor = useEditor({
       immediatelyRender: false,
-      extensions: createTextEditorBarExtensions(defaultText),
+      extensions: createTextEditorBarExtensions(
+        placeholderMode === 'overlay' ? undefined : defaultText
+      ),
       content: value ?? null,
       editorProps: {
         attributes: {
@@ -473,7 +477,9 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       },
     });
 
-    const italicActive = editor ? isTextMarkFullyActive(editor, 'italic') : false;
+    const italicActive = editor
+      ? isTextMarkFullyActive(editor, 'italic')
+      : false;
 
     useEffect(() => {
       void loadEditorFont(
@@ -598,29 +604,29 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       setColorPickerOpen(prev => !prev);
     };
 
-      const handleItalicToggle = () => {
-        if (italicActive) {
-          runAtSavedSelection(editor, command =>
-            command.unsetItalic().setFontStyleOverride('normal')
-          );
-          return;
-        }
-
-        const activeFamily =
-          fontFamilySelected.value === MIXED_STYLE_VALUE
-            ? editorBaseStyles.fontFamily.value
-            : fontFamilySelected.value;
-        const activeWeight =
-          fontWeightSelected.value === MIXED_STYLE_VALUE
-            ? editorBaseStyles.fontWeight.value
-            : fontWeightSelected.value;
-
-        void loadEditorFont(activeFamily, activeWeight, 'italic');
-
+    const handleItalicToggle = () => {
+      if (italicActive) {
         runAtSavedSelection(editor, command =>
-          command.setItalic().setFontStyleOverride(null)
+          command.unsetItalic().setFontStyleOverride('normal')
         );
-      };
+        return;
+      }
+
+      const activeFamily =
+        fontFamilySelected.value === MIXED_STYLE_VALUE
+          ? editorBaseStyles.fontFamily.value
+          : fontFamilySelected.value;
+      const activeWeight =
+        fontWeightSelected.value === MIXED_STYLE_VALUE
+          ? editorBaseStyles.fontWeight.value
+          : fontWeightSelected.value;
+
+      void loadEditorFont(activeFamily, activeWeight, 'italic');
+
+      runAtSavedSelection(editor, command =>
+        command.setItalic().setFontStyleOverride(null)
+      );
+    };
 
     const handleUnderlineToggle = () => {
       if (underlineActive) {
@@ -755,13 +761,20 @@ export const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
         <div
           data-state={editorFocused ? 'focused' : 'default'}
           className={cn(
-            'rounded-lg border px-4 py-3 transition-colors duration-150',
+            'relative rounded-lg border px-4 py-3 transition-colors duration-150',
             editorFocused
               ? 'border-primary bg-bg-base'
               : 'border-transparent bg-border-neutral'
           )}
           style={editorContentStyle}
         >
+          {placeholderMode === 'overlay' &&
+            !editorFocused &&
+            editor.isEmpty && (
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-4 text-center text-[14px] leading-7 text-text-secondary whitespace-pre-wrap">
+                {defaultText}
+              </div>
+            )}
           <EditorContent editor={editor} />
         </div>
       </div>

--- a/components/organisms/calendar/Calendar.tsx
+++ b/components/organisms/calendar/Calendar.tsx
@@ -116,42 +116,41 @@ export function Calendar({ blockInfo, id }: Props) {
   );
 
   return (
-    <LeftEditorWrapper ariaLabel="행사 일시">
+    <LeftEditorWrapper ariaLabel="행사 일시" className="pb-3">
       <NavigationBar>{defaultTitle}</NavigationBar>
 
-      <div className="w-full flex flex-col gap-3 mb-2">
+      <TextField
+        key={`title-${id}`}
+        label="제목"
+        inputProps={{
+          placeholder: blockInfo.type === 'wedding' ? '예식 일시' : '행사 일시',
+          defaultValue: blockInfo.props.title,
+          onChange: handleTitleChange,
+        }}
+        className="w-full text-center py-1.5"
+      />
+
+      {blockInfo.props.isEnglishTitle && (
         <TextField
-          key={`title-${id}`}
-          label="제목"
+          key={`english-title-${id}`}
+          label="영문제목"
           inputProps={{
             placeholder:
-              blockInfo.type === 'wedding' ? '예식 일시' : '행사 일시',
-            defaultValue: blockInfo.props.title,
-            onChange: handleTitleChange,
+              blockInfo.type === 'wedding'
+                ? 'THE WEDDING DATE'
+                : 'THE EVENT DATE',
+            defaultValue: blockInfo.props.englishTitle,
+            onChange: handleEnglishTitleChange,
           }}
           className="w-full text-center py-1.5"
         />
+      )}
 
-        {blockInfo.props.isEnglishTitle && (
-          <TextField
-            key={`english-title-${id}`}
-            label="영문제목"
-            inputProps={{
-              placeholder:
-                blockInfo.type === 'wedding'
-                  ? 'THE WEDDING DATE'
-                  : 'THE EVENT DATE',
-              defaultValue: blockInfo.props.englishTitle,
-              onChange: handleEnglishTitleChange,
-            }}
-            className="w-full text-center py-1.5"
-          />
-        )}
-
+      <div className="flex flex-col gap-1 w-full">
         <Divider className="w-full" />
         <TextField
           label={blockInfo.type === 'wedding' ? '예식일' : '행사일'}
-          className="w-full"
+          className="w-full py-1.5"
           labelClassName="w-14 text-center"
           inputProps={{
             placeholder: '2026-03-09',
@@ -160,7 +159,7 @@ export function Calendar({ blockInfo, id }: Props) {
             maxLength: 10,
           }}
         />
-        <div className="flex items-center gap-2 w-full">
+        <section className="flex flex-row gap-2 items-center w-full py-1.5">
           <Label className="w-14 text-center font-semibold shrink-0">
             {blockInfo.type === 'wedding' ? '예식시간' : '행사시간'}
           </Label>
@@ -170,7 +169,7 @@ export function Calendar({ blockInfo, id }: Props) {
               onChange={handleTimeChange}
             />
           </div>
-        </div>
+        </section>
         <NavigationBar
           action={
             <UtilityButton size="sm" onClick={handleInsertDday}>
@@ -194,49 +193,47 @@ export function Calendar({ blockInfo, id }: Props) {
                     : '내용을 입력해주세요.'
                 }
                 defaultAlign="center"
+                placeholderMode="overlay"
                 onChange={handleEditorChange}
               />
             </div>
-
-            <div className="flex items-center gap-2 w-full">
-              <Label className="w-14 text-center font-semibold shrink-0">
-                추가기능
-              </Label>
-              <div className="flex flex-col">
-                <div className="flex gap-3">
-                  <Checkbox
-                    checked={blockInfo.props.isEnglishTitle}
-                    onChange={handleEnglishTitleCheck}
-                  >
-                    <span className="text-[13px]">영문 제목 추가</span>
-                  </Checkbox>
-                  <Checkbox
-                    checked={blockInfo.props.showDday}
-                    onChange={handleShowDdayChange}
-                  >
-                    <span className="text-[13px]">디데이&카운트다운</span>
-                  </Checkbox>
-                </div>
-                <Checkbox
-                  checked={blockInfo.props.showCalendar}
-                  onChange={handleShowCalendarChange}
-                >
-                  <span className="text-[13px]">캘린더</span>
-                </Checkbox>
-              </div>
-            </div>
           </div>
-          <EditorNoticeList
-            notices={[
-              {
-                id: 'calendar-dday',
-                text: '디데이 버튼 클릭 시 (D-Day)가 추가되며, (D-Day)에 남은 일수가 표시됩니다.',
-                colorClass: 'text-[#1F72EF]',
-              },
-            ]}
-          />
         </div>
+        <section className="flex flex-row gap-2 items-center w-full py-1.5">
+          <Label className="font-semibold">추가기능</Label>
+          <div className="flex flex-col">
+            <div className="flex gap-3">
+              <Checkbox
+                checked={blockInfo.props.isEnglishTitle}
+                onChange={handleEnglishTitleCheck}
+              >
+                <span className="text-[13px]">영문 제목 추가</span>
+              </Checkbox>
+              <Checkbox
+                checked={blockInfo.props.showDday}
+                onChange={handleShowDdayChange}
+              >
+                <span className="text-[13px]">디데이 카운트다운</span>
+              </Checkbox>
+            </div>
+            <Checkbox
+              checked={blockInfo.props.showCalendar}
+              onChange={handleShowCalendarChange}
+            >
+              <span className="text-[13px]">캘린더</span>
+            </Checkbox>
+          </div>
+        </section>
       </div>
+      <EditorNoticeList
+        notices={[
+          {
+            id: 'calendar-dday',
+            text: '디데이 버튼 클릭 시 (D-Day)가 추가되며, (D-Day)에 남은 일수가 표시됩니다.',
+            colorClass: 'text-[#1F72EF]',
+          },
+        ]}
+      />
     </LeftEditorWrapper>
   );
 }

--- a/components/organisms/calendar/components/CalendarType1.tsx
+++ b/components/organisms/calendar/components/CalendarType1.tsx
@@ -36,14 +36,25 @@ export function CalendarType1({
               className={cn(
                 'flex items-center justify-center relative z-1 transition-colors w-8 h-8 text-sm text-text-tertiary',
                 idx % 7 === 0 && 'text-text-wedding',
-                !dayObj.isCurrentMonth && 'opacity-30',
-                dayObj.isTargetDate && 'text-white'
+                !dayObj.isCurrentMonth && 'opacity-30'
               )}
             >
-              {dayObj.num}
-              {dayObj.isTargetDate && (
-                <div className="absolute size-5.5 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 -z-1 bg-text-wedding rounded-full" />
-              )}
+              <span
+                className={cn(
+                  'flex items-center justify-center leading-none',
+                  dayObj.isTargetDate &&
+                    'size-5.5 rounded-full bg-text-wedding text-white'
+                )}
+              >
+                <span
+                  className={cn(
+                    'block leading-none',
+                    dayObj.isTargetDate && 'translate-y-0.5'
+                  )}
+                >
+                  {dayObj.num}
+                </span>
+              </span>
             </div>
           </div>
         ))}

--- a/components/organisms/calendar/components/CalendarType2.tsx
+++ b/components/organisms/calendar/components/CalendarType2.tsx
@@ -31,10 +31,22 @@ export function CalendarType2({
                   dayObj.isTargetDate && 'text-white'
                 )}
               >
-                {dayObj.num}
-                {dayObj.isTargetDate && (
-                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 size-5.5 -z-1 bg-text-wedding rounded-full" />
-                )}
+                <span
+                  className={cn(
+                    'flex items-center justify-center leading-none',
+                    dayObj.isTargetDate &&
+                      'size-5.5 rounded-full bg-text-wedding text-white'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'block leading-none',
+                      dayObj.isTargetDate && 'translate-y-0.5'
+                    )}
+                  >
+                    {dayObj.num}
+                  </span>
+                </span>
               </div>
             </div>
           );

--- a/components/organisms/calendar/components/DDayCountdown.tsx
+++ b/components/organisms/calendar/components/DDayCountdown.tsx
@@ -100,7 +100,7 @@ export function DDayCountdown({ date, time, messageJson }: Props) {
   return (
     <div
       className={cn(
-        'w-full bg-transparent border-t border-border-divider py-6 px-6 flex flex-col items-center justify-center gap-4 font-bold'
+        'w-full bg-transparent border-t border-border-divider py-6 px-6 flex flex-col items-center justify-center gap-4 text-center font-bold'
       )}
     >
       <div className="flex w-full justify-between items-center text-center">

--- a/components/organisms/interview/Interview.tsx
+++ b/components/organisms/interview/Interview.tsx
@@ -136,7 +136,13 @@ export const Interview = ({ blockInfo, id }: Props) => {
     const target = questionItemRefs.current[pendingQuestionId];
     if (!target) return;
 
-    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const scrollContainer = target.closest('section');
+    window.requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({
+        top: scrollContainer.scrollHeight,
+        behavior: 'smooth',
+      });
+    });
     pendingScrollQuestionIdRef.current = null;
   }, [questions]);
 

--- a/components/organisms/interview/Interview.tsx
+++ b/components/organisms/interview/Interview.tsx
@@ -33,6 +33,8 @@ export const Interview = ({ blockInfo, id }: Props) => {
   );
   const [isQuestionListOpen, setIsQuestionListOpen] = useState(false);
   const questionListTriggerRef = useRef<HTMLDivElement>(null);
+  const questionItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const pendingScrollQuestionIdRef = useRef<string | null>(null);
   const [editorResetKey, setEditorResetKey] = useState(0);
   const { title, questions, checkedEnglishTitle, englishTitle } =
     blockInfo.props;
@@ -54,9 +56,14 @@ export const Interview = ({ blockInfo, id }: Props) => {
   };
 
   const handleQuestionListSelect = (content: string, _index?: number) => {
-    updateBlock(id, {
-      questions: [...(questions || []), createInterviewQuestion(content)],
+    const nextQuestion = createInterviewQuestion(content, {
+      includeEmptyTemplate: true,
     });
+
+    updateBlock(id, {
+      questions: [...(questions || []), nextQuestion],
+    });
+    pendingScrollQuestionIdRef.current = nextQuestion.id;
     setEditorResetKey(prev => prev + 1);
     setIsQuestionListOpen(false);
   };
@@ -122,6 +129,17 @@ export const Interview = ({ blockInfo, id }: Props) => {
     }
   }, [id]);
 
+  useEffect(() => {
+    const pendingQuestionId = pendingScrollQuestionIdRef.current;
+    if (!pendingQuestionId) return;
+
+    const target = questionItemRefs.current[pendingQuestionId];
+    if (!target) return;
+
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    pendingScrollQuestionIdRef.current = null;
+  }, [questions]);
+
   return (
     <LeftEditorWrapper ariaLabel="인터뷰" className="pb-3">
       <NavigationBar
@@ -178,7 +196,13 @@ export const Interview = ({ blockInfo, id }: Props) => {
 
       <div className="flex flex-col gap-1 w-full">
         {(questions || []).map((question, index) => (
-          <div key={question.id} className="flex flex-col gap-1">
+          <div
+            key={question.id}
+            ref={element => {
+              questionItemRefs.current[question.id] = element;
+            }}
+            className="flex flex-col gap-1"
+          >
             {index !== 0 && <Divider className="w-full" />}
             <InterviewItem
               id={id}

--- a/components/organisms/interview/InterviewItem.tsx
+++ b/components/organisms/interview/InterviewItem.tsx
@@ -7,7 +7,10 @@ import { Picture } from '@/components/molecules/picture/Picture';
 import { TextEditor } from '@/components/molecules/text-editor';
 import { cn } from '@/shared/utils/cn';
 
-import type { InterviewQuestion } from './interviewList';
+import {
+  DEFAULT_INTERVIEW_QUESTION,
+  type InterviewQuestion,
+} from './interviewList';
 
 interface Props {
   id: string;
@@ -38,7 +41,10 @@ export const InterviewItem = ({
         label="인터뷰"
         inputProps={{
           placeholder: '제목을 입력해 주세요',
-          value: question.question,
+          value:
+            question.question === DEFAULT_INTERVIEW_QUESTION
+              ? ''
+              : question.question,
           onChange: onQuestionChange,
         }}
         className="w-full py-1.5 text-center"

--- a/components/organisms/interview/interviewList.ts
+++ b/components/organisms/interview/interviewList.ts
@@ -107,23 +107,25 @@ export const getInterviewDefaultImage = (
 };
 
 export const createInterviewQuestion = (
-  label = EMPTY_INTERVIEW_OPTION
+  label = EMPTY_INTERVIEW_OPTION,
+  options: { includeEmptyTemplate?: boolean } = {}
 ): InterviewQuestion => {
   const isEmptyOption = label === EMPTY_INTERVIEW_OPTION;
   const preset = isEmptyOption ? undefined : getInterviewPresetByLabel(label);
-  const defaultAnswerJson = isEmptyOption
+  const defaultAnswerJson = isEmptyOption && options.includeEmptyTemplate
     ? createDefaultInterviewAnswerJson()
     : null;
 
   return {
     id: crypto.randomUUID(),
     presetId: preset?.id,
-    question: isEmptyOption
-      ? DEFAULT_INTERVIEW_QUESTION
-      : (preset?.label ?? label),
+    question: isEmptyOption ? '' : (preset?.label ?? label),
     answer: {
       messageJson: defaultAnswerJson,
-      messageHtml: isEmptyOption ? DEFAULT_INTERVIEW_ANSWER_HTML : null,
+      messageHtml:
+        isEmptyOption && options.includeEmptyTemplate
+          ? DEFAULT_INTERVIEW_ANSWER_HTML
+          : null,
     },
     image: [],
   };

--- a/components/organisms/notice/Notice.tsx
+++ b/components/organisms/notice/Notice.tsx
@@ -35,6 +35,8 @@ export const Notice = ({ blockInfo, id }: Props) => {
   );
   const [isNoticeListOpen, setIsNoticeListOpen] = useState(false);
   const noticeListTriggerRef = useRef<HTMLDivElement>(null);
+  const noticeItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const pendingScrollNoticeIdRef = useRef<string | null>(null);
   const [editorResetKey, setEditorResetKey] = useState(0);
 
   const { noticeList, title, checkedEnglishTitle, englishTitle } =
@@ -57,9 +59,12 @@ export const Notice = ({ blockInfo, id }: Props) => {
   };
 
   const handleNoticeListSelect = (content: string, _index?: number) => {
+    const nextNotice = createNoticeItem(content);
+
     updateBlock(id, {
-      noticeList: [...(noticeList || []), createNoticeItem(content)],
+      noticeList: [...(noticeList || []), nextNotice],
     });
+    pendingScrollNoticeIdRef.current = nextNotice.id;
     setEditorResetKey(prev => prev + 1);
     setIsNoticeListOpen(false);
   };
@@ -124,6 +129,17 @@ export const Notice = ({ blockInfo, id }: Props) => {
     }
   }, [id]);
 
+  useEffect(() => {
+    const pendingNoticeId = pendingScrollNoticeIdRef.current;
+    if (!pendingNoticeId) return;
+
+    const target = noticeItemRefs.current[pendingNoticeId];
+    if (!target) return;
+
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    pendingScrollNoticeIdRef.current = null;
+  }, [noticeList]);
+
   return (
     <LeftEditorWrapper ariaLabel="공지사항" className="pb-3">
       <NavigationBar
@@ -181,7 +197,13 @@ export const Notice = ({ blockInfo, id }: Props) => {
 
       <div className="flex flex-col gap-1 w-full">
         {(noticeList || []).map((notice, index) => (
-          <div key={notice.id} className="flex flex-col gap-1">
+          <div
+            key={notice.id}
+            ref={element => {
+              noticeItemRefs.current[notice.id] = element;
+            }}
+            className="flex flex-col gap-1"
+          >
             {index !== 0 && <Divider className="w-full" />}
             <NoticeItem
               id={id}

--- a/components/organisms/notice/Notice.tsx
+++ b/components/organisms/notice/Notice.tsx
@@ -136,7 +136,13 @@ export const Notice = ({ blockInfo, id }: Props) => {
     const target = noticeItemRefs.current[pendingNoticeId];
     if (!target) return;
 
-    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const scrollContainer = target.closest('section');
+    window.requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({
+        top: scrollContainer.scrollHeight,
+        behavior: 'smooth',
+      });
+    });
     pendingScrollNoticeIdRef.current = null;
   }, [noticeList]);
 

--- a/components/organisms/notice/NoticeItem.tsx
+++ b/components/organisms/notice/NoticeItem.tsx
@@ -6,7 +6,8 @@ import { Picture } from '@/components/molecules/picture/Picture';
 import { TextEditor } from '@/components/molecules/text-editor';
 import { cn } from '@/shared/utils/cn';
 
-import type { NoticeListItem } from './noticeList';
+import { DEFAULT_NOTICE_TITLE, type NoticeListItem } from './noticeList';
+
 import type { JSONContent } from '@tiptap/react';
 
 interface Props {
@@ -38,7 +39,7 @@ export const NoticeItem = ({
         label="공지제목"
         inputProps={{
           placeholder: '제목을 입력해 주세요',
-          value: notice.notice,
+          value: notice.notice === DEFAULT_NOTICE_TITLE ? '' : notice.notice,
           onChange: onNoticeChange,
         }}
         className="w-full py-1.5 text-center"

--- a/components/organisms/notice/noticeList.ts
+++ b/components/organisms/notice/noticeList.ts
@@ -82,7 +82,7 @@ export const createNoticeItem = (
   return {
     id: crypto.randomUUID(),
     presetId: preset?.id,
-    notice: isEmptyOption ? DEFAULT_NOTICE_TITLE : (preset?.label ?? label),
+    notice: isEmptyOption ? '' : (preset?.label ?? label),
     content: {
       messageJson: null,
       messageHtml: null,

--- a/components/organisms/notice/noticeList.ts
+++ b/components/organisms/notice/noticeList.ts
@@ -71,7 +71,7 @@ export const getNoticePresetForItem = (
 
 export const getNoticeDefaultImage = (
   item: Pick<NoticeListItem, 'notice' | 'presetId'>
-) => getNoticePresetForItem(item)?.image;
+) => getNoticePresetForItem(item)?.image ?? DEFAULT_NOTICE_PRESET.image;
 
 export const createNoticeItem = (
   label = EMPTY_NOTICE_OPTION

--- a/components/organisms/picture/PictureBlock.tsx
+++ b/components/organisms/picture/PictureBlock.tsx
@@ -49,7 +49,10 @@ function PictureBlock({ blockInfo, id }: Props) {
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const checked = e.target.checked;
-    updateBlock(id, { isTitle: checked, isEnglishTitle: checked });
+    updateBlock(
+      id,
+      checked ? { isTitle: true } : { isTitle: false, isEnglishTitle: false }
+    );
   };
   const handleEngTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     updateBlock(id, { isEnglishTitle: e.target.checked });
@@ -130,9 +133,12 @@ function PictureBlock({ blockInfo, id }: Props) {
                 <span className="text-[13px]">제목 추가</span>
               </Checkbox>
               <Checkbox
-                className={!blockInfo.props.isTitle ? 'hidden' : undefined}
-                checked={blockInfo.props.isEnglishTitle}
+                checked={
+                  blockInfo.props.isTitle && blockInfo.props.isEnglishTitle
+                }
                 onChange={handleEngTitleChange}
+                disabled={!blockInfo.props.isTitle}
+                dimDisabled={false}
               >
                 <span className="text-[13px]">영문 제목 추가</span>
               </Checkbox>

--- a/components/organisms/popup/PopupOptions.tsx
+++ b/components/organisms/popup/PopupOptions.tsx
@@ -71,11 +71,12 @@ function PopupOptions({
       onClose={onClose}
       triggerRef={triggerRef}
       hideCloseButton
-      wrapperClassName="w-[280px] pb-3.5 pl-4 pr-3"
+      wrapperClassName="h-[370px] w-[280px] px-0"
+      contentClassName="min-h-0 flex-1 px-4 pb-3.5"
     >
       <ul
         className={cn(
-          'h-[370px] max-h-[370px] space-y-3 overflow-y-auto edit-custom-scrollbar pr-1',
+          'h-full max-h-full space-y-3 overflow-y-auto scrollbar-hide',
           listWrapperClassName
         )}
       >

--- a/widgets/editor/preview/Preview.tsx
+++ b/widgets/editor/preview/Preview.tsx
@@ -34,9 +34,13 @@ function Preview() {
   const isPreviewCalloutOpen = useEditorCalloutStore(
     state => state.callouts['preview-panel']
   );
+  const isAnyCalloutOpen = useEditorCalloutStore(
+    state => state.callouts['preview-panel'] || state.callouts['order-panel']
+  );
   const showAllCalloutsFor = useEditorCalloutStore(
     state => state.showAllCalloutsFor
   );
+  const hideAllCallouts = useEditorCalloutStore(state => state.hideAllCallouts);
 
   useEffect(() => {
     if (!selectedId) return;
@@ -130,6 +134,11 @@ function Preview() {
         className="absolute left-[-24px] top-[95%] z-[20000] flex h-8 w-8 -translate-x-full -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-black/5 bg-white text-[#111827] shadow-[0_8px_24px_0_rgb(0_0_0_/_6%),0_2px_10px_0_rgb(0_0_0_/_8%)] transition-colors enabled:hover:bg-[#FAFAFB] enabled:active:bg-[#F5F8FF]"
         onClick={event => {
           event.stopPropagation();
+          if (isAnyCalloutOpen) {
+            hideAllCallouts();
+            return;
+          }
+
           showAllCalloutsFor(6000);
         }}
       >


### PR DESCRIPTION
# FEATURE

---

## 📋 작업 내용

- 대시보드 제목/에디터 이동 버튼을 동일한 스케일 요소로 묶어 반응형 크기 조정 적용
- 대시보드 캐러셀 최소 높이 보정
- 캘린더, 팝업 옵션, 체크박스, 컬러픽커, 텍스트 에디터 UI 폴리싱
- 인터뷰/공지사항 기본 플레이스홀더 및 항목 추가 시 스크롤 동작 개선
- 캘린더 예식 일시 D-Day 메시지 프리뷰가 다른 텍스트 프리뷰처럼 중앙 정렬되도록 수정
- 에디터 물음표 콜아웃 버튼 재클릭 시 애니메이션과 함께 닫히는 토글 동작 추가

## 🔗 관련 이슈

Closes # null

## 📸 스크린샷 / 영상

미첨부

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [x] 디자인 시안과 비교 확인
- [ ] 최악의 환경에서 확인 (느린 네트워크 환경)
- [ ] 모바일 환경에서 테스트

## 🧪 테스트 방법

1. 대시보드에서 브라우저 크기를 조정하며 제목 영역과 에디터 이동 버튼이 함께 스케일되는지 확인
2. 에디터에서 캘린더, 인터뷰, 공지사항, 팝업, 컬러픽커, 텍스트 에디터 UI가 정상 동작하는지 확인
3. 캘린더 예식 일시의 텍스트 에디터에 내용을 입력하고 프리뷰에서 중앙 정렬로 표시되는지 확인
4. 에디터 물음표 버튼 클릭 시 콜아웃이 열리고, 다시 클릭하면 닫힘 애니메이션과 함께 사라지는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 대시보드 제목 영역과 작업 버튼이 재배치되어 더 안정적으로 표시됩니다.
  * 텍스트 편집기에서 플레이스홀더 표시 방식이 개선되어 더 자연스럽게 보입니다.
  * 질문/공지/항목 추가 후 새로 만든 항목으로 자동 스크롤됩니다.

* **Bug Fixes**
  * 캐러셀 영역이 너무 작아지는 문제를 줄여 최소 높이를 보장합니다.
  * 비활성 체크박스와 색상 선택 도구의 커서·표시 상태가 더 일관되게 동작합니다.
  * 달력의 선택된 날짜 표시와 정렬이 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->