### PR TITLE
[fix] 마무리 멘트 여백 수정

### DIFF
--- a/components/organisms/closingComment/ClosingComment.tsx
+++ b/components/organisms/closingComment/ClosingComment.tsx
@@ -37,7 +37,7 @@ function ClosingComment({ blockInfo, id }: Props) {
   };
 
   return (
-    <LeftEditorWrapper ariaLabel="인사말" className="gap-4">
+    <LeftEditorWrapper ariaLabel="인사말" className="gap-1">
       <NavigationBar
         action={
           <div ref={questionListTriggerRef}>

--- a/components/organisms/closingComment/ClosingQuestionPopup.tsx
+++ b/components/organisms/closingComment/ClosingQuestionPopup.tsx
@@ -54,7 +54,7 @@ function ClosingQuestionPopup({
       wrapperClassName="h-[370px] w-[280px] px-0"
       contentClassName="min-h-0 flex-1 px-0 pb-3.5 flex flex-col "
     >
-      <div className="flex border-b border-border-neutral">
+      <div className="flex px-2.5 gap-2.5 pt-2.5 pb-1.5">
         {CLOSING_CATEGORIES.map(category => (
           <button
             key={category.value}
@@ -63,9 +63,9 @@ function ClosingQuestionPopup({
               setSelectedText('');
             }}
             className={cn(
-              'flex-1 py-3 px-2 text-xs font-normal transition-colors',
+              'flex-1 py-1.5 text-[13px] font-normal transition-colors',
               activeCategory === category.value
-                ? 'border-b-2 border-text-primary text-text-primary font-medium'
+                ? 'border-b-[1.5px] border-text-primary text-text-primary font-medium'
                 : 'text-text-secondary hover:text-text-primary'
             )}
           >
@@ -76,7 +76,7 @@ function ClosingQuestionPopup({
 
       <ul
         className={cn(
-          'flex-1 max-h-full space-y-3 overflow-y-auto scrollbar-hide px-4 pt-3'
+          'flex-1 max-h-full space-y-3 overflow-y-auto scrollbar-hide px-3 pt-1'
         )}
       >
         {options.length === 0 && (
@@ -88,9 +88,9 @@ function ClosingQuestionPopup({
         {options.map((text, index) => (
           <li
             key={`${text}-${index}`}
-            className={cn('flex h-9 items-center justify-center gap-2.5 p-0')}
+            className={cn('flex h-9 items-center justify-center gap-1 p-0')}
           >
-            <div className={cn('flex shrink-0 items-center')}>
+            <div className={cn('flex-center shrink-0 w-8 h-8')}>
               <Radio
                 name={radioName}
                 value={text}
@@ -101,7 +101,7 @@ function ClosingQuestionPopup({
 
             <PopupText
               text={text}
-              className="flex-1 "
+              className="flex-1 text-[13px]"
               twoLineEllipsis={false}
             />
           </li>


### PR DESCRIPTION

# FEATURE

---

## 📋 작업 내용

- 일부 디자인과 여백 틀린 부분 수정

## 🔗 관련 이슈



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 일부 댓글 작성/질문 팝업의 간격, 탭 표시, 목록 여백과 정렬이 조정되어 화면이 더 깔끔하게 보이도록 개선되었습니다.
  * 활성 카테고리와 항목 텍스트의 강조 방식이 변경되어 선택 상태가 더 잘 드러납니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->