### PR TITLE
[Fix] 프레임의 복사, 그룹 선택 비활성화 및 영역 선택 오류 개선

### DIFF
--- a/components/molecules/selector/Selector.tsx
+++ b/components/molecules/selector/Selector.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react';
-import { useSearchParams } from 'next/navigation';
+// import { useSearchParams } from 'next/navigation';
 import {
   useState,
   useRef,
@@ -87,8 +87,8 @@ export const Selector = <T extends Option>({
   const popoverRef = useRef<HTMLUListElement>(null);
   const baseId = useId();
   const popoverId = `popover-${baseId}`;
-  const searchParams = useSearchParams();
-  const isAdmin = searchParams.get('type') === 'admin';
+  // const searchParams = useSearchParams();
+  // const isAdmin = searchParams.get('type') === 'admin';
 
   // 실제 값이 있는지 확인 (객체 내부의 value나 label 체크)
   const hasValue = !!(selected?.value || selected?.label);
@@ -199,14 +199,15 @@ export const Selector = <T extends Option>({
     };
   }, [isOpen, updatePopoverPosition]);
 
-  const filteredOptions =
-    searchable || isAdmin
-      ? options.filter(opt => {
-          const labelStr =
-            typeof opt.label === 'string' ? opt.label : String(opt.label);
-          return labelStr.toLowerCase().includes(searchTerm.toLowerCase());
-        })
-      : options;
+  // const filteredOptions =
+  //   searchable || isAdmin
+  const filteredOptions = searchable
+    ? options.filter(opt => {
+        const labelStr =
+          typeof opt.label === 'string' ? opt.label : String(opt.label);
+        return labelStr.toLowerCase().includes(searchTerm.toLowerCase());
+      })
+    : options;
 
   const variantStyles = variant ? selectorStyles[variant] : null;
 
@@ -305,7 +306,8 @@ export const Selector = <T extends Option>({
           inset: 'auto', // popover 기본값 오버라이드
         }}
       >
-        {(searchable || isAdmin) && (
+        {/* {(searchable || isAdmin) && ( */}
+        {searchable && (
           <div className="sticky top-0 z-10 p-1 bg-bg-base border-b border-border-neutral rounded-md">
             <Input
               type="text"

--- a/widgets/mainPoster/components/MainPoster.tsx
+++ b/widgets/mainPoster/components/MainPoster.tsx
@@ -1,8 +1,8 @@
-import { useSearchParams } from 'next/navigation';
+// import { useSearchParams } from 'next/navigation';
 import { useShallow } from 'zustand/shallow';
 
 import { UtilityButton } from '@/components/atoms/button';
-import { Label } from '@/components/atoms/label/Label';
+// import { Label } from '@/components/atoms/label/Label';
 import { NavigationBar } from '@/components/molecules/navigation-bar/NavigationBar';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
@@ -21,10 +21,11 @@ export const MainPoster = () => {
       setActiveTab: state.setActiveTab,
     }))
   );
-  const searchParams = useSearchParams();
-  const isAdmin = searchParams.get('type') === 'admin';
-  const { canvas, exportCanvasPreview, exportIntersectedJSON, createTextBox } =
-    useFabricContext();
+  // const searchParams = useSearchParams();
+  // const isAdmin = searchParams.get('type') === 'admin';
+  // const { canvas, exportCanvasPreview, exportIntersectedJSON, createTextBox } =
+  //   useFabricContext();
+  const { canvas, createTextBox } = useFabricContext();
 
   if (!canvas) return null;
 
@@ -60,28 +61,28 @@ export const MainPoster = () => {
     },
   ];
 
-  const handleDownloadImage = () => {
-    const preview = exportCanvasPreview();
-    if (!preview) return;
-    const link = document.createElement('a');
-    link.href = preview.dataUrl;
-    link.download = preview.name;
-    link.click();
-  };
+  // const handleDownloadImage = () => {
+  //   const preview = exportCanvasPreview();
+  //   if (!preview) return;
+  //   const link = document.createElement('a');
+  //   link.href = preview.dataUrl;
+  //   link.download = preview.name;
+  //   link.click();
+  // };
 
-  const handleDownloadJSON = () => {
-    const json = exportIntersectedJSON();
-    if (!json) return;
-    const blob = new Blob([JSON.stringify(json, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'template.json';
-    link.click();
-    URL.revokeObjectURL(url);
-  };
+  // const handleDownloadJSON = () => {
+  //   const json = exportIntersectedJSON();
+  //   if (!json) return;
+  //   const blob = new Blob([JSON.stringify(json, null, 2)], {
+  //     type: 'application/json',
+  //   });
+  //   const url = URL.createObjectURL(blob);
+  //   const link = document.createElement('a');
+  //   link.href = url;
+  //   link.download = 'template.json';
+  //   link.click();
+  //   URL.revokeObjectURL(url);
+  // };
 
   if (!canvas) return null;
 
@@ -90,7 +91,7 @@ export const MainPoster = () => {
       className="flex flex-col pb-3.5 px-5 items-center w-full max-h-[812px] overflow-y-scroll overflow-x-hidden scrollbar-hide"
       data-canvas="true"
     >
-      {isAdmin && (
+      {/* {isAdmin && (
         <div className="flex gap-2 w-full py-3">
           <Label className="text-sm text-text-secondary">개발용</Label>
           <UtilityButton
@@ -108,7 +109,7 @@ export const MainPoster = () => {
             데이터 다운로드
           </UtilityButton>
         </div>
-      )}
+      )} */}
 
       <NavigationBar
         action={

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -4,6 +4,7 @@ import {
   Canvas,
   FabricObject,
   FabricImage,
+  Point,
   Rect,
   Circle,
   Triangle,
@@ -30,6 +31,7 @@ import {
   getImagePanelMode,
   isFilledSlotImage,
   isFrameTarget,
+  isPointInsideSlotFrame,
   isReplaceableSlotImage,
   isReplaceableSlotTarget,
   SlotTargetObject,
@@ -284,21 +286,34 @@ export const MainPosterPreview = () => {
       }
     };
 
+    const isSelectableAtPointer = (
+      object: FabricObject | undefined,
+      pointer: Point
+    ) => {
+      if (!object) return false;
+      if (isReplaceableSlotImage(object)) {
+        return isPointInsideSlotFrame(object, pointer);
+      }
+      return object.containsPoint(pointer);
+    };
     // 마우스 드래그해 그룹으로 영역 선택시 잠금 객체 제외하고 선택될수있게
     const handleMouseDown = (options: TPointerEventInfo) => {
       const e = options.e as MouseEvent;
       if (e.button === 2) return; // 우클릭(Right Click)은 무시
 
+      const pointer = options.scenePoint || fabricCanvas.getScenePoint(e);
       let target = options.target;
+
+      if (target && !isSelectableAtPointer(target, pointer)) {
+        target = undefined;
+      }
+
       const targetId = target?.get('id');
       const isBackground = targetId === 'background-layer';
-      const isLocked = (target as any)?.isLocked;
+      const isLocked = (target as FabricObjectWithLock | undefined)?.isLocked;
       const isFrame = isFrameTarget(target);
-
       // 잠긴 객체가 잡혔을 때, 그 위치에 있는 다른 (잠기지 않은) 객체를 찾아서 선택해줌
       if (target && (isLocked || isFrame) && !isBackground) {
-        const pointer =
-          options.scenePoint || (fabricCanvas as any).getScenePoint(e);
         const objects = fabricCanvas.getObjects();
 
         // 역순(맨 위 객체부터)으로 탐색하여 잠기지 않은 객체가 있는지 확인
@@ -306,9 +321,9 @@ export const MainPosterPreview = () => {
           const obj = objects[i];
           if (
             obj !== target &&
-            !(obj as any).isLocked &&
+            !(obj as FabricObjectWithLock).isLocked &&
             !isFrameTarget(obj) &&
-            obj.containsPoint(pointer)
+            isSelectableAtPointer(obj, pointer)
           ) {
             fabricCanvas.setActiveObject(obj);
             target = obj;
@@ -354,12 +369,20 @@ export const MainPosterPreview = () => {
 
       if (isCropping) return;
 
-      if (isReplaceableSlotTarget(options.target)) {
-        fabricCanvas.setActiveObject(options.target);
+      const pointer =
+        options.scenePoint || fabricCanvas.getScenePoint(options.e);
+      const slotTarget =
+        isReplaceableSlotTarget(options.target) &&
+        isSelectableAtPointer(options.target, pointer)
+          ? options.target
+          : null;
+
+      if (slotTarget) {
+        fabricCanvas.setActiveObject(slotTarget);
         setActiveTab('image');
 
-        if (!isAdmin && !isFilledSlotImage(options.target)) {
-          openSlotFilePicker(options.target);
+        if (!isAdmin && !isFilledSlotImage(slotTarget)) {
+          openSlotFilePicker(slotTarget);
         }
       }
     };

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -5,14 +5,14 @@ import {
   FabricObject,
   FabricImage,
   Point,
-  Rect,
-  Circle,
-  Triangle,
+  // Rect,
+  // Circle,
+  // Triangle,
   TPointerEventInfo,
   Textbox,
   IText,
 } from 'fabric';
-import { useSearchParams } from 'next/navigation';
+// import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 
@@ -41,8 +41,8 @@ import { ContextMenu } from './context-menu/ContextMenu';
 import Toolbar from './Toolbar';
 
 export const MainPosterPreview = () => {
-  const searchParams = useSearchParams();
-  const isAdmin = searchParams.get('type') === 'admin';
+  // const searchParams = useSearchParams();
+  // const isAdmin = searchParams.get('type') === 'admin';
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isMouseInCanvasRef = useRef(false);
   const isInitialLoadDoneRef = useRef(false);
@@ -185,11 +185,11 @@ export const MainPosterPreview = () => {
       const isActiveText =
         activeObj instanceof Textbox || activeObj instanceof IText;
       const imagePanelMode = getImagePanelMode(activeObj);
-      const isActiveShape =
-        activeObj instanceof Rect ||
-        activeObj instanceof Circle ||
-        activeObj instanceof Triangle ||
-        activeObj.isType('line');
+      // const isActiveShape =
+      //   activeObj instanceof Rect ||
+      //   activeObj instanceof Circle ||
+      //   activeObj instanceof Triangle ||
+      //   activeObj.isType('line');
       const isCropZone =
         (activeObj as FabricObject & { name?: string })?.name === 'crop-zone';
 
@@ -204,9 +204,11 @@ export const MainPosterPreview = () => {
         setActiveTab('image');
       } else if (imagePanelMode === 'empty-frame') {
         setActiveTab('image');
-      } else if (isActiveShape && isAdmin) {
-        setActiveTab('shape');
-      } else {
+      }
+      // else if (isActiveShape && isAdmin) {
+      //   setActiveTab('shape');
+      // }
+      else {
         setActiveTab('background');
       }
     };
@@ -233,7 +235,8 @@ export const MainPosterPreview = () => {
       fabricCanvas.off('selection:cleared', handleSelectionCleared);
       fabricCanvas.dispose();
     };
-  }, [isAdmin, setCanvas, setActiveTab]);
+    // }, [isAdmin, setCanvas, setActiveTab]);
+  }, [setCanvas, setActiveTab]);
 
   useEffect(() => {
     if (!canvas) return;
@@ -381,7 +384,8 @@ export const MainPosterPreview = () => {
         fabricCanvas.setActiveObject(slotTarget);
         setActiveTab('image');
 
-        if (!isAdmin && !isFilledSlotImage(slotTarget)) {
+        // if (!isAdmin && !isFilledSlotImage(slotTarget)) {
+        if (!isFilledSlotImage(slotTarget)) {
           openSlotFilePicker(slotTarget);
         }
       }
@@ -406,7 +410,7 @@ export const MainPosterPreview = () => {
     setActiveTab,
     setupEventListeners,
     startCrop,
-    isAdmin,
+    // isAdmin,
   ]);
 
   // 마우스가 캔버스에 들어왔는지 나갔는지 확인

--- a/widgets/mainPoster/components/MainPosterPreview.tsx
+++ b/widgets/mainPoster/components/MainPosterPreview.tsx
@@ -29,6 +29,7 @@ import { preloadPreviewFonts } from '../utils/fontLoader';
 import {
   getImagePanelMode,
   isFilledSlotImage,
+  isFrameTarget,
   isReplaceableSlotImage,
   isReplaceableSlotTarget,
   SlotTargetObject,
@@ -292,25 +293,10 @@ export const MainPosterPreview = () => {
       const targetId = target?.get('id');
       const isBackground = targetId === 'background-layer';
       const isLocked = (target as any)?.isLocked;
-
-      const getType = (obj: any) => {
-        if (!obj) return '빈 공간';
-        if (obj.get('id') === 'background-layer') return '배경';
-        if (obj.isType('textbox') || obj.isType('itext') || obj.isType('text'))
-          return '텍스트';
-        if (obj.isType('image')) return '이미지';
-        if (
-          obj.isType('rect') ||
-          obj.isType('circle') ||
-          obj.isType('triangle')
-        )
-          return '도형';
-        if (obj.isType('path') || obj.isType('line')) return '선/경로';
-        return obj.type;
-      };
+      const isFrame = isFrameTarget(target);
 
       // 잠긴 객체가 잡혔을 때, 그 위치에 있는 다른 (잠기지 않은) 객체를 찾아서 선택해줌
-      if (target && isLocked && !isBackground) {
+      if (target && (isLocked || isFrame) && !isBackground) {
         const pointer =
           options.scenePoint || (fabricCanvas as any).getScenePoint(e);
         const objects = fabricCanvas.getObjects();
@@ -321,12 +307,11 @@ export const MainPosterPreview = () => {
           if (
             obj !== target &&
             !(obj as any).isLocked &&
+            !isFrameTarget(obj) &&
             obj.containsPoint(pointer)
           ) {
-            console.log(`[Fabric] 잠긴 객체 투과 -> ${getType(obj)} 선택`);
-
             fabricCanvas.setActiveObject(obj);
-            target = obj; // ?��?교체
+            target = obj;
             break;
           }
         }
@@ -337,7 +322,9 @@ export const MainPosterPreview = () => {
         fabricCanvas.getObjects().forEach(obj => {
           const t = obj as FabricObjectWithLock;
           if (
-            (t.isLocked || t.get('id') === 'background-layer') &&
+            (t.isLocked ||
+              t.get('id') === 'background-layer' ||
+              isFrameTarget(t)) &&
             t !== target
           ) {
             t.set({ selectable: false });
@@ -356,7 +343,11 @@ export const MainPosterPreview = () => {
       // 드래그 종료 시 (또는 클릭 종료 시) 잠긴 객체와 배경 레이어의 selectable 다시 복구
       fabricCanvas.getObjects().forEach(obj => {
         const target = obj as FabricObjectWithLock;
-        if (target.isLocked || target.get('id') === 'background-layer') {
+        if (
+          target.isLocked ||
+          target.get('id') === 'background-layer' ||
+          isFrameTarget(target)
+        ) {
           target.set({ selectable: true });
         }
       });

--- a/widgets/mainPoster/components/Toolbar.tsx
+++ b/widgets/mainPoster/components/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'next/navigation';
+// import { useSearchParams } from 'next/navigation';
 import React from 'react';
 import { useShallow } from 'zustand/shallow';
 
@@ -13,7 +13,8 @@ import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
 
 function Toolbar() {
-  const { canvas, createTextBox, setDrawingType, drawingType, addSlotRect } =
+  // const { canvas, createTextBox, setDrawingType, drawingType, addSlotRect } = useFabricContext();
+  const { canvas, createTextBox, setDrawingType, drawingType } =
     useFabricContext();
   const { activeTab, setActiveTab } = useEditorStore(
     useShallow(state => ({
@@ -21,8 +22,9 @@ function Toolbar() {
       setActiveTab: state.setActiveTab,
     }))
   );
-  const searchParams = useSearchParams();
-  const isAdmin = searchParams.get('type') === 'admin';
+
+  // const searchParams = useSearchParams();
+  // const isAdmin = searchParams.get('type') === 'admin';
 
   if (!canvas) return null;
 
@@ -98,66 +100,66 @@ function Toolbar() {
     },
   ];
 
-  if (isAdmin) {
-    TOOLBAR_ITEMS.unshift({
-      id: 'slot',
-      active: activeTab === 'slot',
-      araiaLabel: '슬롯 추가',
-      icon: (
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-          <path d="M3 9h18"></path>
-          <path d="M9 3v18"></path>
-        </svg>
-      ),
-      hoverIcon: (
-        <p className="w-26.25 font-bold text-[16px] text-text-plain">
-          슬롯 추가
-        </p>
-      ),
-      onClick: () => {
-        setActiveTab('slot');
-        addSlotRect();
-      },
-    });
+  // if (isAdmin) {
+  //   TOOLBAR_ITEMS.unshift({
+  //     id: 'slot',
+  //     active: activeTab === 'slot',
+  //     araiaLabel: '슬롯 추가',
+  //     icon: (
+  //       <svg
+  //         width="14"
+  //         height="14"
+  //         viewBox="0 0 24 24"
+  //         fill="none"
+  //         stroke="currentColor"
+  //         strokeWidth="2"
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //       >
+  //         <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+  //         <path d="M3 9h18"></path>
+  //         <path d="M9 3v18"></path>
+  //       </svg>
+  //     ),
+  //     hoverIcon: (
+  //       <p className="w-26.25 font-bold text-[16px] text-text-plain">
+  //         슬롯 추가
+  //       </p>
+  //     ),
+  //     onClick: () => {
+  //       setActiveTab('slot');
+  //       addSlotRect();
+  //     },
+  //   });
 
-    TOOLBAR_ITEMS.unshift({
-      id: 'shape',
-      active: activeTab === 'shape',
-      araiaLabel: '도형 추가',
-      icon: (
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-        </svg>
-      ),
-      hoverIcon: (
-        <p className="w-26.25 font-bold text-[16px] text-text-plain">
-          도형 추가
-        </p>
-      ),
-      onClick: () => {
-        setActiveTab('shape');
-      },
-    });
-  }
+  //   TOOLBAR_ITEMS.unshift({
+  //     id: 'shape',
+  //     active: activeTab === 'shape',
+  //     araiaLabel: '도형 추가',
+  //     icon: (
+  //       <svg
+  //         width="14"
+  //         height="14"
+  //         viewBox="0 0 24 24"
+  //         fill="none"
+  //         stroke="currentColor"
+  //         strokeWidth="2"
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //       >
+  //         <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+  //       </svg>
+  //     ),
+  //     hoverIcon: (
+  //       <p className="w-26.25 font-bold text-[16px] text-text-plain">
+  //         도형 추가
+  //       </p>
+  //     ),
+  //     onClick: () => {
+  //       setActiveTab('shape');
+  //     },
+  //   });
+  // }
 
   return (
     <div

--- a/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
+++ b/widgets/mainPoster/components/context-menu/CopyAndPaste.tsx
@@ -1,5 +1,9 @@
 import { cn } from '@/shared/utils/cn';
 import { useFabricContext } from '@/widgets/mainPoster/context/FabricContext';
+import {
+  containsFrameTarget,
+  isFrameTarget,
+} from '@/widgets/mainPoster/utils/imageSlot';
 
 import { ActiveStyle, DisabledShortCutStyle, DisabledStyle } from './style';
 
@@ -8,8 +12,13 @@ interface Props {
 }
 
 function CopyAndPaste({ onClick }: Props) {
-  const { copy, paste, activeInfo, clipboard } = useFabricContext();
-  const hasActiveObject = activeInfo.type !== null;
+  const { copy, paste, activeInfo, clipboard, canvas } = useFabricContext();
+  const activeObject = canvas?.getActiveObject() ?? null;
+  const activeObjects = canvas?.getActiveObjects() ?? [];
+  const hasCopyRestrictedFrame =
+    (activeObject ? isFrameTarget(activeObject) : false) ||
+    containsFrameTarget(activeObjects);
+  const hasActiveObject = activeInfo.type !== null && !hasCopyRestrictedFrame;
   const hasClipboard = clipboard !== null;
 
   return (

--- a/widgets/mainPoster/components/image/ImagePanel.tsx
+++ b/widgets/mainPoster/components/image/ImagePanel.tsx
@@ -204,19 +204,18 @@ const DefaultImagePanel = () => {
         onChange={() => {}}
         onCommit={() => {}}
       />
-      {activeUserImage ? (
-        <div className="w-full flex items-center gap-3">
-          <Label className="font-semibold">추가기능</Label>
-          <Checkbox
-            checked={false}
-            onChange={async event => {
-              await handleSetAsBackground(event.target.checked);
-            }}
-          >
-            <span className="text-[13px]">해당 이미지를 배경으로 적용하기</span>
-          </Checkbox>
-        </div>
-      ) : null}
+      <div className="w-full flex items-center gap-3">
+        <Label className="font-semibold">추가기능</Label>
+        <Checkbox
+          checked={false}
+          disabled={!activeUserImage}
+          onChange={async event => {
+            await handleSetAsBackground(event.target.checked);
+          }}
+        >
+          <span className="text-[13px]">해당 이미지를 배경으로 적용하기</span>
+        </Checkbox>
+      </div>
       <EditorNoticeList
         className="pl-1"
         notices={[

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useConfirm } from '@/shared/hooks/useConfirm';
 
 import { ActiveObject } from '../types/fabric';
+import { containsFrameTarget, isFrameTarget } from '../utils/imageSlot';
 export const useFabric = () => {
   const [canvas, setCanvas] = useState<Canvas | null>(null);
   const [activeInfo, setActiveInfo] = useState<ActiveObject>({
@@ -240,6 +241,12 @@ export const useFabric = () => {
     if (!canvas) return;
     const activeObject = canvas.getActiveObject();
     if (!activeObject) return;
+
+    const activeObjects = canvas.getActiveObjects();
+    if (isFrameTarget(activeObject) || containsFrameTarget(activeObjects)) {
+      return;
+    }
+
     const cloned = await activeObject.clone();
     setClipboard(cloned);
   }, [canvas]);

--- a/widgets/mainPoster/hooks/useFabric.ts
+++ b/widgets/mainPoster/hooks/useFabric.ts
@@ -24,50 +24,50 @@ export const useFabric = () => {
   const isRestoringCanvasState = useRef<boolean>(false);
   const { confirm } = useConfirm();
   const MAX_STACK_SIZE = 30;
-  const shouldLogSelection =
-    typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).get('type') === 'admin';
+  // const shouldLogSelection =
+  //   typeof window !== 'undefined' &&
+  //   new URLSearchParams(window.location.search).get('type') === 'admin';
 
-  const logSelectionSnapshot = useCallback(
-    (label: string, targetCanvas?: Canvas | null) => {
-      const currentCanvas = targetCanvas ?? canvas;
-      if (!currentCanvas || !shouldLogSelection) return;
+  // const logSelectionSnapshot = useCallback(
+  //   (label: string, targetCanvas?: Canvas | null) => {
+  //     const currentCanvas = targetCanvas ?? canvas;
+  //     if (!currentCanvas || !shouldLogSelection) return;
 
-      const activeObject = currentCanvas.getActiveObject();
-      const activeObjects = currentCanvas.getActiveObjects();
+  //     const activeObject = currentCanvas.getActiveObject();
+  //     const activeObjects = currentCanvas.getActiveObjects();
 
-      console.groupCollapsed(`[Fabric][Selection] ${label}`);
-      console.log('activeObject', {
-        id: activeObject?.get?.('id'),
-        type: activeObject?.type,
-        selectable: activeObject?.selectable,
-        evented: activeObject?.evented,
-        isLocked: (activeObject as any)?.isLocked,
-      });
-      console.log(
-        'activeObjects',
-        activeObjects.map(obj => ({
-          id: obj.get?.('id'),
-          type: obj.type,
-          selectable: obj.selectable,
-          evented: obj.evented,
-          isLocked: (obj as any)?.isLocked,
-        }))
-      );
-      console.log(
-        'allObjects',
-        currentCanvas.getObjects().map(obj => ({
-          id: obj.get?.('id'),
-          type: obj.type,
-          selectable: obj.selectable,
-          evented: obj.evented,
-          isLocked: (obj as any)?.isLocked,
-        }))
-      );
-      console.groupEnd();
-    },
-    [canvas, shouldLogSelection]
-  );
+  //     console.groupCollapsed(`[Fabric][Selection] ${label}`);
+  //     console.log('activeObject', {
+  //       id: activeObject?.get?.('id'),
+  //       type: activeObject?.type,
+  //       selectable: activeObject?.selectable,
+  //       evented: activeObject?.evented,
+  //       isLocked: (activeObject as any)?.isLocked,
+  //     });
+  //     console.log(
+  //       'activeObjects',
+  //       activeObjects.map(obj => ({
+  //         id: obj.get?.('id'),
+  //         type: obj.type,
+  //         selectable: obj.selectable,
+  //         evented: obj.evented,
+  //         isLocked: (obj as any)?.isLocked,
+  //       }))
+  //     );
+  //     console.log(
+  //       'allObjects',
+  //       currentCanvas.getObjects().map(obj => ({
+  //         id: obj.get?.('id'),
+  //         type: obj.type,
+  //         selectable: obj.selectable,
+  //         evented: obj.evented,
+  //         isLocked: (obj as any)?.isLocked,
+  //       }))
+  //     );
+  //     console.groupEnd();
+  //   },
+  //   [canvas, shouldLogSelection]
+  // );
 
   const saveHistory = useCallback(() => {
     if (isUpdating.current || isRestoringCanvasState.current || !canvas) return;
@@ -451,34 +451,34 @@ export const useFabric = () => {
     const activeObjects = canvas.getActiveObjects();
 
     if (activeObjects.length === 0) {
-      if (shouldLogSelection) {
-        console.log('[Fabric] 선택 해제됨');
-      }
+      // if (shouldLogSelection) {
+      //   console.log('[Fabric] 선택 해제됨');
+      // }
       setActiveInfo({ type: null, isLocked: false, filters: [], styles: {} });
       return;
     }
 
     const primaryObject = activeObjects[0];
-    const getKoreanType = (obj: any) => {
-      if (obj.get('id') === 'background-layer') return '배경';
-      if (obj.isType('textbox') || obj.isType('itext') || obj.isType('text'))
-        return '텍스트';
-      if (obj.isType('image')) return '이미지';
-      if (obj.isType('rect') || obj.isType('circle') || obj.isType('triangle'))
-        return '도형';
-      if (obj.isType('path') || obj.isType('line')) return '선/경로';
-      if (obj.isType('activeSelection')) return '다중 선택';
-      return obj.type;
-    };
+    // const getKoreanType = (obj: any) => {
+    //   if (obj.get('id') === 'background-layer') return '배경';
+    //   if (obj.isType('textbox') || obj.isType('itext') || obj.isType('text'))
+    //     return '텍스트';
+    //   if (obj.isType('image')) return '이미지';
+    //   if (obj.isType('rect') || obj.isType('circle') || obj.isType('triangle'))
+    //     return '도형';
+    //   if (obj.isType('path') || obj.isType('line')) return '선/경로';
+    //   if (obj.isType('activeSelection')) return '다중 선택';
+    //   return obj.type;
+    // };
 
-    if (shouldLogSelection) {
-      console.log(`[Fabric] 객체 활성화: ${getKoreanType(primaryObject)}`, {
-        id: primaryObject.get('id'),
-        isLocked: (primaryObject as any).isLocked,
-        selectable: primaryObject.selectable,
-        evented: primaryObject.evented,
-      });
-    }
+    // if (shouldLogSelection) {
+    //   console.log(`[Fabric] 객체 활성화: ${getKoreanType(primaryObject)}`, {
+    //     id: primaryObject.get('id'),
+    //     isLocked: (primaryObject as any).isLocked,
+    //     selectable: primaryObject.selectable,
+    //     evented: primaryObject.evented,
+    //   });
+    // }
 
     // UI 버튼 활성화를 위해 필요한 정보만 추출
     setActiveInfo({
@@ -617,11 +617,12 @@ export const useFabric = () => {
       await canvas.loadFromJSON(prevState);
     });
 
-    logSelectionSnapshot('undo:after-render');
+    // logSelectionSnapshot('undo:after-render');
     // 저장된 필터 효과를 다시 렌더링하도록 applyFilters 호출
     setCanUndo(undoStack.current.length > 1);
     setCanRedo(redoStack.current.length > 0);
-  }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
+    // }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
+  }, [canvas, runHistoryTransaction]);
 
   const redo = useCallback(async () => {
     if (redoStack.current.length === 0 || isUpdating.current || !canvas) return;
@@ -634,11 +635,12 @@ export const useFabric = () => {
       });
 
       // 저장된 필터 효과를 다시 렌더링하도록 applyFilters 호출
-      logSelectionSnapshot('redo:after-render');
+      // logSelectionSnapshot('redo:after-render');
     }
     setCanUndo(undoStack.current.length > 1);
     setCanRedo(redoStack.current.length > 0);
-  }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
+    // }, [canvas, logSelectionSnapshot, runHistoryTransaction]);
+  }, [canvas, runHistoryTransaction]);
 
   const exportIntersectedJSON = useCallback(() => {
     if (!canvas) return;

--- a/widgets/mainPoster/hooks/useFabricSlot.tsx
+++ b/widgets/mainPoster/hooks/useFabricSlot.tsx
@@ -1,4 +1,4 @@
-import { Canvas, FabricImage, FabricObject, Pattern, Rect } from 'fabric';
+import { Canvas, FabricImage, FabricObject, Intersection, Pattern, Point, Rect } from 'fabric';
 import { useEffect } from 'react';
 
 import {
@@ -10,7 +10,12 @@ import {
   createFabricControlImage,
   isImageReadyForCanvas,
 } from '../utils/fabricUtils';
-import { ImageSlotMeta, SlotTargetObject } from '../utils/imageSlot';
+import {
+  ImageSlotMeta,
+  isPointInsideSlotFrame,
+  isReplaceableSlotImage,
+  SlotTargetObject,
+} from '../utils/imageSlot';
 import { getPreviewExportMultiplier } from '../utils/previewExport';
 
 interface Props {
@@ -34,6 +39,7 @@ type SlotImageBehaviorObject = FabricImageWithLock & {
   __slotImageModifiedHandler?: () => void;
   __slotDragLastFrameLeft?: number;
   __slotDragLastFrameTop?: number;
+  __slotOriginalContainsPoint?: FabricObject['containsPoint'];
 };
 
 type SlotFrameState = {
@@ -42,6 +48,13 @@ type SlotFrameState = {
   left: number;
   top: number;
   angle: number;
+};
+
+type SlotCanvasWithSelectionAreaPatch = Canvas & {
+  __slotOriginalPointIsInObjectSelectionArea?: (
+    obj: FabricObject,
+    point: Point
+  ) => boolean;
 };
 
 const PATTERN_BASE_WIDTH = 335;
@@ -343,6 +356,28 @@ const createSlotClipPath = (frame: SlotFrameState) =>
     absolutePositioned: true,
   });
 
+const getSlotFrameCoords = (frame: SlotFrameState): Point[] => {
+  const radians = (frame.angle * Math.PI) / 180;
+  const halfWidth = frame.width / 2;
+  const halfHeight = frame.height / 2;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const corners = [
+    { x: -halfWidth, y: -halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: -halfWidth, y: halfHeight },
+  ];
+
+  return corners.map(
+    corner =>
+      new Point(
+        frame.left + corner.x * cos - corner.y * sin,
+        frame.top + corner.x * sin + corner.y * cos
+      )
+  );
+};
+
 const getSlotBoundingBox = (frame: SlotFrameState) => {
   const radians = (frame.angle * Math.PI) / 180;
   const absCos = Math.abs(Math.cos(radians));
@@ -407,6 +442,30 @@ const applySlotFrameControlVisibility = (image: FabricImageWithLock) => {
     bl_rotate: true,
     br_rotate: true,
   });
+};
+
+const attachSlotImageHitArea = (image: FabricImage) => {
+  const slotImage = image as SlotImageBehaviorObject;
+
+  if (slotImage.__slotOriginalContainsPoint) {
+    return;
+  }
+
+  slotImage.__slotOriginalContainsPoint = image.containsPoint.bind(image);
+  image.containsPoint = function (point: Point) {
+    return isPointInsideSlotFrame(this, point);
+  };
+};
+
+const detachSlotImageHitArea = (image: FabricImage) => {
+  const slotImage = image as SlotImageBehaviorObject;
+
+  if (!slotImage.__slotOriginalContainsPoint) {
+    return;
+  }
+
+  image.containsPoint = slotImage.__slotOriginalContainsPoint;
+  delete slotImage.__slotOriginalContainsPoint;
 };
 const getSlotInteractionState = (image: FabricImageWithLock) => {
   if (!image.isLocked) {
@@ -596,6 +655,59 @@ const detachSlotImageBehavior = (image: FabricImage) => {
   }
 };
 
+const attachSlotSelectionAreaPatch = (canvas: Canvas) => {
+  const slotCanvas = canvas as SlotCanvasWithSelectionAreaPatch;
+
+  if (slotCanvas.__slotOriginalPointIsInObjectSelectionArea) {
+    return;
+  }
+
+  slotCanvas.__slotOriginalPointIsInObjectSelectionArea = (
+    canvas as any)._pointIsInObjectSelectionArea.bind(canvas);
+  (canvas as any)._pointIsInObjectSelectionArea = function (
+    obj: FabricObject,
+    point: Point
+  ) {
+    if (obj instanceof FabricImage && isReplaceableSlotImage(obj)) {
+      const frame = getSlotFrameState(obj);
+      const coords = getSlotFrameCoords(frame);
+      const padding = (obj.padding || 0) / this.getZoom();
+
+      if (padding) {
+        const [tl, tr, br, bl] = coords;
+        const angleRadians = Math.atan2(tr.y - tl.y, tr.x - tl.x);
+        const cosP = Math.cos(angleRadians) * padding;
+        const sinP = Math.sin(angleRadians) * padding;
+        const cosPSinP = cosP + sinP;
+        const cosPMinusSinP = cosP - sinP;
+
+        return Intersection.isPointInPolygon(point, [
+          new Point(tl.x - cosPMinusSinP, tl.y - cosPSinP),
+          new Point(tr.x + cosPSinP, tr.y - cosPMinusSinP),
+          new Point(br.x + cosPMinusSinP, br.y + cosPSinP),
+          new Point(bl.x - cosPSinP, bl.y + cosPMinusSinP),
+        ]);
+      }
+
+      return Intersection.isPointInPolygon(point, coords);
+    }
+
+    return slotCanvas.__slotOriginalPointIsInObjectSelectionArea?.(obj, point) ?? false;
+  };
+};
+
+const detachSlotSelectionAreaPatch = (canvas: Canvas) => {
+  const slotCanvas = canvas as SlotCanvasWithSelectionAreaPatch;
+
+  if (!slotCanvas.__slotOriginalPointIsInObjectSelectionArea) {
+    return;
+  }
+
+  (canvas as any)._pointIsInObjectSelectionArea =
+    slotCanvas.__slotOriginalPointIsInObjectSelectionArea;
+  delete slotCanvas.__slotOriginalPointIsInObjectSelectionArea;
+};
+
 export const useFabricSlot = ({
   canvas,
   saveHistory,
@@ -604,7 +716,12 @@ export const useFabricSlot = ({
   useEffect(() => {
     if (!canvas) return;
 
+    attachSlotSelectionAreaPatch(canvas);
     preloadSlotIconImages(() => canvas.requestRenderAll());
+
+    return () => {
+      detachSlotSelectionAreaPatch(canvas);
+    };
   }, [canvas]);
 
   useEffect(() => {
@@ -629,6 +746,7 @@ export const useFabricSlot = ({
         }
 
         applySlotImageTransform(target);
+        attachSlotImageHitArea(target);
         attachSlotImageBehavior(target);
       }
     };
@@ -654,6 +772,7 @@ export const useFabricSlot = ({
 
         if (obj instanceof FabricImage) {
           detachSlotImageBehavior(obj);
+          detachSlotImageHitArea(obj);
         }
       });
     };

--- a/widgets/mainPoster/utils/imageSlot.ts
+++ b/widgets/mainPoster/utils/imageSlot.ts
@@ -56,6 +56,12 @@ export const isReplaceableSlotImage = (
   target: unknown
 ): target is SlotImageObject => getImageSlot(target) !== null;
 
+export const isFrameTarget = (target: unknown): target is SlotTargetObject =>
+  isReplaceableSlotTarget(target);
+
+export const containsFrameTarget = (targets: readonly unknown[]) =>
+  targets.some(target => isFrameTarget(target));
+
 export const isFilledSlotImage = (
   target: unknown
 ): target is SlotImageObject => {
@@ -64,7 +70,9 @@ export const isFilledSlotImage = (
 };
 
 export const isBackgroundImage = (target: unknown): target is FabricImage => {
-  return target instanceof FabricImage && target.get('id') === 'background-layer';
+  return (
+    target instanceof FabricImage && target.get('id') === 'background-layer'
+  );
 };
 
 export const getImagePanelMode = (target: unknown): ImagePanelMode => {

--- a/widgets/mainPoster/utils/imageSlot.ts
+++ b/widgets/mainPoster/utils/imageSlot.ts
@@ -1,4 +1,4 @@
-import { FabricImage, FabricObject } from 'fabric';
+import { FabricImage, FabricObject, Point, util } from 'fabric';
 
 import { FabricObjectWithLock } from '../types/fabric';
 
@@ -27,6 +27,13 @@ export type ImagePanelMode =
   | 'empty-frame'
   | null;
 
+type SlotFrameBoundsTarget = SlotTargetObject & {
+  slotFrameWidth?: number;
+  slotFrameHeight?: number;
+  slotFrameLeft?: number;
+  slotFrameTop?: number;
+  slotFrameAngle?: number;
+};
 export const getSlotMeta = (target: unknown) => {
   if (!(target instanceof FabricObject)) {
     return null;
@@ -62,6 +69,44 @@ export const isFrameTarget = (target: unknown): target is SlotTargetObject =>
 export const containsFrameTarget = (targets: readonly unknown[]) =>
   targets.some(target => isFrameTarget(target));
 
+const hasSlotFrameBounds = (
+  target: unknown
+): target is SlotFrameBoundsTarget & FabricImage => {
+  if (!(target instanceof FabricImage)) {
+    return false;
+  }
+
+  const slotTarget = target as SlotFrameBoundsTarget & FabricImage;
+
+  return (
+    typeof slotTarget.slotFrameWidth === 'number' &&
+    typeof slotTarget.slotFrameHeight === 'number' &&
+    typeof slotTarget.slotFrameLeft === 'number' &&
+    typeof slotTarget.slotFrameTop === 'number'
+  );
+};
+
+export const isPointInsideSlotFrame = (target: unknown, point: Point) => {
+  if (!hasSlotFrameBounds(target)) {
+    return target instanceof FabricObject ? target.containsPoint(point) : false;
+  }
+
+  const frameWidth = target.slotFrameWidth ?? 0;
+  const frameHeight = target.slotFrameHeight ?? 0;
+  const frameLeft = target.slotFrameLeft ?? 0;
+  const frameTop = target.slotFrameTop ?? 0;
+  const frameAngle = target.slotFrameAngle ?? target.angle ?? 0;
+  const radians = util.degreesToRadians(frameAngle);
+  const dx = point.x - frameLeft;
+  const dy = point.y - frameTop;
+  const localX = dx * Math.cos(radians) + dy * Math.sin(radians);
+  const localY = -dx * Math.sin(radians) + dy * Math.cos(radians);
+
+  return (
+    Math.abs(localX) <= frameWidth / 2 &&
+    Math.abs(localY) <= frameHeight / 2
+  );
+};
 export const isFilledSlotImage = (
   target: unknown
 ): target is SlotImageObject => {


### PR DESCRIPTION
# FEATURE

#296 의 이슈 해결 : 프레임의 복사, 그룹 선택 비활성화 및 영역 선택 오류 개선

---

## 📋 작업 내용
- 프레임 복사 방지
- 프레임의 그룹 선택 방지
- 프레임의 가려진 영역 선택 방지
- 관리자 기능 비활성화
- 기본 이미지 패널 이미지 없을때 추가기능 보여주도록 변경

## 📸 스크린샷 / 영상

<!-- UI 변경이 있는 경우 첨부 -->

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [x] 디자인 시안과 비교 확인
- [x] 최악의 환경에서 확인 (느린 네트워크 환경)
- [x] 모바일 환경에서 테스트
- [x] 기존 초대장 영향 테스트

## 🧪 테스트 방법

<!-- 리뷰어가 직접 테스트할 수 있도록 -->

1. 프레임의 복사와 그룹 선택이 되지 않는지 확인합니다 (선택되지 않아야함)
2. 프레임보다 큰 사진을 넣거나, 확대 또는 위치 조절을 하고난 후, 프레임 바깥 영역 선택시 프레임이 활성화되지 않는지 확인합니다 (활성화되면 안됨)

## 🚨 이슈
프레임의 일부 제한되는 기능이 생기는 문제와 원활한 유지보수를 위해 구조를 마이그레이션 할 예정입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 이미지 슬롯의 선택·교체 영역이 프레임 기준으로 더 정확하게 동작합니다.
  * 배경 적용 옵션이 이미지 선택 여부와 관계없이 항상 표시됩니다.
  * 검색 가능한 선택 UI는 검색 기능이 있는 경우에만 노출되도록 정리됐습니다.

* **Bug Fixes**
  * 잠금/배경/프레임 영역 클릭 시 선택 상태가 더 일관되게 처리됩니다.
  * 프레임 대상은 복사·붙여넣기 동작에서 잘못 선택되지 않도록 개선됐습니다.
  * 일부 편집 도구와 다운로드 관련 항목이 더 이상 불필요하게 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->