### PR TITLE
[fix] 인터뷰 프리뷰 버튼 인헤릿 이슈 수정

### DIFF
--- a/components/organisms/interview/InterviewPreviewItem.tsx
+++ b/components/organisms/interview/InterviewPreviewItem.tsx
@@ -78,7 +78,7 @@ export const InterviewPreviewItem = ({
       </div>
       <button
         type="button"
-        className="flex justify-center items-center py-2 px-10 rounded-lg border border-[#e5e5e8] hover:bg-gray-50 hover:border-gray-300 cursor-pointer select-none [-webkit-tap-highlight-color:transparent]"
+        className="flex justify-center items-center py-2 px-10 rounded-lg border border-[#e5e5e8] bg-[#FFFFFF] hover:bg-gray-50 hover:border-gray-300 cursor-pointer select-none [-webkit-tap-highlight-color:transparent]"
         draggable={false}
         onDragStart={event => event.preventDefault()}
         onClick={onToggle}


### PR DESCRIPTION
# FEATURE

---

## 📋 작업 내용

인터뷰 컴포넌트의 `인터뷰 더 읽어보기` 버튼 배경색이 상속되지 않도록, 연락처 프리뷰 팝업 버튼과 동일한 흰색 배경(`bg-[#FFFFFF]`)을 명시했습니다.

## 🔗 관련 이슈

Closes #

## 📸 스크린샷 / 영상

<!-- UI 변경이 있는 경우 첨부 -->

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [ ] 디자인 시안과 비교 확인
- [ ] 최악의 환경에서 확인 (느린 네트워크 환경)
- [ ] 모바일 환경에서 테스트

## 🧪 테스트 방법

1. 인터뷰 컴포넌트가 포함된 초대장 미리보기를 확인합니다.
2. `인터뷰 더 읽어보기` 버튼 배경색이 연락처 프리뷰 팝업 버튼과 동일한 흰색으로 표시되는지 확인합니다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 인터뷰 미리보기의 토글 버튼에 기본 흰색 배경을 적용했습니다.
  * 기존 호버 시 배경색 및 테두리 변경 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->