### PR TITLE
[Fix] 메인포스터 UI 버그 수정

### DIFF
--- a/components/molecules/color-picker/LargeColorPicker.tsx
+++ b/components/molecules/color-picker/LargeColorPicker.tsx
@@ -35,7 +35,7 @@ function LargeColorPicker({
   return (
     <div
       className={cn(
-        'box-border flex w-93.75 flex-col gap-5 rounded-lg border bg-white px-5',
+        'box-border flex w-full max-w-full min-w-0 flex-col gap-5 rounded-lg border bg-white px-5',
         showHeader ? 'pt-0' : 'pt-5',
         className
       )}

--- a/components/organisms/wrapper/LeftEditorWrapper.tsx
+++ b/components/organisms/wrapper/LeftEditorWrapper.tsx
@@ -14,7 +14,7 @@ export const LeftEditorWrapper = ({
   ariaLabel,
 }: Props) => {
   return (
-    <div className="animate-grow-height grid ">
+    <div className="grid w-full justify-items-center">
       <section
         className={cn(
           'relative flex flex-col items-center gap-1 px-5 pb-1.5 w-93.75 h-fit max-h-[750px] overflow-y-auto scrollbar-hide transition-all min-h-0',
@@ -27,4 +27,3 @@ export const LeftEditorWrapper = ({
     </div>
   );
 };
-

--- a/widgets/editor/leftPanel/LeftPanel.tsx
+++ b/widgets/editor/leftPanel/LeftPanel.tsx
@@ -42,7 +42,7 @@ function LeftPanel() {
 
           <div
             key={`bulk-edit-${isEdit}`}
-            className={`grid max-h-158 ${isEdit ? 'animate-grow-height opacity-100 mt-0' : 'grid-rows-[0fr] opacity-0'}`}
+            className={isEdit ? 'max-h-158 overflow-hidden mt-0' : 'hidden'}
           >
             <div className="overflow-hidden rounded-b-lg">
               <BulkEdit />
@@ -67,9 +67,9 @@ function LeftPanel() {
         ) : (
           <div
             key={`edit-${isEdit}`}
-            className={`grid ${!isEdit ? 'animate-grow-height opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
+            className={!isEdit ? 'overflow-hidden' : 'hidden'}
           >
-            <div className="w-full overflow-hidden max-h-[750px]">
+            <div className="w-full">
               <Edit />
             </div>
           </div>

--- a/widgets/mainPoster/components/MainPoster.tsx
+++ b/widgets/mainPoster/components/MainPoster.tsx
@@ -87,7 +87,7 @@ export const MainPoster = () => {
 
   return (
     <div
-      className="flex flex-col pb-3.5 px-5 items-center w-full max-h-[812px] overflow-y-scroll overflow-x-hidden scrollbar-hide"
+      className="flex w-full flex-col items-center pb-3.5 max-h-[812px] overflow-y-scroll overflow-x-hidden scrollbar-hide"
       data-canvas="true"
     >
       {/* {isAdmin && (
@@ -110,42 +110,44 @@ export const MainPoster = () => {
         </div>
       )} */}
 
-      <NavigationBar
-        action={
-          activeTab === 'text' ? (
-            <UtilityButton
-              size="md"
-              variant="primary"
-              className="text-sm"
-              onClick={() => createTextBox(canvas)}
-            >
-              텍스트 추가
-            </UtilityButton>
-          ) : null
-        }
-        direction="right"
-      >
-        포스터
-      </NavigationBar>
-      <div className="w-full h-11 flex gap-2 items-center justify-center bg-white rounded-lg user-select-none">
-        {PanelItems.map(item => {
-          const isActive =
-            activeTab === item.id ||
-            (activeTab === 'template' && item.id === 'image');
+      <div className="w-full px-5">
+        <NavigationBar
+          action={
+            activeTab === 'text' ? (
+              <UtilityButton
+                size="md"
+                variant="primary"
+                className="text-sm"
+                onClick={() => createTextBox(canvas)}
+              >
+                텍스트 추가
+              </UtilityButton>
+            ) : null
+          }
+          direction="right"
+        >
+          포스터
+        </NavigationBar>
 
-          return (
-            <button
-              key={item.id}
-              type="button"
-              className={`w-[54px] h-8 font-medium text-sm ${isActive ? 'border-b text-text-primary' : 'text-text-secondary'}`}
-              onClick={item.onClick}
-            >
-              <p>{item.value}</p>
-            </button>
-          );
-        })}
+        <div className="w-full h-11 flex gap-2 items-center justify-center bg-white rounded-lg user-select-none">
+          {PanelItems.map(item => {
+            const isActive =
+              activeTab === item.id ||
+              (activeTab === 'template' && item.id === 'image');
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={`w-[54px] h-8 font-medium text-sm ${isActive ? 'border-b text-text-primary' : 'text-text-secondary'}`}
+                onClick={item.onClick}
+              >
+                <p>{item.value}</p>
+              </button>
+            );
+          })}
+        </div>
       </div>
-
       {activeTab === 'text' && <RichTextPanel />}
 
       {(activeTab === 'image' || activeTab === 'template') && <ImagePanel />}

--- a/widgets/mainPoster/components/MainPoster.tsx
+++ b/widgets/mainPoster/components/MainPoster.tsx
@@ -42,7 +42,6 @@ export const MainPoster = () => {
       value: '텍스트',
       onClick: () => {
         setActiveTab('text');
-        createTextBox(canvas);
       },
     },
     {

--- a/widgets/mainPoster/components/graphic/GraphicPanel.tsx
+++ b/widgets/mainPoster/components/graphic/GraphicPanel.tsx
@@ -55,8 +55,8 @@ export function GraphicPanel() {
   if (!canvas) return null;
 
   return (
-    <LeftEditorWrapper ariaLabel="그리기 설정" className="pb-0">
-      <div className="flex flex-col w-full items-center">
+    <LeftEditorWrapper ariaLabel="그리기 설정" className="min-h-0 pb-0 px-0">
+      <div className="flex w-full flex-col items-stretch">
         <section className="w-full h-11 flex flex-row gap-2 items-center justify-center bg-bg-base">
           <p className="w-[47px] h-8 flex items-center justify-center text-[13px] font-semibold text-text-primary">
             굵기
@@ -87,7 +87,7 @@ export function GraphicPanel() {
         <LargeColorPicker
           value={drawingConfig.color}
           onChange={e => setDrawingConfig({ color: e.hsva })}
-          className="border-none pl-6 pr-4"
+          className="w-full border-none"
         />
       </div>
     </LeftEditorWrapper>


### PR DESCRIPTION
# FEATURE

---

## 📋 작업 내용

- 포스터 편집 패널의 정렬/스크롤 기준 정리
- 좌측 편집 패널 전환 시 애니메이션 제거
- 포스터의 `텍스트` 탭 라벨 클릭만으로 텍스트 박스가 생성되던 오동작 수정
- 그리기 판넬의 컬러 히스토리 잘림 버그 수정


## 🔗 관련 이슈

Closes #

## 📸 스크린샷 / 영상

<!-- UI 변경이 있는 경우 첨부 -->

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 환경에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 환경변수 추가 시 팀 공유 및 Vercel 등록 완료
- [x] 디자인 시안과 비교 확인
- [x] 최악의 환경에서 확인 (느린 네트워크 환경)
- [x] 모바일 환경에서 테스트

## 🧪 테스트 방법

<!-- 리뷰어가 직접 테스트할 수 있도록 -->

1. 텍스트 판넬에서 라벨명을 눌렀을때 텍스트 박스가 생성되지 않아야 합니다
2. 그리기 판넬에서 컬러 히스토리가 잘려 보이지 않아야 합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 색상 선택기와 그래픽 패널이 화면 너비에 맞춰 유연하게 표시됩니다.
  - 왼쪽 편집 패널의 일괄 편집·상세 편집 영역 전환이 더 안정적으로 동작합니다.
  - 편집 영역이 가로 중앙에 정렬되고 불필요한 여백이 조정되었습니다.
  - 텍스트 탭 선택과 텍스트 상자 추가 동작이 분리되어, 전용 추가 버튼을 통해 텍스트 상자를 생성할 수 있습니다.
  - 메인 포스터 영역의 콘텐츠 여백과 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->