### PR TITLE
[fix] 예식일시 시간 ui 변경(10분단위로 설정 가능)

### DIFF
--- a/components/molecules/time-selector/TimeSelector.tsx
+++ b/components/molecules/time-selector/TimeSelector.tsx
@@ -13,38 +13,54 @@ const AMPM_OPTIONS = [
 ];
 
 export const TimeSelector = ({ value, onChange }: TimeSelectorProps) => {
-  // 30분 단위 옵션 생성 컴포넌트 마운트 시 한번만 생성
-  const timeOptions = useMemo(() => {
+  // 시(1~12) 옵션 생성 컴포넌트 마운트 시 한번만 생성
+  const hourOptions = useMemo(() => {
     const options = [];
     for (let h = 1; h <= 12; h++) {
       const hourStr = h.toString().padStart(2, '0');
-      options.push({ label: `${hourStr}:00`, value: `${hourStr}:00` });
-      options.push({ label: `${hourStr}:30`, value: `${hourStr}:30` });
+      options.push({ label: hourStr, value: hourStr });
+    }
+    return options;
+  }, []);
+
+  // 분(10분 단위) 옵션 생성 컴포넌트 마운트 시 한번만 생성
+  const minuteOptions = useMemo(() => {
+    const options = [];
+    for (let m = 0; m < 60; m += 10) {
+      const minuteStr = m.toString().padStart(2, '0');
+      options.push({ label: minuteStr, value: minuteStr });
     }
     return options;
   }, []);
 
   // 외부로부터 주입되는 value (예: "오후 12:30") 파싱
-  const [currentAmPm, currentTime] = useMemo(() => {
-    if (!value) return ['오후', '12:00'];
+  const [currentAmPm, currentHour, currentMinute] = useMemo(() => {
+    if (!value) return ['오후', '12', '00'];
     const parts = value.split(' ');
-    // 파싱 실패 또는 빈 값일 경우 기본값 "오후", "12:00" 설정
-    if (parts.length < 2) return ['오후', '12:00'];
-    return [parts[0], parts[1]];
+    // 파싱 실패 또는 빈 값일 경우 기본값 "오후", "12", "00" 설정
+    if (parts.length < 2) return ['오후', '12', '00'];
+    const [hour, minute] = parts[1].split(':');
+    return [parts[0], hour, minute];
   }, [value]);
 
   const handleAmPmChange = (option: { label: string; value: string }) => {
-    onChange(`${option.value} ${currentTime}`);
+    onChange(`${option.value} ${currentHour}:${currentMinute}`);
   };
 
-  const handleTimeChange = (option: { label: string; value: string }) => {
-    onChange(`${currentAmPm} ${option.value}`);
+  const handleHourChange = (option: { label: string; value: string }) => {
+    onChange(`${currentAmPm} ${option.value}:${currentMinute}`);
+  };
+
+  const handleMinuteChange = (option: { label: string; value: string }) => {
+    onChange(`${currentAmPm} ${currentHour}:${option.value}`);
   };
 
   const selectedAmPm =
     AMPM_OPTIONS.find(opt => opt.value === currentAmPm) || AMPM_OPTIONS[1];
-  const selectedTime =
-    timeOptions.find(opt => opt.value === currentTime) || timeOptions[22]; // 12:00 (인덱스 22)
+  const selectedHour =
+    hourOptions.find(opt => opt.value === currentHour) || hourOptions[11]; // 12
+  const selectedMinute =
+    minuteOptions.find(opt => opt.value === currentMinute) || minuteOptions[0]; // 00
 
   return (
     <div className="flex gap-2 w-full">
@@ -56,12 +72,20 @@ export const TimeSelector = ({ value, onChange }: TimeSelectorProps) => {
           onSelect={handleAmPmChange}
         />
       </div>
-      <div className="min-w-0 flex-[2]">
+      <div className="min-w-0 flex-1">
         <Selector
           type="normal"
-          options={timeOptions}
-          selected={selectedTime}
-          onSelect={handleTimeChange}
+          options={hourOptions}
+          selected={selectedHour}
+          onSelect={handleHourChange}
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <Selector
+          type="normal"
+          options={minuteOptions}
+          selected={selectedMinute}
+          onSelect={handleMinuteChange}
         />
       </div>
     </div>


### PR DESCRIPTION

# HOTFIX

---

## 🚨 장애 심각도

[ ] P0 - 서비스 전체 불가 / 보안 사고
[ ] P1 - 핵심 기능 불가
[x] P2 - 일부 기능 오류

## ⏰ 발생 시간

- 2026-08-08 14:22

## 🐛 문제 상황

예식 일시가 10분단위로 설정 불가능한 문제

## 🔧 수정 내용

시와 분으로 필드를 나누고 10분단위로 설정 가능하도록함

## 🧪 검증 방법

로컬 환경과 프로덕션 환경에서 초대장 저장, 수정, 발행 과정 수행

## ✅ 배포 전 체크리스트

- [x] main 최신 브랜치 기준으로 작업
- [x] 로컬 테스트 완료
- [x] 수정 범위가 최소화
- [x] Vercel 미리보기 URL 확인
- [x] 장애 해결과 무관한 기능, 리팩터링, 의존성 업데이트를 포함하지 않음
- [x] 영향을 줄 수 있는 다른 기능까지 확인
- [x] 관련 API, 공통 컴포넌트, 인증, 전역 상태 영향 여부를 확인

## ✅ 검증

- [x] 운영과 동일하거나 최대한 유사한 조건에서 장애를 재현했다.
- [x] 수정 후 동일한 재현 절차로 문제가 해결됐음을 확인했다.
- [x] 정상 사용자 흐름을 확인했다.
- [x] 오류가 발생하던 케이스를 확인했다.
- [x] 로그인 / 권한 / API 실패 상태를 확인했다.
- [x] 브라우저 콘솔 에러가 없다.
- [x] Network 탭에서 실패 요청이 없는지 확인했다.
- [x] 관련 테스트가 있다면 통과했다.

## ✅ 배포 후 체크리스트

- [x] main merge 완료
- [x] dev 브랜치에도 동일 내용 merge 완료 ⚠️ 필수
- [x] 운영 배포 후 정상 동작 확인
- [x] 운영 배포 후 Vercel,Clarity 에러 확인
- [x] 팀 디스코드 공유 완료
- [x] hotfix 브랜치를 삭제했다.

## 📢 영향 범위

<!-- 어떤 기능/페이지에 영향이 있는지 -->

---
