### PR TITLE
Fix/editor/UI function fix

### DIFF
--- a/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
+++ b/components/organisms/myFamilyWedding/MyFamilyWeddingPreview.tsx
@@ -28,17 +28,10 @@ export const MyFamilyWeddingPreview = ({
       childClassName="w-full flex flex-col gap-1"
       {...rest}
     >
-      <div className="flex flex-row items-center gap-1" style={{ fontFamily }}>
-        {brideFamily?.map((member, index) => (
-          <p key={index} className="flex items-center">
-            {brideFamily.length > 1 && index !== 0 && '•'}
-            {member.flower && <Flower />}
-            {member.name}
-          </p>
-        ))}
-        <span>의 딸</span>
-      </div>
-      <div className="flex flex-row items-center gap-1" style={{ fontFamily }}>
+      <div
+        className="flex flex-row items-center text-sm"
+        style={{ fontFamily }}
+      >
         {groomFamily?.map((member, index) => (
           <p key={index} className="flex items-center">
             {groomFamily.length > 1 && index !== 0 && '•'}
@@ -47,6 +40,19 @@ export const MyFamilyWeddingPreview = ({
           </p>
         ))}
         <span>의 아들</span>
+      </div>
+      <div
+        className="flex flex-row items-center text-sm"
+        style={{ fontFamily }}
+      >
+        {brideFamily?.map((member, index) => (
+          <p key={index} className="flex items-center">
+            {brideFamily.length > 1 && index !== 0 && '•'}
+            {member.flower && <Flower />}
+            {member.name}
+          </p>
+        ))}
+        <span>의 딸</span>
       </div>
     </MiddlePreviewWrapper>
   );

--- a/features/session/components/DashboardShell.tsx
+++ b/features/session/components/DashboardShell.tsx
@@ -1,17 +1,13 @@
-import Link from 'next/link';
 import { ReactNode } from 'react';
 
 import { getAuthSession } from '@/app/api/auth/_lib/getAuthSession';
-import { DASHBOARD_SHELL_NAV_MENU } from '@/features/session/config/dashboardShell.config';
 import homeBackgroundImage from '@/shared/assets/images/home/home-background.png';
 
 import FooterPolicyLink from './FooterPolicyLink';
 import HeaderAuthControl from './HeaderAuthControl';
 import HeaderPrivacyNoticeButton from './HeaderPrivacyNoticeButton';
 import HomeButton from './HomeButton';
-
-const HEADER_NAV_LINK_CLASS =
-  'flex items-center border-b border-transparent px-2 py-[6.5px] text-[16px] font-semibold text-text-plain transition-colors hover:border-black hover:text-black';
+import NavMenu from './NavMenu';
 
 export default async function DashboardShell({
   children,
@@ -49,15 +45,7 @@ export default async function DashboardShell({
           <nav className="flex h-full items-center gap-6">
             <HeaderAuthControl initialIsLoggedIn={session.isLoggedIn} />
 
-            {DASHBOARD_SHELL_NAV_MENU.map(menu => (
-              <Link
-                key={`${menu.title}-${menu.href}`}
-                href={menu.href}
-                className={HEADER_NAV_LINK_CLASS}
-              >
-                {menu.title}
-              </Link>
-            ))}
+            <NavMenu />
           </nav>
         </div>
 

--- a/features/session/components/NavMenu.tsx
+++ b/features/session/components/NavMenu.tsx
@@ -1,0 +1,52 @@
+'use client';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import React from 'react';
+import { Fragment } from 'react/jsx-runtime';
+
+import { useConfirm } from '@/shared/hooks/useConfirm';
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
+import { DASHBOARD_SHELL_NAV_MENU } from '../config/dashboardShell.config';
+
+const HEADER_NAV_LINK_CLASS =
+  'flex items-center border-b border-transparent px-2 py-[6.5px] text-[16px] font-semibold text-text-plain transition-colors hover:border-black hover:text-black';
+
+function NavMenu() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { confirm } = useConfirm();
+  const isDirty = useEditorStore(state => state.isDirty);
+
+  const handleNavMenuClick = async (e: React.MouseEvent) => {
+    if (pathname.startsWith('/editor') && isDirty) {
+      e.preventDefault();
+      const isConfirm = await confirm({
+        message:
+          '수정된 내용이 저장되지 않을 수 있습니다.\n정말 나가시겠습니까?',
+        variant: 'white',
+        yPosition: 'center',
+      });
+      if (!isConfirm) {
+        e.preventDefault();
+        return;
+      }
+      router.push('/faq');
+    }
+  };
+  return (
+    <Fragment>
+      {DASHBOARD_SHELL_NAV_MENU.map(menu => (
+        <Link
+          key={`${menu.title}-${menu.href}`}
+          href={menu.href}
+          className={HEADER_NAV_LINK_CLASS}
+          onClick={handleNavMenuClick}
+        >
+          {menu.title}
+        </Link>
+      ))}
+    </Fragment>
+  );
+}
+export default NavMenu;

--- a/widgets/editor/leftPanel/LeftPanel.tsx
+++ b/widgets/editor/leftPanel/LeftPanel.tsx
@@ -9,38 +9,47 @@ import BulkEdit from './components/BulkEdit';
 import Edit from './components/Edit';
 
 function LeftPanel() {
-  const { isEdit, setIsEdit } = useEditorStore(
-    useShallow(state => ({ isEdit: state.isEdit, setIsEdit: state.setIsEdit }))
+  const { isEdit, setIsEdit, selectedId } = useEditorStore(
+    useShallow(state => ({
+      isEdit: state.isEdit,
+      setIsEdit: state.setIsEdit,
+      selectedId: state.selectedId,
+    }))
   );
+
+  const isComponentSelected =
+    !!selectedId && selectedId !== 'mainPoster' && selectedId !== 'shareUrl';
 
   return (
     <div
       className="w-93.75 max-h-[810px] ml-5 min-[1540px]:ml-15 flex flex-col gap-4"
       data-editor-left-panel
     >
-      <div className="w-full">
-        <button
-          type="button"
-          className={`flex-center relative bg-white rounded-lg ${isEdit ? 'rounded-b-none border-b-0' : 'shadow-edit'} border border-black/5 w-full h-11 transition-default`}
-          onClick={() => setIsEdit(!isEdit)}
-        >
-          <p className="font-semibold text-sm">일괄 편집</p>
-          <div
-            className={`absolute right-6 ${isEdit ? 'rotate-180' : ''} transition-default`}
+      {isComponentSelected && (
+        <div className="w-full">
+          <button
+            type="button"
+            className={`flex-center relative bg-white rounded-lg ${isEdit ? 'rounded-b-none border-b-0' : 'shadow-edit'} border border-black/5 w-full h-11 transition-default`}
+            onClick={() => setIsEdit(!isEdit)}
           >
-            <SectionArrow className="w-[14px] h-[7px]" />
-          </div>
-        </button>
+            <p className="font-semibold text-sm">일괄 편집</p>
+            <div
+              className={`absolute right-6 ${isEdit ? 'rotate-180' : ''} transition-default`}
+            >
+              <SectionArrow className="w-[14px] h-[7px]" />
+            </div>
+          </button>
 
-        <div
-          key={`bulk-edit-${isEdit}`}
-          className={`grid min-h-158 ${isEdit ? 'animate-grow-height opacity-100 mt-0' : 'grid-rows-[0fr] opacity-0'}`}
-        >
-          <div className="overflow-hidden rounded-b-lg">
-            <BulkEdit />
+          <div
+            key={`bulk-edit-${isEdit}`}
+            className={`grid max-h-158 ${isEdit ? 'animate-grow-height opacity-100 mt-0' : 'grid-rows-[0fr] opacity-0'}`}
+          >
+            <div className="overflow-hidden rounded-b-lg">
+              <BulkEdit />
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div
         className={`flex flex-col bg-white rounded-lg shadow-edit border border-black/5 transition-default ${

--- a/widgets/editor/leftPanel/LeftPanel.tsx
+++ b/widgets/editor/leftPanel/LeftPanel.tsx
@@ -34,7 +34,7 @@ function LeftPanel() {
 
         <div
           key={`bulk-edit-${isEdit}`}
-          className={`grid ${isEdit ? 'animate-grow-height opacity-100 mt-0' : 'grid-rows-[0fr] opacity-0'}`}
+          className={`grid min-h-158 ${isEdit ? 'animate-grow-height opacity-100 mt-0' : 'grid-rows-[0fr] opacity-0'}`}
         >
           <div className="overflow-hidden rounded-b-lg">
             <BulkEdit />

--- a/widgets/editor/leftPanel/components/BodyEdit.tsx
+++ b/widgets/editor/leftPanel/components/BodyEdit.tsx
@@ -72,13 +72,13 @@ function BodyEdit({
       >
         <div className="w-full h-full flex flex-col gap-1 px-3">
           <p
-            className="font-base text-base text-center"
+            className="font-base text-base text-center wrap-break-word"
             style={toStyle(bulkBodyData, false)}
           >
             Eng Sample
           </p>
           <p
-            className="font-base text-base text-center"
+            className="font-base text-base text-center wrap-break-word"
             style={toStyle(bulkBodyData, false)}
           >
             본문입니다

--- a/widgets/editor/leftPanel/components/BulkEdit.tsx
+++ b/widgets/editor/leftPanel/components/BulkEdit.tsx
@@ -17,7 +17,7 @@ function BulkEdit() {
 
   return (
     <div className="w-full bg-white rounded-b-lg shadow-edit border border-t-0 border-black/5 transition-default">
-      <LeftEditorWrapper className="overflow-x-hidden">
+      <LeftEditorWrapper className="overflow-x-hidden max-h-158">
         <TitleEdit
           activeColorPickerId={activeColorPickerId}
           onActiveColorPickerChange={setActiveColorPickerId}

--- a/widgets/editor/leftPanel/components/TitleEdit.tsx
+++ b/widgets/editor/leftPanel/components/TitleEdit.tsx
@@ -75,14 +75,14 @@ function TitleEdit({
             }`}
           >
             <p
-              className="sub-title text-center"
+              className="sub-title text-center wrap-break-word"
               style={toStyle(bulkTitleData, true, true)}
             >
               ENG TITLE
             </p>
 
             <p
-              className="main-title text-center"
+              className="main-title text-center wrap-break-word"
               style={toStyle(bulkTitleData, true)}
             >
               제목입니다

--- a/widgets/editor/preview/components/OrderPanel.tsx
+++ b/widgets/editor/preview/components/OrderPanel.tsx
@@ -69,6 +69,11 @@ function OrderPanel() {
   // 각 탭 아이템에 연결
   const handleContextMenu = (e: React.MouseEvent, tabId: string) => {
     e.preventDefault(); // 기본 브라우저 메뉴 차단
+    // 일부 PC(확장 프로그램, 마우스 드라이버 등)에서 preventDefault가
+    // 늦게 처리되거나 다른 리스너에 의해 무시되는 경우를 방지하기 위해
+    // 네이티브 이벤트 레벨에서도 한 번 더 차단한다.
+    e.nativeEvent.preventDefault();
+    e.nativeEvent.stopImmediatePropagation();
     const containerRect = containerRef.current?.getBoundingClientRect();
     if (containerRect) {
       setContextMenu({
@@ -78,6 +83,20 @@ function OrderPanel() {
       });
     }
   };
+
+  // 캡처 단계에서 한 번 더 네이티브 컨텍스트 메뉴를 차단 (일부 PC 환경 방어)
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const blockNativeMenu = (e: MouseEvent) => e.preventDefault();
+    container.addEventListener('contextmenu', blockNativeMenu, {
+      capture: true,
+    });
+    return () =>
+      container.removeEventListener('contextmenu', blockNativeMenu, {
+        capture: true,
+      });
+  }, []);
 
   // 메뉴 닫기 (바깥 클릭 시)
   useEffect(() => {


### PR DESCRIPTION

# FEATURE

---

## 📋 작업 내용

- 네비게이션 바(nav) 라우팅 버그 수정 및 `NavMenu` 컴포넌트 분리
  - 에디터 페이지에서 저장되지 않은 변경사항(`isDirty`)이 있는 상태로 다른 메뉴로 이동 시 confirm 모달을 통해 이탈 여부 확인하도록 처리
  - `DashboardShell`에서 nav 메뉴 렌더링 로직을 `features/session/components/NavMenu.tsx`로 분리
- 좌측 패널(`LeftPanel`) 일괄편집 UI 개선
  - 일괄편집 영역 max-height 값 조정
  - 일괄편집 미리보기 UI 수정
  - 컴포넌트가 선택되지 않은 상태(포스터/공유 URL 선택 시)에서는 일괄편집 버튼이 노출되지 않도록 수정하여 UX상 모호함 제거
- 가족 소개(`MyFamilyWeddingPreview`) UI 및 디자인 수정
- 메뉴 바 컨텍스트 메뉴 버그 임시 조치
  - `OrderPanel`의 `handleContextMenu`에서 일부 PC(확장 프로그램/마우스 드라이버 등) 환경에서 `preventDefault`가 늦게 처리되거나 무시되는 문제 방지를 위해 네이티브 이벤트 레벨에서도 추가 차단 처리 (⚠️ 테스트 필요)

## 🔗 관련 이슈

- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [x] 디자인 시안과 비교 확인
- [x] 최악의 환경에서 확인 (느린 네트워크 환경)
- [x] 모바일 환경에서 테스트

## 🧪 테스트 방법

<!-- 리뷰어가 직접 테스트할 수 있도록 -->

1. 에디터 페이지에서 콘텐츠를 수정한 뒤(dirty 상태) 상단 nav 메뉴(FAQ 등) 클릭 → 이탈 확인 모달이 정상적으로 노출되는지 확인
2. 에디터 좌측 패널에서 포스터/공유 URL 선택 시 일괄편집 버튼이 숨겨지고, 개별 컴포넌트 선택 시에만 노출되는지 확인
3. 일괄편집 패널을 열고 미리보기 및 max-height 스크롤이 정상 동작하는지 확인
4. 순서 패널(OrderPanel) 탭에서 우클릭 시 브라우저 기본 컨텍스트 메뉴가 뜨지 않고 커스텀 메뉴만 노출되는지 다양한 환경(마우스/터치패드, 확장 프로그램 유무)에서 확인
5. 가족 소개 섹션 UI가 디자인 시안과 일치하는지 확인


---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 편집 중인 상태에서 대시보드 메뉴를 이동하면 변경사항 확인 안내가 표시됩니다.
  - 선택한 항목에 따라 일괄 편집 기능이 필요한 경우에만 표시됩니다.

- **개선 사항**
  - 가족 구성원 미리보기의 줄 배치와 글꼴 표시가 일관되게 개선되었습니다.
  - 제목과 본문이 긴 단어에서도 화면을 벗어나지 않도록 자동 줄바꿈됩니다.
  - 일괄 편집 영역의 펼침 애니메이션과 최대 높이가 조정되었습니다.
  - 탭의 우클릭 메뉴가 의도치 않게 브라우저 메뉴로 열리는 현상이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->