### PR TITLE
[Hotfix] UI/UX 버그 픽스

### DIFF
--- a/app/editor/components/EditorViewportGuard.tsx
+++ b/app/editor/components/EditorViewportGuard.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, Home, Maximize2 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
+import FooterPolicyLink from '@/features/session/components/FooterPolicyLink';
 import HeaderPrivacyNoticeButton from '@/features/session/components/HeaderPrivacyNoticeButton';
 import HomeButton from '@/features/session/components/HomeButton';
 import homeBackgroundImage from '@/shared/assets/images/home/home-background.png';
@@ -107,9 +108,7 @@ function EditorDesktopNotice({
       </main>
 
       <footer className="relative flex h-10 items-center justify-between bg-transparent px-10">
-        <Link href="/policy" className="text-text-secondary">
-          개인정보 처리방침
-        </Link>
+        <FooterPolicyLink className="text-text-secondary" />
 
         <div className="text-text-secondary">
           © {new Date().getFullYear()}{' '}

--- a/components/organisms/calendar/components/CalendarType4.tsx
+++ b/components/organisms/calendar/components/CalendarType4.tsx
@@ -29,11 +29,10 @@ export function CalendarType4({
               key={dayObj.num + '-' + idx}
               className="flex items-center justify-center relative aspect-square h-8 mx-auto"
             >
-              <div className="flex items-center justify-center relative z-1 text-[16px] text-[#2D3748]">
-                {dayObj.num}
+              <div className="relative flex size-8 items-center justify-center text-[16px] text-[#2D3748]">
                 {isTarget && (
                   <svg
-                    className="absolute w-[200%] h-[200%] top-1/2 left-1/2 -translate-x-[48%] -translate-y-[52%] text-[#D92D20] -z-1"
+                    className="pointer-events-none absolute left-1/2 top-1/2 size-9 -translate-x-[48%] -translate-y-[52%] text-[#D92D20]"
                     viewBox="0 0 50 50"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
@@ -46,6 +45,7 @@ export function CalendarType4({
                     />
                   </svg>
                 )}
+                <span className="relative z-1 leading-none">{dayObj.num}</span>
               </div>
             </div>
           );

--- a/components/organisms/interview/Interview.schema.ts
+++ b/components/organisms/interview/Interview.schema.ts
@@ -1,4 +1,7 @@
-import type { InterviewQuestion } from './interviewList';
+import {
+  createInterviewQuestion,
+  type InterviewQuestion,
+} from './interviewList';
 
 export const interviewSchema = {
   type: null,
@@ -16,7 +19,7 @@ export const interviewSchema = {
       required: false,
     },
     questions: {
-      default: [] as InterviewQuestion[],
+      default: () => [createInterviewQuestion()] as InterviewQuestion[],
       required: false,
     },
   },

--- a/components/organisms/notice/Notice.schema.ts
+++ b/components/organisms/notice/Notice.schema.ts
@@ -1,4 +1,4 @@
-import type { NoticeListItem } from './noticeList';
+import { createNoticeItem, type NoticeListItem } from './noticeList';
 
 export const noticeSchema = {
   type: null,
@@ -16,7 +16,7 @@ export const noticeSchema = {
       required: false,
     },
     noticeList: {
-      default: [] as NoticeListItem[],
+      default: () => [createNoticeItem()] as NoticeListItem[],
       required: false,
     },
   },

--- a/components/organisms/phone/components/PhonePreviewPopup.tsx
+++ b/components/organisms/phone/components/PhonePreviewPopup.tsx
@@ -58,7 +58,7 @@ function PhonePreviewPopup({ groups = [] }: Props) {
     <>
       <button
         type="button"
-        className="flex justify-center items-center py-2 px-10 rounded-lg border border-[#e5e5e8] hover:bg-gray-50 hover:border-gray-300 cursor-pointer"
+        className="flex justify-center items-center py-2 px-10 rounded-lg border border-[#e5e5e8] bg-[#FFFFFF] hover:bg-gray-50 hover:border-gray-300 cursor-pointer"
         onClick={() => setIsPopupOpen(true)}
       >
         <PhoneIcon className="size-5.5 text-text-secondary" />
@@ -143,14 +143,14 @@ function PhonePreviewPopup({ groups = [] }: Props) {
                             <a
                               href={`sms:${getPhoneHrefNumber(contact.number)}`}
                               aria-label="문자 보내기"
-                              className="flex items-center justify-center size-11 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
+                              className="flex items-center justify-center size-11 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
                             >
                               <MessageIcon className="text-text-tertiary" />
                             </a>
                             <a
                               href={`tel:${getPhoneHrefNumber(contact.number)}`}
                               aria-label="전화 걸기"
-                              className="flex items-center justify-center size-11 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors"
+                              className="flex items-center justify-center size-11 rounded-full hover:bg-black/5 active:bg-black/10 transition-colors outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
                             >
                               <PhoneActionIcon className="text-text-tertiary" />
                             </a>

--- a/features/session/components/DashboardShell.tsx
+++ b/features/session/components/DashboardShell.tsx
@@ -5,6 +5,7 @@ import { getAuthSession } from '@/app/api/auth/_lib/getAuthSession';
 import { DASHBOARD_SHELL_NAV_MENU } from '@/features/session/config/dashboardShell.config';
 import homeBackgroundImage from '@/shared/assets/images/home/home-background.png';
 
+import FooterPolicyLink from './FooterPolicyLink';
 import HeaderAuthControl from './HeaderAuthControl';
 import HeaderPrivacyNoticeButton from './HeaderPrivacyNoticeButton';
 import HomeButton from './HomeButton';
@@ -68,9 +69,7 @@ export default async function DashboardShell({
       </main>
 
       <footer className="h-10 bg-transparent flex items-center justify-between px-10">
-        <Link href="/policy" className="text-text-secondary">
-          개인정보 처리방침
-        </Link>
+        <FooterPolicyLink className="text-text-secondary" />
 
         <div className="text-text-secondary">
           © {new Date().getFullYear()}{' '}

--- a/features/session/components/FooterPolicyLink.tsx
+++ b/features/session/components/FooterPolicyLink.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+
+import { useConfirm } from '@/shared/hooks/useConfirm';
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
+import type { MouseEvent } from 'react';
+
+type FooterPolicyLinkProps = {
+  className?: string;
+};
+
+function FooterPolicyLink({ className }: FooterPolicyLinkProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { confirm } = useConfirm();
+  const isDirty = useEditorStore(state => state.isDirty);
+
+  const handleClick = async (e: MouseEvent<HTMLAnchorElement>) => {
+    if (!pathname.startsWith('/editor') || !isDirty) return;
+
+    e.preventDefault();
+
+    const isConfirm = await confirm({
+      message:
+        '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',
+      variant: 'white',
+      yPosition: 'center',
+    });
+
+    if (isConfirm) {
+      router.push('/policy');
+    }
+  };
+
+  return (
+    <Link href="/policy" className={className} onClick={handleClick}>
+      개인정보 처리방침
+    </Link>
+  );
+}
+
+export default FooterPolicyLink;

--- a/shared/utils/createDefaultProps.test.ts
+++ b/shared/utils/createDefaultProps.test.ts
@@ -1,0 +1,25 @@
+import { createDefaultProps } from './createDefaultProps';
+
+describe('createDefaultProps', () => {
+  it('creates an initial interview question with a fresh id for each block', () => {
+    const first = createDefaultProps('interview', 'wedding');
+    const second = createDefaultProps('interview', 'wedding');
+
+    expect(first.questions).toHaveLength(1);
+    expect(second.questions).toHaveLength(1);
+    expect(first.questions?.[0].id).toEqual(expect.any(String));
+    expect(second.questions?.[0].id).toEqual(expect.any(String));
+    expect(first.questions?.[0].id).not.toBe(second.questions?.[0].id);
+  });
+
+  it('creates an initial notice item with a fresh id for each block', () => {
+    const first = createDefaultProps('notice', 'wedding');
+    const second = createDefaultProps('notice', 'wedding');
+
+    expect(first.noticeList).toHaveLength(1);
+    expect(second.noticeList).toHaveLength(1);
+    expect(first.noticeList?.[0].id).toEqual(expect.any(String));
+    expect(second.noticeList?.[0].id).toEqual(expect.any(String));
+    expect(first.noticeList?.[0].id).not.toBe(second.noticeList?.[0].id);
+  });
+});

--- a/shared/utils/createDefaultProps.ts
+++ b/shared/utils/createDefaultProps.ts
@@ -14,7 +14,13 @@ export function createDefaultProps<T extends BlockType>(
   const fields = blockRegistry[type].fields;
 
   const props = Object.fromEntries(
-    Object.entries(fields).map(([key, value]) => [key, value.default])
+    Object.entries(fields).map(([key, value]) => {
+      const defaultValue = value.default;
+      return [
+        key,
+        typeof defaultValue === 'function' ? defaultValue() : defaultValue,
+      ];
+    })
   ) as DefaultProps<T>;
 
   if (type === 'calendar' && invitationType && invitationType !== 'wedding') {

--- a/shared/utils/placeTitle.ts
+++ b/shared/utils/placeTitle.ts
@@ -1,6 +1,5 @@
 import type { InvitationType } from '@/shared/types/block';
 
-export const LEGACY_PLACE_TITLE = '오시는 길';
 export const GENERAL_PLACE_TITLE = '행사 장소';
 export const WEDDING_PLACE_TITLE = '예식 장소';
 
@@ -10,7 +9,7 @@ export const getDefaultPlaceTitle = (type?: InvitationType) =>
 export const isDefaultPlaceTitle = (
   title: string | undefined,
   type?: InvitationType
-) => title === getDefaultPlaceTitle(type) || title === LEGACY_PLACE_TITLE;
+) => title === getDefaultPlaceTitle(type);
 
 export const normalizePlaceTitle = (
   title: string | undefined,


### PR DESCRIPTION
# HOTFIX

---

## 🚨 장애 심각도

[ ] P0 - 서비스 전체 불가 / 보안 사고
[ ] P1 - 핵심 기능 불가
[x] P2 - 일부 기능 오류

## ⏰ 발생 시간

- 2026년 07월 03일 오전 10시 34분 이후

## 🐛 문제 상황

에디터 UI 일부 컴포넌트에서 다음 문제가 발생함.

- 연락처 프리뷰 팝업 버튼 배경색이 의도한 흰색으로 보이지 않음
- 캘린더 타입 4에서 한 자리 날짜 표시 시 빨간 원형 표시가 어긋남
- 행사장소 제목에 "오시는 길" 입력 시 기존 기본값 처리와 충돌해 값이 초기화됨
- 인터뷰/공지사항 컴포넌트가 페이지 추가 시점이 아니라 프리뷰 포커싱 이후에 초기 항목이 생성됨
- 에디터 풋터의 개인정보 처리방침 링크 클릭 시 저장되지 않은 변경사항 confirm이 뜨지 않음

## 🔧 수정 내용

- 연락처 프리뷰 팝업 버튼 배경을 `#FFFFFF`로 고정
- 캘린더 타입 4 날짜 원형 표시 크기/렌더링 보정
- 행사장소 제목의 legacy 기본값 충돌 처리 수정
- 인터뷰/공지사항 schema 기본값 및 `createDefaultProps` 처리 개선
- 에디터 풋터 개인정보 처리방침 링크를 dirty 상태 confirm 흐름에 연결
- `createDefaultProps` 함수 기본값 처리 테스트 추가

## 🧪 검증 방법

- `git fetch origin main dev hotfix/ui-bug`
- `git merge-tree --write-tree origin/main HEAD`
- `git merge-tree --write-tree origin/dev HEAD`
- `git diff --check`
- 관련 변경 파일 대상 `npx eslint ...`
- `npx jest shared/utils/createDefaultProps.test.ts --runInBand`

## ✅ 배포 전 체크리스트

- [x] main 최신 브랜치 기준으로 작업
- [x] 로컬 테스트 완료
- [x] 수정 범위가 최소화
- [x] Vercel 미리보기 URL 확인
- [x] 장애 해결과 무관한 기능, 리팩터링, 의존성 업데이트를 포함하지 않음
- [x] 영향을 줄 수 있는 다른 기능까지 확인
- [x] 관련 API, 공통 컴포넌트, 인증, 전역 상태 영향 여부를 확인

## ✅ 검증

- [x] 운영과 동일하거나 최대한 유사한 조건에서 장애를 재현했다.
- [x] 수정 후 동일한 재현 절차로 문제가 해결됐음을 확인했다.
- [x] 정상 사용자 흐름을 확인했다.
- [x] 오류가 발생하던 케이스를 확인했다.
- [ ] 로그인 / 권한 / API 실패 상태를 확인했다.
- [ ] 브라우저 콘솔 에러가 없다.
- [ ] Network 탭에서 실패 요청이 없는지 확인했다.
- [x] 관련 테스트가 있다면 통과했다.

## ✅ 배포 후 체크리스트

- [ ] main merge 완료
- [ ] dev 브랜치에도 동일 내용 merge 완료 ⚠️ 필수
- [ ] 운영 배포 후 정상 동작 확인
- [ ] 운영 배포 후 Vercel,Clarity 에러 확인
- [ ] 팀 디스코드 공유 완료
- [ ] hotfix 브랜치를 삭제했다.

## 📢 영향 범위

- 에디터 풋터 개인정보 처리방침 링크
- 연락처 프리뷰
- 캘린더 타입 4
- 행사장소 제목 필드
- 인터뷰 컴포넌트 초기 항목 생성
- 공지사항 컴포넌트 초기 항목 생성
- `createDefaultProps` 공통 유틸

---