### PR TITLE
[fix] 에디터 뷰포트 가드 복원

### DIFF
--- a/app/editor/components/EditorViewportGuard.tsx
+++ b/app/editor/components/EditorViewportGuard.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { ArrowUpRight, Home, Maximize2 } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import HeaderPrivacyNoticeButton from '@/features/session/components/HeaderPrivacyNoticeButton';
+import HomeButton from '@/features/session/components/HomeButton';
+import homeBackgroundImage from '@/shared/assets/images/home/home-background.png';
+import { DESKTOP_CONTENT_MIN_WIDTH } from '@/shared/config/layout';
+import { useEditorCalloutStore } from '@/shared/store/useEditorCalloutStore';
+
+import type { ReactNode } from 'react';
+
+const HEADER_NAV_LINK_CLASS =
+  'flex items-center border-b border-transparent px-2 py-[6.5px] text-[16px] font-semibold text-text-plain transition-colors hover:border-black hover:text-black';
+
+function EditorDesktopNotice({
+  viewportWidth,
+}: {
+  viewportWidth: number | null;
+}) {
+  return (
+    <div className="fixed inset-0 isolate z-[40000] grid min-h-dvh grid-rows-[auto_1fr_auto] overflow-y-auto text-[#171717]">
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 -z-10 bg-cover bg-center bg-no-repeat"
+        style={{ backgroundImage: `url(${homeBackgroundImage.src})` }}
+      />
+
+      <header className="relative flex h-14 items-center justify-between bg-transparent px-10">
+        <div className="flex h-full items-center gap-8">
+          <HomeButton />
+
+          <nav className="flex h-full items-center gap-6">
+            <Link href="/faq" className={HEADER_NAV_LINK_CLASS}>
+              FAQ
+            </Link>
+          </nav>
+        </div>
+
+        <HeaderPrivacyNoticeButton />
+      </header>
+
+      <main className="relative mx-auto grid w-full max-w-7xl items-center gap-12 px-5 py-14 sm:px-8 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.72fr)] lg:gap-20 lg:px-12 lg:py-20">
+        <section>
+          <p className="text-xs font-bold tracking-[0.24em] text-black/45">
+            WIDER WORKSPACE REQUIRED
+          </p>
+          <h1 className="mt-6 max-w-3xl text-[clamp(4rem,9vw,8.8rem)] font-semibold leading-[0.88]">
+            Create on
+            <br />
+            desktop.
+          </h1>
+          <p className="mt-8 max-w-xl text-base leading-7 text-black/60 sm:text-lg sm:leading-8">
+            초대장은 데스크톱에서 만들어 주세요.
+            <br />
+            섬세한 편집을 위해 {DESKTOP_CONTENT_MIN_WIDTH}px 이상의 브라우저
+            너비가 필요합니다.
+          </p>
+        </section>
+
+        <section className="border-t border-black lg:border-t-0">
+          <div className="flex items-end justify-between gap-6 border-b border-black/15 py-6">
+            <span className="text-xs font-bold tracking-[0.2em] text-black/40">
+              WORKSPACE WIDTH
+            </span>
+            <Maximize2 className="h-7 w-7 text-black/60" />
+          </div>
+
+          <div className="grid grid-cols-2 border-b border-black/15">
+            <div className="border-r border-black/15 py-5 pr-4">
+              <p className="text-xs font-bold tracking-[0.16em] text-black/40">
+                REQUIRED
+              </p>
+              <p className="mt-3 text-2xl font-semibold tracking-[-0.05em]">
+                {DESKTOP_CONTENT_MIN_WIDTH}px+
+              </p>
+            </div>
+            <div className="py-5 pl-4">
+              <p className="text-xs font-bold tracking-[0.16em] text-black/40">
+                CURRENT
+              </p>
+              <p className="mt-3 text-2xl font-semibold tracking-[-0.05em]">
+                {viewportWidth === null ? 'Checking' : `${viewportWidth}px`}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3 pt-6">
+            <Link
+              href="/"
+              className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-black px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-black/80"
+            >
+              홈으로 돌아가기
+              <Home className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/faq"
+              className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-black/20 px-4 py-2.5 text-sm font-semibold transition-colors hover:border-black"
+            >
+              FAQ 살펴보기
+              <ArrowUpRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <footer className="relative flex h-10 items-center justify-between bg-transparent px-10">
+        <Link href="/policy" className="text-text-secondary">
+          개인정보 처리방침
+        </Link>
+
+        <div className="text-text-secondary">
+          © {new Date().getFullYear()}{' '}
+          <span className="font-semibold">Invia</span>. All rights reserved.
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function EditorViewportGuard({ children }: { children: ReactNode }) {
+  const [viewportWidth, setViewportWidth] = useState<number | null>(null);
+  const hideAllCallouts = useEditorCalloutStore(state => state.hideAllCallouts);
+
+  useEffect(() => {
+    const updateViewportWidth = () => {
+      const nextViewportWidth = window.innerWidth;
+
+      setViewportWidth(nextViewportWidth);
+    };
+
+    updateViewportWidth();
+    window.addEventListener('resize', updateViewportWidth);
+
+    return () => window.removeEventListener('resize', updateViewportWidth);
+  }, []);
+
+  const shouldShowDesktopNotice =
+    viewportWidth !== null && viewportWidth < DESKTOP_CONTENT_MIN_WIDTH;
+
+  useEffect(() => {
+    if (!shouldShowDesktopNotice) return;
+
+    hideAllCallouts();
+  }, [hideAllCallouts, shouldShowDesktopNotice]);
+
+  return (
+    <>
+      <div
+        className="h-full w-full"
+        inert={shouldShowDesktopNotice ? true : undefined}
+        aria-hidden={shouldShowDesktopNotice ? true : undefined}
+      >
+        {children}
+      </div>
+      {shouldShowDesktopNotice && (
+        <EditorDesktopNotice viewportWidth={viewportWidth} />
+      )}
+    </>
+  );
+}
+
+export default EditorViewportGuard;

--- a/app/editor/layout.tsx
+++ b/app/editor/layout.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 
 import DashboardShell from '@/features/session/components/DashboardShell';
 
+import EditorViewportGuard from './components/EditorViewportGuard';
+
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -19,7 +21,7 @@ export default function EditorLayout({
 }>) {
   return (
     <DashboardShell variant="editor">
-      {children}
+      <EditorViewportGuard>{children}</EditorViewportGuard>
     </DashboardShell>
   );
 }


### PR DESCRIPTION
# FEATURE

---

## 📋 작업 내용

에디터 화면에서 브라우저 너비가 최소 작업 영역보다 좁을 때 안내 오버레이를 표시하는 `EditorViewportGuard`를 복원했습니다.

모바일 홈과 충돌하지 않도록 전역 레이아웃이 아닌 `/editor` 레이아웃에만 적용했습니다.

## 🔗 관련 이슈

Closes #

## 📸 스크린샷 / 영상

<!-- UI 변경이 있는 경우 첨부 -->

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [x] 디자인 시안과 비교 확인
- [ ] 최악의 환경에서 확인 (느린 네트워크 환경)
- [x] 모바일 환경에서 테스트

## 🧪 테스트 방법

1. `/editor` 또는 `/editor/[id]`에 접속합니다.
2. 브라우저 너비를 `1340px` 미만으로 줄였을 때 데스크톱 이용 안내 오버레이가 표시되는지 확인합니다.
3. 브라우저 너

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 에디터 화면에 데스크톱 최소 너비 기준을 적용해, 화면이 너무 좁을 때 안내 메시지를 보여주고 에디터 본문은 비활성화되도록 개선했습니다.
  * 좁은 화면에서는 에디터 관련 안내 요소가 자동으로 숨겨져 더 깔끔한 사용 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->