### PR TITLE
[fix] 에디터 페이지 추가 및 타입 패널 UX 개선

### DIFF
--- a/components/organisms/place/Place.tsx
+++ b/components/organisms/place/Place.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/shared/utils/phoneNumber';
 import {
   getDefaultPlaceTitle,
+  getPlaceFieldCopy,
   isDefaultPlaceTitle,
 } from '@/shared/utils/placeTitle';
 import { sanitizeEnglishTitleInput } from '@/shared/utils/stringUtils';
@@ -58,6 +59,7 @@ export function Place({ blockInfo, id }: Props) {
     country,
   } = blockInfo.props;
   const defaultTitle = getDefaultPlaceTitle(blockInfo.type);
+  const fieldCopy = getPlaceFieldCopy(blockInfo.type);
 
   const searchAddress = (query: string) => {
     if (!isScriptLoaded || !window.naver) {
@@ -167,18 +169,18 @@ export function Place({ blockInfo, id }: Props) {
           />
         </section>
         <TextField
-          label="예식장명"
+          label={fieldCopy.placeNameLabel}
           inputProps={{
-            placeholder: '예식장 이름 입력',
+            placeholder: fieldCopy.placeNamePlaceholder,
             onChange: e => handleUpdateBlock('placeName', e.target.value),
             value: placeName,
           }}
           className="w-full py-1.5 text-center"
         />
         <TextField
-          label="층과 홀"
+          label={fieldCopy.placeDetailLabel}
           inputProps={{
-            placeholder: '층과 웨딩홀 이름 입력',
+            placeholder: fieldCopy.placeDetailPlaceholder,
             onChange: e => handleUpdateBlock('placeDetail', e.target.value),
             value: placeDetail,
           }}
@@ -187,7 +189,7 @@ export function Place({ blockInfo, id }: Props) {
         <TextField
           label="연락처"
           inputProps={{
-            placeholder: '예식장 연락처, ex.02-000-000',
+            placeholder: fieldCopy.placeTelPlaceholder,
             type: 'tel',
             inputMode: 'numeric',
             onChange: e =>

--- a/shared/utils/createDefaultProps.test.ts
+++ b/shared/utils/createDefaultProps.test.ts
@@ -1,4 +1,5 @@
 import { createDefaultProps } from './createDefaultProps';
+import { getPlaceFieldCopy } from './placeTitle';
 
 describe('createDefaultProps', () => {
   it('creates an initial interview question with a fresh id for each block', () => {
@@ -21,5 +22,16 @@ describe('createDefaultProps', () => {
     expect(first.noticeList?.[0].id).toEqual(expect.any(String));
     expect(second.noticeList?.[0].id).toEqual(expect.any(String));
     expect(first.noticeList?.[0].id).not.toBe(second.noticeList?.[0].id);
+  });
+
+  it('uses wedding-specific place field copy only for wedding invitations', () => {
+    expect(getPlaceFieldCopy('wedding').placeNameLabel).toBe('예식장명');
+    expect(getPlaceFieldCopy('birthday').placeNameLabel).toBe('장소명');
+    expect(getPlaceFieldCopy('birthday').placeNamePlaceholder).not.toContain(
+      '예식장'
+    );
+    expect(getPlaceFieldCopy('seminar').placeTelPlaceholder).not.toContain(
+      '예식장'
+    );
   });
 });

--- a/shared/utils/placeTitle.ts
+++ b/shared/utils/placeTitle.ts
@@ -6,6 +6,23 @@ export const WEDDING_PLACE_TITLE = '예식 장소';
 export const getDefaultPlaceTitle = (type?: InvitationType) =>
   type === 'wedding' ? WEDDING_PLACE_TITLE : GENERAL_PLACE_TITLE;
 
+export const getPlaceFieldCopy = (type?: InvitationType) =>
+  type === 'wedding'
+    ? {
+        placeNameLabel: '예식장명',
+        placeNamePlaceholder: '예식장 이름 입력',
+        placeDetailLabel: '층과 홀',
+        placeDetailPlaceholder: '층과 홀 이름 입력',
+        placeTelPlaceholder: '예식장 연락처, ex.02-000-000',
+      }
+    : {
+        placeNameLabel: '장소명',
+        placeNamePlaceholder: '장소 이름 입력',
+        placeDetailLabel: '상세 위치',
+        placeDetailPlaceholder: '층과 호실 등 상세 위치 입력',
+        placeTelPlaceholder: '행사 장소 연락처, ex.02-000-000',
+      };
+
 export const isDefaultPlaceTitle = (
   title: string | undefined,
   type?: InvitationType

--- a/widgets/editor/preview/components/ComponentsPopup.tsx
+++ b/widgets/editor/preview/components/ComponentsPopup.tsx
@@ -17,6 +17,9 @@ function ComponentsPopup({ onPopClose }: Props) {
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isManualScrolling = useRef(false);
+  const manualScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   useEffect(() => {
     const closeIfViewportGuardActive = () => {
@@ -60,8 +63,19 @@ function ComponentsPopup({ onPopClose }: Props) {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (manualScrollTimeoutRef.current) {
+        clearTimeout(manualScrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleTabClick = (english: string) => {
-    if (isManualScrolling.current) return;
+    if (manualScrollTimeoutRef.current) {
+      clearTimeout(manualScrollTimeoutRef.current);
+    }
+
     isManualScrolling.current = true;
     setActive(english);
     sectionRefs.current[english]?.scrollIntoView({
@@ -70,8 +84,9 @@ function ComponentsPopup({ onPopClose }: Props) {
     });
 
     // 스크롤 이동이 끝날 때까지 감지 일시 중단
-    setTimeout(() => {
+    manualScrollTimeoutRef.current = setTimeout(() => {
       isManualScrolling.current = false;
+      manualScrollTimeoutRef.current = null;
     }, 800);
   };
 

--- a/widgets/editor/preview/components/TabArea.tsx
+++ b/widgets/editor/preview/components/TabArea.tsx
@@ -12,7 +12,7 @@ function TabArea({ active, tabClick, closeClick }: Props) {
         {componentCls.map((items, index) => (
           <li
             key={index}
-            className={`w-19 h-11 cursor-pointer flex-center font-semibold text-sm ${active === items.english ? 'text-text-primary border-b' : 'text-text-secondary border-0'}`}
+            className={`w-19 h-11 cursor-pointer select-none flex-center font-semibold text-sm ${active === items.english ? 'text-text-primary border-b' : 'text-text-secondary border-0'}`}
             onClick={() => tabClick(items.english)}
           >
             {items.korea}

--- a/widgets/editor/rightPanel/RightPanel.test.tsx
+++ b/widgets/editor/rightPanel/RightPanel.test.tsx
@@ -12,7 +12,7 @@ jest.mock('./components/TypePanel', () => ({
 }));
 jest.mock('./components/PosterPanel', () => ({
   __esModule: true,
-  default: () => <div data-testid="poster-panel">PosterPanel</div>,
+  PosterPanel: () => <div data-testid="poster-panel">PosterPanel</div>,
 }));
 
 const STABLE_TYPE_ARRAY = ['type1'];
@@ -63,7 +63,10 @@ describe('RightPanel 컴포넌트 테스트', () => {
 
     // Assert
     const posterButton = screen.getByRole('button', { name: /포스터/i });
+    const typeButton = screen.getByRole('button', { name: /타입/i });
     expect(posterButton).toHaveClass('border-b text-text-primary');
+    expect(typeButton).toBeDisabled();
+    expect(typeButton).toHaveClass('cursor-not-allowed');
   });
 
   it('유저가 수동으로 탭을 변경할 수 있다', () => {
@@ -85,6 +88,28 @@ describe('RightPanel 컴포넌트 테스트', () => {
     // Assert
     expect(posterButton).toHaveClass('border-b text-text-primary');
   });
+
+  it.each(['gallery', 'calendar'])(
+    '%s 컴포넌트 선택 시 포스터 탭을 클릭할 수 없다',
+    component => {
+      mockUseEditorStore.mockReturnValue({
+        block: [{ id: 'component-1', component }],
+        selectedId: 'component-1',
+      } as any);
+      mockUseComponentType.mockReturnValue({
+        typeArray: STABLE_TYPE_ARRAY,
+      });
+
+      render(<RightPanel />);
+      const posterButton = screen.getByRole('button', { name: /포스터/i });
+
+      fireEvent.pointerDown(posterButton);
+
+      expect(posterButton).toBeDisabled();
+      expect(screen.getByTestId('type-panel')).toBeInTheDocument();
+      expect(screen.queryByTestId('poster-panel')).not.toBeInTheDocument();
+    }
+  );
 
   it('selectedId가 변경되어 typeArray가 달라지면 탭이 자동으로 재설정된다', () => {
     // Stage 1: comp-1 with types

--- a/widgets/editor/rightPanel/RightPanel.tsx
+++ b/widgets/editor/rightPanel/RightPanel.tsx
@@ -17,6 +17,11 @@ function RightPanel() {
     }))
   );
   const { typeArray } = useComponentType({ block, selectedId });
+  const selectedBlock = block.find(item => item.id === selectedId);
+  const hasTypeArray = Boolean(typeArray && typeArray.length > 0);
+  const isPosterTabDisabled =
+    selectedBlock?.component === 'gallery' ||
+    selectedBlock?.component === 'calendar';
 
   const [prevTypeArray, setPrevTypeArray] = useState(typeArray);
   const [tab, setTab] = useState(
@@ -36,15 +41,23 @@ function RightPanel() {
         <div className="w-full h-11">
           <button
             type="button"
-            className={`w-41.5 h-11 cursor-pointer select-none text-sm ${tab === 'poster' ? 'border-b font-semibold text-text-primary' : 'font-normal text-[#838383]'}`}
-            onPointerDown={() => setTab('poster')}
+            disabled={isPosterTabDisabled}
+            className={`w-41.5 h-11 select-none text-sm ${isPosterTabDisabled ? 'cursor-not-allowed text-text-disabled' : 'cursor-pointer'} ${tab === 'poster' ? 'border-b font-semibold text-text-primary' : 'font-normal text-[#838383]'}`}
+            onPointerDown={() => {
+              if (isPosterTabDisabled) return;
+              setTab('poster');
+            }}
           >
             포스터
           </button>
           <button
             type="button"
-            className={`w-41.75 h-11 cursor-pointer select-none text-sm ${typeArray && typeArray.length > 0 ? 'pointer-events-auto' : 'pointer-events-none'} ${tab === 'type' ? 'border-b font-semibold text-text-primary' : 'font-normal text-[#838383]'}`}
-            onPointerDown={() => setTab('type')}
+            disabled={!hasTypeArray}
+            className={`w-41.75 h-11 select-none text-sm ${hasTypeArray ? 'cursor-pointer' : 'cursor-not-allowed text-text-disabled'} ${tab === 'type' ? 'border-b font-semibold text-text-primary' : 'font-normal text-[#838383]'}`}
+            onPointerDown={() => {
+              if (!hasTypeArray) return;
+              setTab('type');
+            }}
           >
             타입
           </button>

--- a/widgets/editor/rightPanel/components/TypePanel.test.tsx
+++ b/widgets/editor/rightPanel/components/TypePanel.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+
+import TypePanel from './TypePanel';
+
+jest.mock('@/shared/store/editorStore/useEditorStore');
+jest.mock('@/components/atoms/image', () => ({
+  Image: ({ alt }: { alt: string }) => <span aria-label={alt} role="img" />,
+}));
+
+describe('TypePanel', () => {
+  const mockUseEditorStore = useEditorStore as jest.MockedFunction<
+    typeof useEditorStore
+  >;
+  const updateBlock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEditorStore.mockImplementation(selector =>
+      selector({
+        block: [
+          {
+            id: 'selected-block',
+            component: 'gallery',
+            props: {
+              template: 'galleryType2',
+            },
+          },
+        ],
+        updateBlock,
+      } as any)
+    );
+  });
+
+  it('선택된 타입 버튼에 강조 보더를 표시한다', () => {
+    render(
+      <TypePanel
+        typeArray={['galleryType1', 'galleryType2']}
+        selectedId="selected-block"
+      />
+    );
+
+    const selectedButton = screen.getByRole('button', {
+      name: /galleryType2/i,
+    });
+    const unselectedButton = screen.getByRole('button', {
+      name: /galleryType1/i,
+    });
+
+    expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
+    expect(selectedButton).toHaveClass('border-primary bg-white');
+    expect(selectedButton.className).toContain('shadow-[');
+    expect(unselectedButton).toHaveAttribute('aria-pressed', 'false');
+    expect(unselectedButton).toHaveClass('border-text-primary/5');
+  });
+
+  it('타입을 클릭하면 선택된 블록의 template 값을 갱신한다', () => {
+    render(
+      <TypePanel
+        typeArray={['galleryType1', 'galleryType2']}
+        selectedId="selected-block"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /galleryType1/i }));
+
+    expect(updateBlock).toHaveBeenCalledWith('selected-block', {
+      template: 'galleryType1',
+    });
+  });
+});

--- a/widgets/editor/rightPanel/components/TypePanel.tsx
+++ b/widgets/editor/rightPanel/components/TypePanel.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import React from 'react';
+import { useShallow } from 'zustand/shallow';
 
 import { Image } from '@/components/atoms/image';
 import { useEditorStore } from '@/shared/store/editorStore/useEditorStore';
+import { cn } from '@/shared/utils/cn';
 
 interface Props {
   typeArray: string[];
@@ -11,7 +13,20 @@ interface Props {
 }
 
 function TypePanel({ typeArray, selectedId }: Props) {
-  const updateBlock = useEditorStore(state => state.updateBlock);
+  const { updateBlock, selectedTemplate } = useEditorStore(
+    useShallow(state => {
+      const selectedBlock = state.block.find(block => block.id === selectedId);
+      const template =
+        selectedBlock?.props && 'template' in selectedBlock.props
+          ? selectedBlock.props.template
+          : undefined;
+
+      return {
+        updateBlock: state.updateBlock,
+        selectedTemplate: typeof template === 'string' ? template : undefined,
+      };
+    })
+  );
 
   const handleSelectType = (type: string) => {
     if (!selectedId) return;
@@ -20,21 +35,31 @@ function TypePanel({ typeArray, selectedId }: Props) {
 
   return (
     <div className="min-h-0 flex-1 flex flex-wrap gap-3.5 content-start w-full overflow-y-auto scrollbar-hide relative">
-      {typeArray.map((item, index) => (
-        <button
-          type="button"
-          key={index}
-          className="aspect-square relative w-40 h-40 rounded-lg border border-text-primary/5 bg-[#FAFAFB]"
-          onClick={() => handleSelectType(item)}
-        >
-          <Image
-            src={`/images/${item}.png`}
-            alt={`${item} 이미지`}
-            fill
-            className="object-contain"
-          />
-        </button>
-      ))}
+      {typeArray.map(item => {
+        const isSelected = selectedTemplate === item;
+
+        return (
+          <button
+            type="button"
+            key={item}
+            aria-pressed={isSelected}
+            className={cn(
+              'aspect-square relative w-40 h-40 rounded-lg border bg-[#FAFAFB] transition-[border-color,box-shadow,background-color] duration-150',
+              isSelected
+                ? 'border-primary bg-white shadow-[0_0_14px_rgb(66_133_244_/_16%)]'
+                : 'border-text-primary/5 hover:border-primary/30'
+            )}
+            onClick={() => handleSelectType(item)}
+          >
+            <Image
+              src={`/images/${item}.png`}
+              alt={`${item} 이미지`}
+              fill
+              className="object-contain"
+            />
+          </button>
+        );
+      })}
 
       <div className="flex justify-center w-full h-13 items-end sticky bottom-0 left-0 right-0  bg-linear-to-t from-white from-0% via-white/24 via-53% to-white/6 to-100%"></div>
     </div>


### PR DESCRIPTION
# FEATURE

---

## 📋 작업 내용

에디터의 페이지 추가 모달과 오른쪽 타입 패널 UX를 개선했습니다.

- 페이지 추가 모달의 카테고리 탭 텍스트 선택 방지
- 카테고리 탭 연속 클릭 시 스크롤 클릭이 무시되던 문제 수정
- 장소 컴포넌트 입력 문구를 초대장 카테고리에 따라 분기
  - 결혼식: 예식장명, 예식장 이름 입력 등 결혼식 전용 문구 유지
  - 그 외: 장소명, 장소 이름 입력, 상세 위치 등 일반 행사 문구 적용
- 갤러리/행사 일시 컴포넌트 선택 시 오른쪽 패널의 포스터 탭 비활성화
- 포스터 선택 시 오른쪽 패널의 타입 탭 비활성화 커서 표시 개선
- 타입 패널에서 현재 선택된 타입 카드에 선택 상태 표시 추가

## 🔗 관련 이슈

Closes #

## 📸 스크린샷 / 영상

<!-- UI 변경이 있는 경우 첨부 -->

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [ ] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [ ] 디자인 시안과 비교 확인
- [ ] 최악의 환경에서 확인 (느린 네트워크 환경)
- [ ] 모바일 환경에서 테스트

## 🧪 테스트 방법

1. 에디터에서 페이지 추가 버튼을 클릭한다.
2. 페이지 추가 모달의 카테고리 탭 텍스트가 드래그 선택되지 않는지 확인한다.
3. 카테고리 탭을 연속으로 클릭했을 때 한 번의 클릭으로 해당 영역까지 스크롤되는지 확인한다.
4. 결혼식 외 카테고리에서 행사 장소 컴포넌트를 추가한 뒤, 예식장 문구가 일반 장소 문구로 표시되는지 확인한다.
5. 갤러리 또는 행사 일시 컴포넌트를 선택한 뒤 오른쪽 패널의 포스터 탭이 비활성화되는지 확인한다.
6. 포스터를 선택했을 때 오른쪽 패널의 타입 탭이 비활성화되고 커서가 변경되는지 확인한다.
7. 갤러리 또는 행사 일시 타입을 선택했을 때 선택된 타입 카드에 보더와 쉐도우가 표시되는지 확인한다.
8. 다른 컴포넌트를 선택했다가 다시 돌아왔을 때 기존 타입 선택 표시가 유지되는지 확인한다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 초대 유형에 따라 장소 입력란의 라벨과 안내 문구가 알맞게 표시됩니다.
  - 편집기에서 선택한 블록에 따라 사용할 수 없는 포스터·타입 탭이 명확히 비활성화됩니다.
  - 타입 선택 시 현재 선택 상태가 시각적으로 구분되고, 선택한 디자인이 즉시 반영됩니다.
  - 탭을 빠르게 전환하거나 수동으로 스크롤할 때 미리보기 이동 동작이 더욱 안정적으로 처리됩니다.
  - 탭의 클릭 가능 여부와 마우스 포인터 표시가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->